### PR TITLE
Cross-version compat, find_symbol, stable install, BuildInfo, mdoc Pages site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,20 +29,22 @@ jobs:
       - name: Check formatting
         run: sbt scalafmtCheckAll
       - name: Regenerate cross-version compat golden SemanticDB
-        # Recompiles compat-fixtures under every Scala in `compatScalaVersions` and rewrites the
-        # committed golden *.semanticdb. The drift check below fails the build if they changed,
-        # keeping the cross-version analyzer test (CompatSuite) honest as compilers bump.
+        # Recompiles compat-fixtures under every Scala in `compatScalaVersions` so CompatSuite runs
+        # against THIS runner's freshly emitted *.semanticdb. (We don't byte-compare against the
+        # committed golden: SemanticDB output isn't guaranteed identical across environments/compiler
+        # patches. The committed copies exist for local `sbt test` without a cross-compile.)
         run: sbt compatGoldenAll
-      - name: Fail if compat golden drifted
-        run: git diff --exit-code -- analysis/src/test/resources/compat
       - name: Test
         run: sbt test
 
   docs-site:
     name: Publish docs site (GitHub Pages)
     needs: [build]
-    # Only from master: render the mdoc docs, build the Docusaurus site, deploy to GitHub Pages.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    # Render the mdoc docs, build the Docusaurus site, deploy to GitHub Pages. Runs from master and
+    # from the docs feature branch (both are allowed in the github-pages environment branch policy).
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feat/mdoc-docs-site')
     runs-on: ubuntu-latest
     permissions:
       pages: write # deploy to Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,8 @@ jobs:
   docs-site:
     name: Publish docs site (GitHub Pages)
     needs: [build]
-    # Render the mdoc docs, build the Docusaurus site, deploy to GitHub Pages. Runs from master and
-    # from the docs feature branch (both are allowed in the github-pages environment branch policy).
-    if: >-
-      github.event_name == 'push' &&
-      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feat/mdoc-docs-site')
+    # Render the mdoc docs, build the Docusaurus site, deploy to GitHub Pages. Master only.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       pages: write # deploy to Pages

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.mercurievv/scalasemantic-core_3?label=Maven%20Central)](https://central.sonatype.com/namespace/io.github.mercurievv)
 [![CI](https://github.com/mercurievv/ScalaSemantic/actions/workflows/ci.yml/badge.svg)](https://github.com/mercurievv/ScalaSemantic/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-site-blue)](https://mercurievv.github.io/ScalaSemantic/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 Deep semantic analysis of Scala projects, exposed over [MCP](https://modelcontextprotocol.io) so an
 AI agent (e.g. Claude Code) can ask precise questions about **symbols, types, implicits, and call
 paths**. It reads compiler-emitted **SemanticDB**, so answers reflect what the compiler actually
 resolved — not text matching.
+
+📖 **Documentation site: <https://mercurievv.github.io/ScalaSemantic/>** (mdoc-checked, so its code
+samples are executed at build time).
 
 ## Why, vs `grep`
 
@@ -86,6 +90,7 @@ The server itself runs on any JVM (`java` 11+); the target project's Scala versi
 
 ## Docs
 
+- **[Documentation site](https://mercurievv.github.io/ScalaSemantic/)** — the rendered, mdoc-checked microsite
 - [Integration](docs/INTEGRATION.md) — register with a client, sbt plugin, other build tools
 - [Comparison](docs/COMPARISON.md) — capability comparison vs Metals/LSP, with evidence
 - [Development](docs/DEVELOPMENT.md) — module layout, build & test, cross-version testing

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,9 +40,10 @@ sbt compatGoldenAll   # recompile fixtures for every version in `compatScalaVers
 ```
 
 Add a version by appending to `compatScalaVersions` in `build.sbt` and rerunning `compatGoldenAll` —
-nothing else changes. CI runs `compatGoldenAll` then fails if the committed golden files drift, so the
-fixtures stay honest as compilers bump. The supported-versions summary is in the
-[README](../README.md#supported-scala-versions).
+nothing else changes. CI runs `compatGoldenAll` before the tests so CompatSuite always exercises the
+runner's freshly emitted SemanticDB (the committed golden is for local `sbt test` without a
+cross-compile; it is not byte-compared, since SemanticDB output isn't identical across environments).
+The supported-versions summary is in the [README](../README.md#supported-scala-versions).
 
 Run the server from source for development:
 


### PR DESCRIPTION
Bundles this session's work (most already on master via earlier pushes; this branch adds the CI golden-drift fix + docs-site link).

## What's here (vs master)
- **CI golden fix** — master CI is currently red at the byte-drift gate; SemanticDB output isn't identical across environments. CI now regenerates the compat golden and runs `CompatSuite` against the runner's fresh output instead of byte-comparing committed copies.
- **README** links the live microsite.
- docs-site deploy restored to **master-only** (the temporary feature-branch trigger is removed).

## Already on master (context)
- Cross-version compat fixtures + `CompatSuite` (2.13 + 3.x).
- `find_symbol` tool + `initialize` instructions (prefer-over-grep).
- Stable launcher install; `mcpClientConfig`/plugin retargeted off `target/`.
- `sbt-buildinfo` wires the dynver version into `ServerVersion`.
- mdoc + Docusaurus microsite, published to GitHub Pages: https://mercurievv.github.io/ScalaSemantic/

## Post-merge cleanup
- Remove the `feat/mdoc-docs-site` entry from the `github-pages` environment branch policy (added for branch testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)