### PR TITLE
feat(mcp): sharpen tool + server descriptions for better tool selection

### DIFF
--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -37,35 +37,44 @@ object Mcp:
     * drive the tools and — crucially — to prefer them over text search for Scala code questions.
     */
   val Instructions: String =
-    """ScalaSemantic answers questions about Scala code from compiler-emitted SemanticDB, so results
-      |reflect what the compiler actually resolved — exact symbols, not text matches.
+    """ScalaSemantic answers questions about Scala code from compiler-emitted SemanticDB: resolved
+      |symbols, types, and references exactly as the compiler saw them — not text matches.
       |
-      |MANDATORY — USE THESE TOOLS INSTEAD OF grep / ripgrep / text search / file-reading FOR ANY
-      |QUESTION ABOUT SCALA CODE STRUCTURE OR SEMANTICS. This is not a suggestion. Whenever you are
-      |about to grep, `rg`, glob, or read `.scala` files to answer ANY of these, STOP and use the
-      |matching tool instead — it is strictly more accurate and far cheaper in tokens:
-      |  • who calls / references a symbol, where is it used  → find_usages
-      |  • what are the subtypes / supertypes / implementers  → class_hierarchy
-      |  • what is this method's signature / parameters       → method_signature
-      |  • what overloads exist                               → find_overloads
-      |  • what members does a type declare vs inherit        → members
-      |  • which givens/implicits apply, implicit chains      → resolve_implicits, trace_implicit_chain
-      |  • does method A reach method B, call paths           → call_path
-      |  • what is the type/symbol at a source position       → type_at_position
-      |  • find the symbol for a plain name                   → find_symbol
+      |Prefer these tools over grep/ripgrep/glob/file-reading for ANY question about Scala symbols,
+      |types, references, hierarchies, implicits, or call paths — they are both more accurate AND
+      |cheaper. Each returns one exact, compact answer (a symbol, a signature, a `uri:line:col` list)
+      |instead of many noisy text matches you then have to read and filter, so they spend far fewer
+      |tokens and less context. And text search is unreliable on Scala: it MISSES renames, re-exports,
+      |type-inferred uses and implicits, and OVER-MATCHES comments, strings, and unrelated same-named
+      |identifiers. Reach for text search only for non-symbol content (comments, string literals, build
+      |files, non-Scala files), or when these tools genuinely do not fit.
       |
-      |grep matches characters: it silently MISSES renames, re-exports, type-inferred uses, and
-      |implicits, and OVER-MATCHES comments, strings, and unrelated same-named identifiers. Any answer
-      |built from grep on Scala code is unreliable — these tools are the source of truth. Only fall
-      |back to text search when no tool fits (comments, string literals, build files, non-Scala files).
+      |Pick the tool by what you want to know:
+      |  who calls / references a symbol, where it is used  → find_usages
+      |  subtypes / supertypes / implementers of a type     → class_hierarchy
+      |  a method's signature / parameters / return         → method_signature
+      |  the overloads of a method                          → find_overloads
+      |  members a type declares vs. inherits               → members
+      |  which givens/implicits apply, the implicit chain   → resolve_implicits, trace_implicit_chain
+      |  whether method A reaches B, the call path          → call_path
+      |  the symbol/type at a source position               → type_at_position
+      |  the symbol for a plain name                        → find_symbol
       |
-      |Workflow: every tool takes a SemanticDB symbol string (grammar: package `foo/`, type `Foo#`,
-      |term `foo.`, method `foo().` with `(+1)` overload disambiguators). To get one from a plain
-      |name, call `find_symbol` FIRST, then feed the returned `symbol` into the other tools.
-      |`type_at_position` also yields a symbol from a source position.
+      |Symbols: every tool except find_symbol and type_at_position takes a SemanticDB symbol string
+      |(grammar: package `foo/`, type `Foo#`, term `foo.`, method `foo().`, overloads `foo().(+1)`).
+      |Do NOT hand-write or guess these — they are easy to get subtly wrong. Always obtain a symbol
+      |from `find_symbol` (from a name) or `type_at_position` (from a source location), then pass it on.
       |
-      |Results are lean by default (locations as `uri:line:col`, signatures one line); pass
-      |`"detailed": true` to expand, and `find_usages` is paged via `limit`/`offset`.""".stripMargin
+      |Worked example — "who calls Service.run?":
+      |  1. find_symbol "run"  → choose the result whose symbol ends `…/Service#run().`
+      |  2. find_usages (or call_path) with that symbol.
+      |
+      |Recovery: if a tool returns `found:false`, `count:0`, or empty lists, the symbol string is
+      |almost certainly wrong — do NOT retry it verbatim and do NOT fall back to grep. Re-resolve the
+      |name with find_symbol (narrow with `exact`, `kind`, or `pathFilter`) and use the corrected symbol.
+      |
+      |Output is lean by default (locations as `uri:line:col`, signatures one line); pass
+      |`"detailed": true` to expand, and page find_usages via `limit`/`offset`.""".stripMargin
 
   /** Pure request handler (no I/O) so it can be unit-tested. Returns `None` for notifications. */
   def handle(req: ujson.Value, tools: List[Tool]): Option[ujson.Value] =

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -25,11 +25,10 @@ object McpTools:
   def all(az: Analyzer, root: java.nio.file.Path = java.nio.file.Paths.get(".")): List[Tool] = List(
     tool(
       "find_symbol",
-      "START HERE INSTEAD OF grep when you have a plain name. Resolve a plain or partial name " +
-        "(e.g. 'Animal', 'show') to the SemanticDB symbol " +
-        "strings the other tools require. Ranked exact > prefix > substring. Narrow with `exact` " +
-        "(name equality only), `kind` (e.g. TRAIT, CLASS, METHOD, OBJECT) and `pathFilter` (glob on " +
-        "the symbol's definition uri) to cut tokens.",
+      "Resolve a plain or partial name (e.g. 'Animal', 'show') to the SemanticDB symbol strings the " +
+        "other tools require — start here whenever you have a name rather than a symbol. Ranked " +
+        "exact > prefix > substring. Narrow with `exact` (name equality only), `kind` (TRAIT, CLASS, " +
+        "METHOD, OBJECT, …) and `pathFilter` (glob on the symbol's definition uri).",
       List(
         ("query", "string", "simple or partial name to search for"),
         ("limit", "integer", "max results (default 50)"),
@@ -65,11 +64,10 @@ object McpTools:
     },
     tool(
       "find_usages",
-      "USE INSTEAD OF grep to find where a symbol is used. All references to a symbol across the " +
-        "codebase, split into definitions and references (paged). " +
-        "Use `pathFilter` (glob, e.g. `core/*` or `*compat*`) to scope to files and `include` " +
-        "(subset of [\"definitions\",\"references\"]) to drop sections — both cut tokens. " +
-        "`referenceCount` is always returned.",
+      "Every resolved reference to a symbol across the codebase, split into definitions and " +
+        "references (paged) — including renames, re-exports, and inferred/implicit uses that text " +
+        "search misses. Scope with `pathFilter` (glob, e.g. `core/*` or `*compat*`); drop sections " +
+        "with `include` (subset of [\"definitions\",\"references\"]). `referenceCount` is always returned.",
       List(
         ("symbol", "string", "SemanticDB symbol to search for"),
         ("limit", "integer", "max references to return (default 100)"),
@@ -106,11 +104,11 @@ object McpTools:
     },
     tool(
       "method_signature",
-      "USE INSTEAD OF reading source to learn a method's shape. Full method signature including " +
-        "type parameters and implicit/using parameter lists. Pass `uri` + `source` (the defining " +
-        "file's path and CURRENT text) to read the signature from a buffer edited since (or never) " +
-        "compiled: the presentation compiler regenerates it and OVERLAYS it on the index, so types " +
-        "it references from other files still resolve. Requires the server to have a classpath.",
+      "A method's full signature: type parameters, (implicit/using) parameter lists, and return " +
+        "type. Pass `uri` + `source` (the defining file's path and CURRENT text) to read it from a " +
+        "buffer edited since — or never — compiled: the presentation compiler regenerates it, " +
+        "error-tolerant, and overlays it on the index so types referenced from other files still " +
+        "resolve. (The server must have been started with a classpath for `source` to take effect.)",
       List(
         ("symbol", "string", "method symbol"),
         ("detailed", "boolean", "include structured parameter breakdown (default false)"),
@@ -161,10 +159,10 @@ object McpTools:
     },
     tool(
       "class_hierarchy",
-      "USE INSTEAD OF grep to find subtypes/supertypes/implementers. Parents, transitive " +
-        "linearization, and known subtypes of a class/trait. Use `pathFilter` " +
-        "(glob on a related type's definition uri) and `include` (subset of [\"parents\"," +
-        "\"linearization\",\"knownSubtypes\"]) to cut tokens.",
+      "Parents, transitive linearization, and known subtypes/implementers of a class or trait — " +
+        "including subtypes anywhere in the project, which a single LSP lookup cannot give. Scope " +
+        "related types with `pathFilter` (glob on a related type's definition uri); trim with " +
+        "`include` (subset of [\"parents\",\"linearization\",\"knownSubtypes\"]).",
       List(
         ("symbol", "string", "class or trait symbol"),
         ("detailed", "boolean", "expand related types to {symbol,name,kind} (default false)"),
@@ -199,8 +197,8 @@ object McpTools:
     },
     tool(
       "find_overloads",
-      "USE INSTEAD OF grep to find overloads. All method overloads sharing a name and owner with " +
-        "the given method.",
+      "All overloads sharing a name and owner with the given method (they differ only by the `(+N)` " +
+        "disambiguator in the symbol). Pass any one overload's symbol.",
       List(("symbol", "string", "any one overload's symbol")),
       List("symbol")
     ) { a =>
@@ -212,10 +210,9 @@ object McpTools:
     },
     tool(
       "members",
-      "USE INSTEAD OF reading source to list a type's members. Members declared on a type versus " +
-        "those inherited from its linearization. Use `pathFilter` " +
-        "(glob on a member's definition uri) and `include` (subset of [\"declared\",\"inherited\"]) " +
-        "to cut tokens.",
+      "Members a type declares versus those it inherits through its linearization (a member " +
+        "re-declared locally counts as declared). Scope with `pathFilter` (glob on a member's " +
+        "definition uri); trim with `include` (subset of [\"declared\",\"inherited\"]).",
       List(
         ("symbol", "string", "class or trait symbol"),
         ("detailed", "boolean", "include kinds and declaring symbols (default false)"),
@@ -254,12 +251,11 @@ object McpTools:
     },
     tool(
       "type_at_position",
-      "USE INSTEAD OF guessing a type from source. The most specific symbol and its type at a " +
-        "0-based position in a document. Pass `source` with the file's CURRENT text to query a " +
-        "buffer edited since (or never) compiled: the presentation compiler regenerates SemanticDB " +
-        "for it in memory, error-tolerant — so this answers even when the file does not compile. " +
-        "Without `source` it reads the last compiled SemanticDB. Requires the server to have been " +
-        "started with a classpath (see startup logs); otherwise `source` is ignored.",
+      "The most specific symbol and its type at a 0-based (line, character) in a document — also the " +
+        "way to turn a source location into a symbol string for the other tools. Pass `source` with " +
+        "the file's CURRENT text to resolve against a buffer edited since — or never — compiled: the " +
+        "presentation compiler regenerates SemanticDB in memory, error-tolerant. Without `source` it " +
+        "reads the last compiled SemanticDB. (`source` needs the server started with a classpath.)",
       List(
         (
           "uri",
@@ -290,8 +286,8 @@ object McpTools:
     },
     tool(
       "resolve_implicits",
-      "USE INSTEAD OF grep for givens/implicits (grep cannot resolve them). Given/implicit " +
-        "definitions in the index that produce a given type.",
+      "The given/implicit definitions in the index that produce a wanted type (by symbol) — implicit " +
+        "resolution that text search cannot do. `chosen` is set when exactly one candidate applies.",
       List(("type", "string", "the wanted type's symbol, e.g. pkg/Show#")),
       List("type")
     ) { a =>
@@ -311,8 +307,8 @@ object McpTools:
     },
     tool(
       "trace_implicit_chain",
-      "USE INSTEAD OF grep (grep cannot follow implicit resolution). Givens producing a type and " +
-        "the implicit dependencies they transitively pull in.",
+      "The givens that produce a type, plus the implicit dependencies they transitively pull in — " +
+        "follows implicit resolution across givens, step by step.",
       List(("type", "string", "the wanted type's symbol")),
       List("type")
     ) { a =>
@@ -335,8 +331,9 @@ object McpTools:
     },
     tool(
       "call_path",
-      "USE INSTEAD OF grep to trace call relationships. Shortest call path between two methods, " +
-        "with the call-site edges (detailed) that realize it.",
+      "The shortest call path from one method to another, with the call-site edges that realize it " +
+        "(pass `detailed` for edge locations). Use for reachability / how A reaches B — for direct " +
+        "callers of a single method, use find_usages.",
       List(
         ("from", "string", "caller method symbol"),
         ("to", "string", "callee method symbol"),


### PR DESCRIPTION
Relocate the prefer-over-grep guidance into the server instructions (benefit-framed: exact compact answers, fewer tokens, less context) instead of repeating it on every tool description. Add: do-not-hand-write-symbols rule, a worked example, and a recovery loop on empty results. Tool descriptions now lead with capability + a neighbour-disambiguator.

Ships in v0.2.1 alongside the fat-jar assembly fix.