### PR TITLE
ci: rename doc-snippet step (not a second version bump)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,9 +184,9 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
-      - name: Update docs snippets
+      - name: Rewrite doc version snippets to the published version
         run: scripts/update-doc-versions.sh "${GITHUB_REF_NAME}"
-      - name: Open PR with the version bump
+      - name: Open PR updating the doc version snippets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
Naming-only: the failing/auto job rewrites README/INTEGRATION version snippets to the published version; it is not a release bump. Clarify the step names.