### PR TITLE
ci: make doc-version job non-blocking (continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
     # After a real tag release publishes successfully, refresh the dependency snippets to the
     # just-published version. master is protected, so open a PR (auto-merged) instead of pushing to
     # it directly. Normal docs rendering stays offline/deterministic.
+    # Cosmetic + post-release: never let it fail the release run. (It also no-ops unless the repo
+    # setting "Allow GitHub Actions to create and approve pull requests" is enabled.)
+    continue-on-error: true
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
A cosmetic post-release job must not fail the release run.