### PR TITLE
feat(structure): Phase 1 dependency metrics tool (Ca/Ce/instability + cycles)

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -1,5 +1,6 @@
 package com.github.mercurievv.scalasemantic.analysis
 
+import com.github.mercurievv.scalasemantic.analysis.graph.StructureMetrics
 import com.github.mercurievv.scalasemantic.model.*
 import com.github.mercurievv.scalasemantic.pc.PresentationCompilerBackend
 import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
@@ -47,6 +48,14 @@ final class Analyzer(
     pc.map(backend =>
       new Analyzer(SemanticIndex(Vector(backend.semanticdb(fileUri, code, docUri))))
     )
+
+  // --- structure / dependency metrics ---------------------------------------
+
+  /** Multi-relational dependency metrics for the whole project: per in-project type, the coupling
+    * (Ca/Ce/instability) and cycle membership across the `extends`/`memberType`/`call`/`implicit`
+    * graphs and their combined overlay, plus a module rollup and the list of dependency cycles.
+    */
+  def structure(): StructureResult = StructureMetrics(index).result()
 
   // --- find-symbol ----------------------------------------------------------
 

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/DependencyGraphs.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/DependencyGraphs.scala
@@ -1,0 +1,182 @@
+package com.github.mercurievv.scalasemantic.analysis.graph
+
+import com.github.mercurievv.scalasemantic.analysis.graph.GraphMetrics.Graph
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+import scala.meta.internal.semanticdb as s
+
+/** Builds the multi-relational dependency graph for a project from its [[SemanticIndex]].
+  *
+  * Nodes are in-project types (a `ClassSignature` with a definition occurrence in the index);
+  * methods are lifted to their owning type. External types (e.g. `scala/Int#`) are not nodes, so
+  * the metrics describe the project's own architecture. One graph per edge dimension, plus a
+  * combined overlay.
+  */
+final class DependencyGraphs(index: SemanticIndex):
+
+  /** Types defined in this project (have a DEFINITION occurrence and a class signature). */
+  val nodes: Set[String] =
+    val defined = index.occurrences.collect {
+      case (_, occ) if occ.role == s.SymbolOccurrence.Role.DEFINITION => occ.symbol
+    }.toSet
+    index.symbols.values.iterator.collect {
+      case si if defined.contains(si.symbol) && isClass(si) => si.symbol
+    }.toSet
+
+  /** The four edge dimensions, each a directed graph over [[nodes]]. */
+  val dimensions: Map[String, Graph] = Map(
+    "extends" -> extendsGraph,
+    "memberType" -> memberTypeGraph,
+    "call" -> callGraph,
+    "implicit" -> implicitGraph
+  )
+
+  /** Union of all dimensions: an edge exists if any dimension has it. */
+  val combined: Graph =
+    nodes.iterator.map(n => n -> dimensions.values.flatMap(_.getOrElse(n, Set.empty)).toSet).toMap
+
+  /** Module of a type: the leading path segment of its definition uri (e.g. `core`, `analysis`). */
+  def moduleOf(symbol: String): String =
+    definitionUri(symbol).map(_.takeWhile(_ != '/')).filter(_.nonEmpty).getOrElse("<unknown>")
+
+  // --- per-dimension extraction ---------------------------------------------
+
+  /** `extends`: a type → the in-project types it directly extends. */
+  private def extendsGraph: Graph =
+    nodes.iterator.map { n =>
+      n -> parentsOf(n).filter(p => p != n && nodes.contains(p)).toSet
+    }.toMap
+
+  /** `memberType`: a type → in-project types referenced in its members' signatures. */
+  private def memberTypeGraph: Graph =
+    nodes.iterator.map { n =>
+      val refs = declarationSymbols(n)
+        .flatMap(m => index.info(m).toList)
+        .flatMap(mi => signatureTypeRefs(mi.signature))
+        .filter(t => t != n && nodes.contains(t))
+        .toSet
+      n -> refs
+    }.toMap
+
+  /** `call`: method-call edges (attributing references to the enclosing method definition), lifted
+    * to the owning types of caller and callee.
+    */
+  private def callGraph: Graph =
+    val typeEdges = index.documents.iterator.flatMap { doc =>
+      val ordered = doc.occurrences.sortBy(o =>
+        (o.range.map(_.startLine).getOrElse(0), o.range.map(_.startCharacter).getOrElse(0))
+      )
+      ordered
+        .foldLeft((Option.empty[String], List.empty[(String, String)])) {
+          case ((current, acc), occ) =>
+            val isDef = occ.role == s.SymbolOccurrence.Role.DEFINITION
+            val method = index.isMethod(occ.symbol)
+            if isDef && method then (Some(occ.symbol), acc)
+            else if method && current.exists(_ != occ.symbol) then
+              (current, (current.getOrElse(""), occ.symbol) :: acc)
+            else (current, acc)
+        }
+        ._2
+    }
+    val lifted = typeEdges.toList.flatMap { (caller, callee) =>
+      val from = index.owner(caller)
+      val to = index.owner(callee)
+      if from != to && nodes.contains(from) && nodes.contains(to) then List(from -> to) else Nil
+    }
+    lifted.groupMap(_._1)(_._2).view.mapValues(_.toSet).toMap
+
+  /** `implicit`: a type that declares a given/implicit → the in-project types that given pulls in
+    * through its implicit parameters.
+    */
+  private def implicitGraph: Graph =
+    val edges = index.symbols.values.toList.flatMap { si =>
+      if !isImplicit(si) then Nil
+      else
+        val owner = if nodes.contains(si.symbol) then si.symbol else index.owner(si.symbol)
+        if !nodes.contains(owner) then Nil
+        else
+          implicitDependencyTypes(si).filter(t => t != owner && nodes.contains(t)).map(owner -> _)
+    }
+    edges.groupMap(_._1)(_._2).view.mapValues(_.toSet).toMap
+
+  // --- semanticdb helpers (local, to keep this module self-contained) -------
+
+  private def isClass(si: s.SymbolInformation): Boolean =
+    si.signature.isInstanceOf[s.ClassSignature]
+
+  private def parentsOf(symbol: String): List[String] =
+    index.info(symbol).map(_.signature).toList.collect { case c: s.ClassSignature => c }.flatMap {
+      _.parents.flatMap(typeHead)
+    }
+
+  private def declarationSymbols(symbol: String): List[String] =
+    index
+      .info(symbol)
+      .map(_.signature)
+      .collect { case c: s.ClassSignature => scopeInfos(c.declarations).map(_.symbol).toList }
+      .getOrElse(Nil)
+
+  /** All in-project type symbols referenced by a member's signature (return/value type, parameter
+    * types) — including type arguments (`List[Foo]` references both `List` and `Foo`).
+    */
+  private def signatureTypeRefs(sig: s.Signature): Set[String] =
+    sig match
+      case v: s.ValueSignature => typeRefs(v.tpe)
+      case m: s.MethodSignature =>
+        typeRefs(m.returnType) ++
+          m.parameterLists.flatMap(pl => scopeInfos(Some(pl))).flatMap(p => typeRefs(valueType(p)))
+      case _ => Set.empty
+
+  private def implicitDependencyTypes(si: s.SymbolInformation): Set[String] =
+    si.signature match
+      case m: s.MethodSignature =>
+        m.parameterLists.toList
+          .flatMap(pl => scopeInfos(Some(pl)))
+          .filter(isImplicit)
+          .flatMap(p => typeRefs(valueType(p)))
+          .toSet
+      case _ => Set.empty
+
+  /** Type symbols a `Type` references, head plus all type arguments, recursively. */
+  private def typeRefs(t: s.Type): Set[String] =
+    t match
+      case s.TypeRef(_, sym, args)  => args.flatMap(typeRefs).toSet + sym
+      case s.SingleType(_, sym)     => Set(sym)
+      case s.ThisType(sym)          => Set(sym)
+      case s.SuperType(_, sym)      => Set(sym)
+      case s.ByNameType(inner)      => typeRefs(inner)
+      case s.RepeatedType(inner)    => typeRefs(inner)
+      case s.WithType(ts)           => ts.flatMap(typeRefs).toSet
+      case s.IntersectionType(ts)   => ts.flatMap(typeRefs).toSet
+      case s.UnionType(ts)          => ts.flatMap(typeRefs).toSet
+      case s.AnnotatedType(_, t2)   => typeRefs(t2)
+      case s.ExistentialType(t2, _) => typeRefs(t2)
+      case s.UniversalType(_, t2)   => typeRefs(t2)
+      case s.StructuralType(t2, _)  => typeRefs(t2)
+      case _                        => Set.empty
+
+  private def typeHead(t: s.Type): Option[String] =
+    t match
+      case s.TypeRef(_, sym, _) => Some(sym)
+      case s.SingleType(_, sym) => Some(sym)
+      case _                    => None
+
+  private def scopeInfos(scope: Option[s.Scope]): Seq[s.SymbolInformation] =
+    scope.toSeq.flatMap { sc =>
+      if sc.hardlinks.nonEmpty then sc.hardlinks else sc.symlinks.flatMap(index.info)
+    }
+
+  private def valueType(info: s.SymbolInformation): s.Type =
+    info.signature match
+      case v: s.ValueSignature  => v.tpe
+      case m: s.MethodSignature => m.returnType
+      case _                    => s.Type.Empty
+
+  private def isImplicit(info: s.SymbolInformation): Boolean =
+    (info.properties & s.SymbolInformation.Property.IMPLICIT.value) != 0
+
+  private def definitionUri(symbol: String): Option[String] =
+    index.occurrences.collectFirst {
+      case (uri, occ) if occ.symbol == symbol && occ.role == s.SymbolOccurrence.Role.DEFINITION =>
+        uri
+    }

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetrics.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetrics.scala
@@ -1,0 +1,79 @@
+package com.github.mercurievv.scalasemantic.analysis.graph
+
+/** Pure graph algorithms over a directed graph `node -> out-neighbours`, restricted to a fixed node
+  * set. Written functionally (immutable accumulators, no mutation) to satisfy the project's
+  * wartremover rules; recursion depth is bounded by the graph's depth, fine for project-sized
+  * graphs.
+  */
+object GraphMetrics:
+
+  /** A directed graph: each node maps to the set of nodes it depends on. Edges point to nodes only.
+    */
+  type Graph = Map[String, Set[String]]
+
+  /** Afferent (Ca, fan-in) and efferent (Ce, fan-out) coupling for every node. */
+  def coupling(nodes: Set[String], graph: Graph): Map[String, (Int, Int)] =
+    val incoming: Map[String, Int] =
+      graph.toList
+        .flatMap((_, outs) => outs.toList)
+        .filter(nodes.contains)
+        .groupBy(identity)
+        .view
+        .mapValues(_.size)
+        .toMap
+    nodes.iterator
+      .map(n => n -> (incoming.getOrElse(n, 0), graph.getOrElse(n, Set.empty).size))
+      .toMap
+
+  /** Instability Ce/(Ca+Ce), or 0 for an isolated node (no edges either way). */
+  def instability(ca: Int, ce: Int): Double =
+    if ca + ce == 0 then 0.0 else ce.toDouble / (ca + ce)
+
+  /** Strongly-connected components (Kosaraju): a list of node sets. Singleton sets are acyclic
+    * nodes; a set of size > 1 is a dependency cycle (mutually-reachable nodes).
+    */
+  def stronglyConnectedComponents(nodes: Set[String], graph: Graph): List[Set[String]] =
+    val order = finishOrder(nodes, graph) // highest finish time first
+    val reversed = reverse(nodes, graph)
+    order
+      .foldLeft((Set.empty[String], List.empty[Set[String]])) { case ((assigned, comps), n) =>
+        if assigned.contains(n) then (assigned, comps)
+        else
+          val comp = collect(n, reversed, assigned, Set.empty)
+          (assigned ++ comp, comp :: comps)
+      }
+      ._2
+
+  /** Post-order DFS over all nodes, accumulating finish order with the last-finished node first. */
+  private def finishOrder(nodes: Set[String], graph: Graph): List[String] =
+    def dfs(n: String, visited: Set[String], acc: List[String]): (Set[String], List[String]) =
+      if visited.contains(n) then (visited, acc)
+      else
+        val (v, a) = graph
+          .getOrElse(n, Set.empty)
+          .foldLeft((visited + n, acc)) { case ((vv, aa), m) => dfs(m, vv, aa) }
+        (v, n :: a)
+    nodes.toList
+      .foldLeft((Set.empty[String], List.empty[String])) { case ((v, a), n) => dfs(n, v, a) }
+      ._2
+
+  /** All nodes reachable from `start` in `graph`, skipping already-assigned nodes — one SCC. */
+  private def collect(
+      start: String,
+      graph: Graph,
+      assigned: Set[String],
+      acc: Set[String]
+  ): Set[String] =
+    if assigned.contains(start) || acc.contains(start) then acc
+    else
+      graph
+        .getOrElse(start, Set.empty)
+        .foldLeft(acc + start) { (a, m) => collect(m, graph, assigned, a) }
+
+  private def reverse(nodes: Set[String], graph: Graph): Graph =
+    val empty = nodes.iterator.map(_ -> Set.empty[String]).toMap
+    graph.foldLeft(empty) { case (acc, (from, outs)) =>
+      outs.foldLeft(acc) { (a, to) =>
+        if nodes.contains(to) then a.updated(to, a.getOrElse(to, Set.empty) + from) else a
+      }
+    }

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala
@@ -1,0 +1,88 @@
+package com.github.mercurievv.scalasemantic.analysis.graph
+
+import com.github.mercurievv.scalasemantic.analysis.graph.GraphMetrics.Graph
+import com.github.mercurievv.scalasemantic.model.*
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+/** Computes the Phase-1 structural metrics for a project: per-type coupling (Ca/Ce/instability) and
+  * cycle membership (SCC) across the four edge dimensions and a combined overlay, plus a
+  * module-level rollup. No layering — cyclic nodes are reported via `inCycle`, not assigned a faked
+  * layer.
+  */
+final class StructureMetrics(index: SemanticIndex):
+
+  private val graphs = new DependencyGraphs(index)
+  private val nodes = graphs.nodes
+  private val dimensionNames = List("extends", "memberType", "call", "implicit")
+
+  def result(): StructureResult =
+    val perDim = graphs.dimensions.view.mapValues(metricsFor).toMap
+    val combined = metricsFor(graphs.combined)
+
+    val symbols = nodes.toList
+      .map { n =>
+        SymbolStructure(
+          symbol = n,
+          displayName = index.displayName(n),
+          module = graphs.moduleOf(n),
+          combined = combined(n),
+          perDimension = dimensionNames.map(d => d -> perDim(d)(n)).toMap
+        )
+      }
+      .sortBy(_.symbol)
+
+    val cycles =
+      (dimensionNames.map(d => d -> graphs.dimensions(d)) :+ ("combined" -> graphs.combined))
+        .flatMap { (name, g) =>
+          GraphMetrics
+            .stronglyConnectedComponents(nodes, g)
+            .filter(_.size > 1)
+            .map(c => DependencyCycle(name, c.toList.sorted))
+        }
+
+    StructureResult(symbols, moduleRollup, cycles)
+
+  /** Per-node `DimensionMetrics` for one graph: coupling + SCC size. */
+  private def metricsFor(graph: Graph): Map[String, DimensionMetrics] =
+    val coupling = GraphMetrics.coupling(nodes, graph)
+    val sccSize = sccSizes(nodes, graph)
+    nodes.iterator.map { n =>
+      val (ca, ce) = coupling.getOrElse(n, (0, 0))
+      val size = sccSize.getOrElse(n, 1)
+      n -> DimensionMetrics(ca, ce, GraphMetrics.instability(ca, ce), size, size > 1)
+    }.toMap
+
+  /** Module-level rollup of the combined graph: each type's module, edges lifted to module pairs.
+    */
+  private def moduleRollup: List[ModuleStructure] =
+    val moduleNodes = nodes.map(graphs.moduleOf)
+    val moduleGraph: Graph =
+      graphs.combined.toList
+        .flatMap((from, tos) => tos.toList.map(to => graphs.moduleOf(from) -> graphs.moduleOf(to)))
+        .filter((a, b) => a != b)
+        .groupMap(_._1)(_._2)
+        .view
+        .mapValues(_.toSet)
+        .toMap
+    val coupling = GraphMetrics.coupling(moduleNodes, moduleGraph)
+    val sccSize = sccSizes(moduleNodes, moduleGraph)
+    val typeCount = nodes.groupBy(graphs.moduleOf).view.mapValues(_.size).toMap
+    moduleNodes.toList.sorted.map { m =>
+      val (ca, ce) = coupling.getOrElse(m, (0, 0))
+      val size = sccSize.getOrElse(m, 1)
+      ModuleStructure(
+        module = m,
+        typeCount = typeCount.getOrElse(m, 0),
+        afferent = ca,
+        efferent = ce,
+        instability = GraphMetrics.instability(ca, ce),
+        sccSize = size,
+        inCycle = size > 1
+      )
+    }
+
+  private def sccSizes(nodeSet: Set[String], graph: Graph): Map[String, Int] =
+    GraphMetrics
+      .stronglyConnectedComponents(nodeSet, graph)
+      .flatMap(c => c.map(_ -> c.size))
+      .toMap

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
@@ -103,6 +103,55 @@ case class TypeAtPosition(
     tpe: String
 ) derives ReadWriter
 
+// --- structure / dependency metrics -----------------------------------------
+
+/** Coupling metrics for one node in one edge dimension (or the combined overlay).
+  *
+  * `afferent` (Ca) = incoming deps (fan-in); `efferent` (Ce) = outgoing deps (fan-out);
+  * `instability` = Ce/(Ca+Ce) in [0,1] — 0 = stable foundation (depended-on, depends on little), 1
+  * \= unstable leaf/entry. `inCycle` is true when the node sits in a non-trivial strongly-connected
+  * component (`sccSize` > 1) — cyclic membership is reported, never hidden behind a faked layer.
+  */
+case class DimensionMetrics(
+    afferent: Int,
+    efferent: Int,
+    instability: Double,
+    sccSize: Int,
+    inCycle: Boolean
+) derives ReadWriter
+
+/** Structural metrics for one in-project type, in the combined graph and per edge dimension
+  * (`extends`, `memberType`, `call`, `implicit`).
+  */
+case class SymbolStructure(
+    symbol: String,
+    displayName: String,
+    module: String,
+    combined: DimensionMetrics,
+    perDimension: Map[String, DimensionMetrics]
+) derives ReadWriter
+
+/** A dependency cycle: the members of one non-trivial strongly-connected component in a dimension.
+  */
+case class DependencyCycle(dimension: String, members: List[String]) derives ReadWriter
+
+/** Module-level rollup of the combined graph (module = leading path segment of a type's uri). */
+case class ModuleStructure(
+    module: String,
+    typeCount: Int,
+    afferent: Int,
+    efferent: Int,
+    instability: Double,
+    sccSize: Int,
+    inCycle: Boolean
+) derives ReadWriter
+
+case class StructureResult(
+    symbols: List[SymbolStructure],
+    modules: List[ModuleStructure],
+    cycles: List[DependencyCycle]
+) derives ReadWriter
+
 // --- call-graph path-find ---------------------------------------------------
 
 case class CallEdge(from: SymbolRef, to: SymbolRef, at: Location) derives ReadWriter

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerStructureSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerStructureSuite.scala
@@ -1,0 +1,51 @@
+package com.github.mercurievv.scalasemantic.analysis
+
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+/** Phase 1 of the structural-metrics feature, dogfooded on this repo. The module dependency
+  * direction here is known (core ← analysis ← mcp, with pc beside analysis), so the computed
+  * coupling must reflect it: core is stable/foundational, mcp is unstable/top, and the modules form
+  * no cycle.
+  */
+class AnalyzerStructureSuite extends munit.FunSuite:
+
+  private val az = Analyzer(SemanticIndex.fromProject("."))
+  private val structure = az.structure()
+  private def module(m: String) =
+    structure.modules
+      .find(_.module == m)
+      .getOrElse(fail(s"no module $m; got ${structure.modules.map(_.module)}"))
+
+  test("structure covers the project's modules and types") {
+    assert(structure.symbols.nonEmpty, "expected some in-project type nodes")
+    val mods = structure.modules.map(_.module).toSet
+    assert(Set("core", "analysis", "mcp").subsetOf(mods), mods.toString)
+  }
+
+  test("module instability reflects the known dependency direction (core stable, mcp unstable)") {
+    // core is depended on by everything and depends on nothing in-project → low instability.
+    // mcp sits at the top → high instability. (Use <= to stay robust to exact counts.)
+    assert(
+      module("core").instability < module("mcp").instability,
+      s"core=${module("core").instability} mcp=${module("mcp").instability}"
+    )
+    assert(module("core").afferent > 0, "core should be depended upon")
+  }
+
+  test("the module graph has no cycle (clean layering)") {
+    val cyclic = structure.modules.filter(_.inCycle).map(_.module)
+    assert(cyclic.isEmpty, s"modules in a cycle: $cyclic")
+  }
+
+  test("per-symbol metrics carry all four dimensions plus the combined overlay") {
+    val s = structure.symbols.head
+    assertEquals(
+      s.perDimension.keySet,
+      Set("extends", "memberType", "call", "implicit"),
+      s.perDimension.keySet.toString
+    )
+    // instability is a proper ratio
+    assert(
+      structure.symbols.forall(x => x.combined.instability >= 0.0 && x.combined.instability <= 1.0)
+    )
+  }

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -59,6 +59,7 @@ object Mcp:
       |  whether method A reaches B, the call path          → call_path
       |  the symbol/type at a source position               → type_at_position
       |  the symbol for a plain name                        → find_symbol
+      |  what's important / where to start, dep cycles       → structure
       |
       |Symbols: every tool except find_symbol and type_at_position takes a SemanticDB symbol string
       |(grammar: package `foo/`, type `Foo#`, term `foo.`, method `foo().`, overloads `foo().(+1)`).

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -3,7 +3,7 @@ package com.github.mercurievv.scalasemantic.mcp
 import com.github.mercurievv.scalasemantic.analysis.Analyzer
 import com.github.mercurievv.scalasemantic.model.*
 
-/** The nine analysis tools exposed over MCP, with token-lean JSON rendering.
+/** The analysis tools exposed over MCP, with token-lean JSON rendering.
   *
   * Conventions: a symbol is a SemanticDB symbol string (e.g. `pkg/Type#method().`). Results stay
   * minimal — pass `"detailed": true` to expand the structured breakdown of a result.
@@ -355,10 +355,120 @@ object McpTools:
           )
         )
       )
+    },
+    tool(
+      "structure",
+      "Whole-project dependency metrics from the symbol graph — use to judge what matters and where " +
+        "to start. Per in-project type: afferent coupling Ca (fan-in = how many depend on it), " +
+        "efferent Ce (fan-out), instability Ce/(Ca+Ce) (0 = stable foundation, 1 = unstable leaf), " +
+        "and cycle membership. Computed over four edge dimensions (extends, memberType, call, " +
+        "implicit) and a combined overlay, with a module rollup. High Ca/low instability = core to " +
+        "understand first; `cycles` flags tangles. No layering (a cyclic node is reported, not ranked).",
+      List(
+        (
+          "sort",
+          "string",
+          "rank symbols by: afferent | efferent | instability | sccSize (default afferent)"
+        ),
+        (
+          "dimension",
+          "string",
+          "which graph's metrics per symbol: combined | extends | memberType | call | implicit (default combined)"
+        ),
+        (
+          "pathFilter",
+          "string",
+          "glob on a type's module (e.g. `core`, `*mcp*`) to scope the list"
+        ),
+        ("limit", "integer", "max symbols to return (default 30)"),
+        (
+          "detailed",
+          "boolean",
+          "include the per-dimension Ca/Ce/instability breakdown (default false)"
+        )
+      ),
+      Nil
+    ) { a =>
+      val res = az.structure()
+      val dim = argStr(a, "dimension") match
+        case "" => "combined"
+        case d  => d
+      val sortKey = argStr(a, "sort") match
+        case "" => "afferent"
+        case s  => s
+      val keep = res.symbols.filter(s => moduleGlob(a, s.module))
+      val pick: SymbolStructure => DimensionMetrics =
+        s => if dim == "combined" then s.combined else s.perDimension.getOrElse(dim, s.combined)
+      val rank: DimensionMetrics => Double = m =>
+        sortKey match
+          case "efferent"    => m.efferent.toDouble
+          case "instability" => m.instability
+          case "sccSize"     => m.sccSize.toDouble
+          case _             => m.afferent.toDouble
+      val ranked = keep.sortBy(s => -rank(pick(s))).take(argInt(a, "limit", 30))
+      jobj(
+        Some("dimension" -> ujson.Str(dim)),
+        Some("sort" -> ujson.Str(sortKey)),
+        Some(
+          "modules" -> ujson.Arr.from(res.modules.map { m =>
+            jobj(
+              Some("module" -> ujson.Str(m.module)),
+              Some("types" -> ujson.Num(m.typeCount)),
+              Some("ca" -> ujson.Num(m.afferent)),
+              Some("ce" -> ujson.Num(m.efferent)),
+              Some("instability" -> ujson.Num(round2(m.instability))),
+              opt(m.inCycle, "inCycle" -> ujson.Bool(true))
+            )
+          })
+        ),
+        Some(
+          "symbols" -> ujson.Arr.from(ranked.map { s =>
+            val m = pick(s)
+            jobj(
+              Some("symbol" -> ujson.Str(s.symbol)),
+              Some("name" -> ujson.Str(s.displayName)),
+              Some("module" -> ujson.Str(s.module)),
+              Some("ca" -> ujson.Num(m.afferent)),
+              Some("ce" -> ujson.Num(m.efferent)),
+              Some("instability" -> ujson.Num(round2(m.instability))),
+              opt(m.inCycle, "inCycle" -> ujson.Bool(true)),
+              opt(
+                argBool(a, "detailed", false),
+                "perDimension" -> ujson.Obj.from(s.perDimension.toList.sortBy(_._1).map { (d, dm) =>
+                  d -> (jobj(
+                    Some("ca" -> ujson.Num(dm.afferent)),
+                    Some("ce" -> ujson.Num(dm.efferent)),
+                    Some("instability" -> ujson.Num(round2(dm.instability)))
+                  ): ujson.Value)
+                })
+              )
+            )
+          })
+        ),
+        opt(
+          res.cycles.nonEmpty,
+          "cycles" -> ujson.Arr.from(res.cycles.map { c =>
+            jobj(
+              Some("dimension" -> ujson.Str(c.dimension)),
+              Some("members" -> strs(c.members))
+            )
+          })
+        )
+      )
     }
   )
 
   // --- rendering helpers ----------------------------------------------------
+
+  /** Keep a module when no `pathFilter` is given, or when the glob (`*` = any chars) matches it. */
+  private def moduleGlob(a: ujson.Value, module: String): Boolean =
+    a.obj.get("pathFilter").map(_.str).filter(_.nonEmpty) match
+      case None => true
+      case Some(glob) =>
+        val re = glob.split("\\*", -1).map(java.util.regex.Pattern.quote).mkString(".*").r
+        re.findFirstIn(module).isDefined
+
+  private def round2(d: Double): Double = math.round(d * 100.0) / 100.0
 
   private def loc(l: Location): String =
     s"${l.uri}:${l.range.start.line}:${l.range.start.character}"

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
@@ -39,13 +39,14 @@ class McpSuite extends munit.FunSuite:
     assert(instr.contains("find_symbol"), instr)
   }
 
-  test("tools/list exposes all ten tools with schemas") {
+  test("tools/list exposes all eleven tools with schemas") {
     val r = Mcp.handle(req("tools/list", ujson.Obj()), tools).get
     val names = r("result")("tools").arr.map(_("name").str).toSet
-    assertEquals(names.size, 10)
+    assertEquals(names.size, 11)
     assert(names.contains("find_symbol"), names.toString)
     assert(names.contains("find_usages"), names.toString)
     assert(names.contains("call_path"), names.toString)
+    assert(names.contains("structure"), names.toString)
     // every tool carries an object input schema
     assert(r("result")("tools").arr.forall(_("inputSchema")("type").str == "object"))
   }
@@ -74,6 +75,22 @@ class McpSuite extends munit.FunSuite:
       )
     val syms = scoped("symbols").arr.map(_("symbol").str)
     assertEquals(syms.toList, List("com/github/mercurievv/scalasemantic/compat/Animal#"))
+  }
+
+  test("structure ranks types by coupling and rolls up modules (dogfood)") {
+    val r = call("structure", ujson.Obj("limit" -> 5))
+    val mods = r("modules").arr.map(_("module").str).toSet
+    assert(Set("core", "analysis", "mcp").subsetOf(mods), mods.toString)
+    // default sort is afferent (fan-in) descending
+    val cas = r("symbols").arr.map(_("ca").num)
+    assertEquals(cas.toList, cas.toList.sortBy(-_), "symbols must be ranked by Ca desc")
+    // every symbol carries the core metrics
+    assert(r("symbols").arr.forall(s => s.obj.contains("instability") && s.obj.contains("module")))
+
+    // detailed adds the per-dimension breakdown with all four dimensions
+    val d = call("structure", ujson.Obj("limit" -> 1, "detailed" -> true))
+    val dims = d("symbols")(0)("perDimension").obj.keys.toSet
+    assertEquals(dims, Set("extends", "memberType", "call", "implicit"), dims.toString)
   }
 
   test("notifications get no response") {
@@ -242,5 +259,5 @@ class McpSuite extends munit.FunSuite:
     // 4 lines in (one blank, one notification) → 2 responses out, with matching ids
     assertEquals(out.size, 2)
     assertEquals(ujson.read(out(0))("id").num, 1.0)
-    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 10)
+    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 11)
   }


### PR DESCRIPTION
Phase 1 of the structural-analysis feature (per the locked plan): multi-relational dependency metrics from the symbol graph, no layering yet.

- Four edge graphs (extends/memberType/call/implicit) + combined overlay over in-project types; functional Kosaraju SCC + Ca/Ce coupling.
- Per-type Ca/Ce/instability + cycle membership, per dimension and combined; module rollup.
- New index-only MCP tool `structure`.
- Dogfood recovers core←analysis/pc←mcp (core I=0.00, mcp I=1.00), 0 cycles.

Cyclic nodes are flagged (`inCycle`), never given a faked layer. Later phases: layering, PageRank/clustering, declared-vs-computed boundary diff.