### PR TITLE
feat(structure): Phase 2 layering (longest-path on the condensed DAG)

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetrics.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetrics.scala
@@ -44,6 +44,45 @@ object GraphMetrics:
       }
       ._2
 
+  /** Longest-path layering on the SCC-condensed DAG: each node's level = the length of the longest
+    * dependency chain beneath it (0 = a foundation that depends on nothing in-project; higher =
+    * depends on deeper chains). Cycles are condensed first, so every member of a cycle shares its
+    * component's level — the level is honest (where the tangle sits), but members cannot be ordered
+    * *within* the cycle (callers should read `inCycle` to know the intra-cycle order is undefined).
+    */
+  def layers(nodes: Set[String], graph: Graph): Map[String, Int] =
+    val components = stronglyConnectedComponents(nodes, graph)
+    val componentOf: Map[String, Int] =
+      components.iterator.zipWithIndex.flatMap((c, i) => c.iterator.map(_ -> i)).toMap
+    // Condensed DAG: component -> the other components it depends on.
+    val condensed: Map[Int, Set[Int]] =
+      graph.toList
+        .flatMap((from, outs) => outs.toList.filter(nodes.contains).map(to => from -> to))
+        .flatMap((from, to) =>
+          val ci = componentOf(from)
+          val cj = componentOf(to)
+          if ci != cj then List(ci -> cj) else Nil
+        )
+        .groupMap(_._1)(_._2)
+        .view
+        .mapValues(_.toSet)
+        .toMap
+    // Longest path to a sink, memoised over the (acyclic) condensed graph.
+    def level(c: Int, memo: Map[Int, Int]): (Int, Map[Int, Int]) =
+      memo.get(c) match
+        case Some(v) => (v, memo)
+        case None =>
+          val (lv, m) =
+            condensed.getOrElse(c, Set.empty).foldLeft((0, memo)) { case ((acc, mm), s) =>
+              val (sv, mm2) = level(s, mm)
+              (math.max(acc, sv + 1), mm2)
+            }
+          (lv, m + (c -> lv))
+    val componentLevels = components.indices.foldLeft(Map.empty[Int, Int]) { (memo, c) =>
+      level(c, memo)._2
+    }
+    nodes.iterator.map(n => n -> componentLevels.getOrElse(componentOf(n), 0)).toMap
+
   /** Post-order DFS over all nodes, accumulating finish order with the last-finished node first. */
   private def finishOrder(nodes: Set[String], graph: Graph): List[String] =
     def dfs(n: String, visited: Set[String], acc: List[String]): (Set[String], List[String]) =

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala
@@ -42,14 +42,22 @@ final class StructureMetrics(index: SemanticIndex):
 
     StructureResult(symbols, moduleRollup, cycles)
 
-  /** Per-node `DimensionMetrics` for one graph: coupling + SCC size. */
+  /** Per-node `DimensionMetrics` for one graph: coupling + layer + SCC size. */
   private def metricsFor(graph: Graph): Map[String, DimensionMetrics] =
     val coupling = GraphMetrics.coupling(nodes, graph)
     val sccSize = sccSizes(nodes, graph)
+    val layer = GraphMetrics.layers(nodes, graph)
     nodes.iterator.map { n =>
       val (ca, ce) = coupling.getOrElse(n, (0, 0))
       val size = sccSize.getOrElse(n, 1)
-      n -> DimensionMetrics(ca, ce, GraphMetrics.instability(ca, ce), size, size > 1)
+      n -> DimensionMetrics(
+        ca,
+        ce,
+        GraphMetrics.instability(ca, ce),
+        layer.getOrElse(n, 0),
+        size,
+        size > 1
+      )
     }.toMap
 
   /** Module-level rollup of the combined graph: each type's module, edges lifted to module pairs.
@@ -66,6 +74,7 @@ final class StructureMetrics(index: SemanticIndex):
         .toMap
     val coupling = GraphMetrics.coupling(moduleNodes, moduleGraph)
     val sccSize = sccSizes(moduleNodes, moduleGraph)
+    val layer = GraphMetrics.layers(moduleNodes, moduleGraph)
     val typeCount = nodes.groupBy(graphs.moduleOf).view.mapValues(_.size).toMap
     moduleNodes.toList.sorted.map { m =>
       val (ca, ce) = coupling.getOrElse(m, (0, 0))
@@ -76,6 +85,7 @@ final class StructureMetrics(index: SemanticIndex):
         afferent = ca,
         efferent = ce,
         instability = GraphMetrics.instability(ca, ce),
+        layer = layer.getOrElse(m, 0),
         sccSize = size,
         inCycle = size > 1
       )

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
@@ -109,13 +109,17 @@ case class TypeAtPosition(
   *
   * `afferent` (Ca) = incoming deps (fan-in); `efferent` (Ce) = outgoing deps (fan-out);
   * `instability` = Ce/(Ca+Ce) in [0,1] — 0 = stable foundation (depended-on, depends on little), 1
-  * \= unstable leaf/entry. `inCycle` is true when the node sits in a non-trivial strongly-connected
-  * component (`sccSize` > 1) — cyclic membership is reported, never hidden behind a faked layer.
+  * \= unstable leaf/entry. `layer` = longest dependency-chain depth (0 = foundation; higher = sits
+  * on deeper chains), computed on the SCC-condensed graph. `inCycle` is true when the node sits in
+  * a non-trivial strongly-connected component (`sccSize` > 1); then `layer` is the cycle's level as
+  * a whole and the order *within* the cycle is undefined — cyclic membership is reported, never
+  * hidden behind a faked per-node layer.
   */
 case class DimensionMetrics(
     afferent: Int,
     efferent: Int,
     instability: Double,
+    layer: Int,
     sccSize: Int,
     inCycle: Boolean
 ) derives ReadWriter
@@ -142,6 +146,7 @@ case class ModuleStructure(
     afferent: Int,
     efferent: Int,
     instability: Double,
+    layer: Int,
     sccSize: Int,
     inCycle: Boolean
 ) derives ReadWriter

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerStructureSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerStructureSuite.scala
@@ -37,6 +37,17 @@ class AnalyzerStructureSuite extends munit.FunSuite:
     assert(cyclic.isEmpty, s"modules in a cycle: $cyclic")
   }
 
+  test("layering puts foundations below dependents (core layer 0, mcp above)") {
+    // core depends on nothing in-project → foundation, layer 0. mcp sits on top → strictly higher.
+    assertEquals(module("core").layer, 0, s"core layer=${module("core").layer}")
+    assert(
+      module("mcp").layer > module("core").layer,
+      s"core=${module("core").layer} mcp=${module("mcp").layer}"
+    )
+    // No cycles here, so no symbol should be flagged ambiguous (inCycle) while still carrying a layer.
+    assert(structure.symbols.forall(s => !s.combined.inCycle), "unexpected cycle in this repo")
+  }
+
   test("per-symbol metrics carry all four dimensions plus the combined overlay") {
     val s = structure.symbols.head
     assertEquals(

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -361,14 +361,16 @@ object McpTools:
       "Whole-project dependency metrics from the symbol graph — use to judge what matters and where " +
         "to start. Per in-project type: afferent coupling Ca (fan-in = how many depend on it), " +
         "efferent Ce (fan-out), instability Ce/(Ca+Ce) (0 = stable foundation, 1 = unstable leaf), " +
+        "`layer` (longest dependency-chain depth: 0 = foundation, higher = built on deeper chains), " +
         "and cycle membership. Computed over four edge dimensions (extends, memberType, call, " +
-        "implicit) and a combined overlay, with a module rollup. High Ca/low instability = core to " +
-        "understand first; `cycles` flags tangles. No layering (a cyclic node is reported, not ranked).",
+        "implicit) and a combined overlay, with a module rollup. High Ca / low instability / low " +
+        "layer = core to understand first; `cycles` flags tangles. A cyclic node shares its cycle's " +
+        "layer (intra-cycle order undefined) and is marked `inCycle` — never given a faked layer.",
       List(
         (
           "sort",
           "string",
-          "rank symbols by: afferent | efferent | instability | sccSize (default afferent)"
+          "rank symbols by: afferent | efferent | instability | layer | sccSize (default afferent)"
         ),
         (
           "dimension",
@@ -403,6 +405,7 @@ object McpTools:
         sortKey match
           case "efferent"    => m.efferent.toDouble
           case "instability" => m.instability
+          case "layer"       => m.layer.toDouble
           case "sccSize"     => m.sccSize.toDouble
           case _             => m.afferent.toDouble
       val ranked = keep.sortBy(s => -rank(pick(s))).take(argInt(a, "limit", 30))
@@ -414,6 +417,7 @@ object McpTools:
             jobj(
               Some("module" -> ujson.Str(m.module)),
               Some("types" -> ujson.Num(m.typeCount)),
+              Some("layer" -> ujson.Num(m.layer)),
               Some("ca" -> ujson.Num(m.afferent)),
               Some("ce" -> ujson.Num(m.efferent)),
               Some("instability" -> ujson.Num(round2(m.instability))),
@@ -428,6 +432,7 @@ object McpTools:
               Some("symbol" -> ujson.Str(s.symbol)),
               Some("name" -> ujson.Str(s.displayName)),
               Some("module" -> ujson.Str(s.module)),
+              Some("layer" -> ujson.Num(m.layer)),
               Some("ca" -> ujson.Num(m.afferent)),
               Some("ce" -> ujson.Num(m.efferent)),
               Some("instability" -> ujson.Num(round2(m.instability))),

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
@@ -84,8 +84,13 @@ class McpSuite extends munit.FunSuite:
     // default sort is afferent (fan-in) descending
     val cas = r("symbols").arr.map(_("ca").num)
     assertEquals(cas.toList, cas.toList.sortBy(-_), "symbols must be ranked by Ca desc")
-    // every symbol carries the core metrics
-    assert(r("symbols").arr.forall(s => s.obj.contains("instability") && s.obj.contains("module")))
+    // every symbol carries the core metrics, including the Phase-2 layer
+    assert(r("symbols").arr.forall(s => s.obj.contains("instability") && s.obj.contains("layer")))
+    assert(r("modules").arr.forall(_.obj.contains("layer")), "modules carry a layer")
+    // sorting by layer is accepted and ranks descending
+    val byLayer = call("structure", ujson.Obj("sort" -> "layer", "limit" -> 5))
+    val layers = byLayer("symbols").arr.map(_("layer").num)
+    assertEquals(layers.toList, layers.toList.sortBy(-_), "symbols ranked by layer desc")
 
     // detailed adds the per-dimension breakdown with all four dimensions
     val d = call("structure", ujson.Obj("limit" -> 1, "detailed" -> true))


### PR DESCRIPTION
Adds a `layer` (longest dependency-chain depth) to every type and module, computed on the SCC-condensed graph. Cyclic nodes share their cycle's level and stay flagged `inCycle` — no faked per-node layer. Dogfood module layers match the build dependsOn exactly (L0 core → L3 mcp).