### PR TITLE
chore: tag releases from latest master

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -28,12 +28,11 @@ If you supply a value that is *already* base64, set `PGP_SECRET_BASE64_ENCODE=fa
 
 ## Cut a release
 
-Development is PR-based (branch protection on `master`, squash-merge). A release is just a tag on
-`master`; the bump scripts refuse to run unless you are on an up-to-date `master`, so the tag always
-lands on the merged commit:
+Development is PR-based (branch protection on `master`, squash-merge). A release is just a tag on the
+latest `origin/master` commit; the bump script switches to `master`, fetches the latest remote commit,
+fast-forwards, tags it, and optionally pushes the tag:
 
 ```sh
-git checkout master && git pull          # after merging the PR(s) for this release
 scripts/bump-version.sh minor --push     # or bump-fix/bump-minor/bump-major — tags vX.Y.Z and pushes
 scripts/check-push-workflow.sh           # wait for CI, report the latest published version
 scripts/retry-last-tag.sh --push         # move the tag to HEAD to retry a release that failed early

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,6 +8,7 @@
 #
 # Rules:
 # - Uses the highest existing v* semver tag if present, else FIRST_VERSION (scripts/config.sh).
+# - Switches to RELEASE_BRANCH (master by default), fast-forwards it from origin, and tags that commit.
 # - Creates the tag locally; with --push, also pushes it to origin (which triggers the release).
 
 set -euo pipefail
@@ -22,20 +23,21 @@ require_clean_git() {
   fi
 }
 
-# Releases are cut from master only, and only when it matches origin/master — so under a PR workflow
-# the tag lands on the merged commit, never a stale or feature branch.
-require_synced_master() {
-  local branch
-  branch="$(git rev-parse --abbrev-ref HEAD)"
-  if [[ "$branch" != "master" ]]; then
-    echo "Releases are tagged from master, not '$branch'. Merge your PR, then: git checkout master && git pull." >&2
-    exit 1
+# Releases are cut from the latest remote release branch commit, so under a PR workflow the tag lands
+# on the merged commit, never a stale checkout or feature branch.
+switch_to_latest_release_branch() {
+  git fetch -q --tags origin "$RELEASE_BRANCH:refs/remotes/origin/$RELEASE_BRANCH"
+
+  if git show-ref --verify --quiet "refs/heads/${RELEASE_BRANCH}"; then
+    git switch -q "$RELEASE_BRANCH"
+  else
+    git switch -q --track -c "$RELEASE_BRANCH" "origin/${RELEASE_BRANCH}"
   fi
-  git fetch -q origin master
-  if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/master)" ]]; then
-    echo "master is not in sync with origin/master — pull/merge before tagging a release." >&2
+
+  git merge --ff-only -q "origin/${RELEASE_BRANCH}" || {
+    echo "${RELEASE_BRANCH} cannot fast-forward to origin/${RELEASE_BRANCH}. Resolve it before tagging." >&2
     exit 1
-  fi
+  }
 }
 
 latest_version() {
@@ -68,7 +70,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 require_clean_git
-require_synced_master
+switch_to_latest_release_branch
 
 current="$(latest_version)"
 if [[ -z "$current" ]]; then
@@ -83,8 +85,8 @@ if git rev-parse -q --verify "refs/tags/${new_tag}" >/dev/null; then
   exit 1
 fi
 
-git tag -a "$new_tag" -m "Release ${new_tag}"
-echo "Created tag ${new_tag}"
+git tag -a "$new_tag" -m "Release ${new_tag}" "HEAD"
+echo "Created tag ${new_tag} on ${RELEASE_BRANCH} ($(git rev-parse --short HEAD))"
 
 if [[ "$push_tag" == "true" ]]; then
   git push origin "$new_tag"

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -9,6 +9,9 @@ REPO="${REPO:-MercurieVV/ScalaSemantic}"
 # First release version, used when no v* tag exists yet.
 FIRST_VERSION="${FIRST_VERSION:-0.1.0}"
 
+# Branch whose latest remote commit is tagged by bump-version.sh.
+RELEASE_BRANCH="${RELEASE_BRANCH:-master}"
+
 # Sonatype Central host (the new portal; legacy OSSRH would be s01.oss.sonatype.org).
 SONATYPE_CREDENTIAL_HOST="${SONATYPE_CREDENTIAL_HOST:-central.sonatype.com}"
 


### PR DESCRIPTION
## Summary
- make bump-version switch to the release branch and fast-forward from origin before tagging
- keep master as the default release branch via RELEASE_BRANCH
- update release docs for the new tagging flow

## Verification
- bash -n scripts/bump-version.sh scripts/config.sh
- sbt prePush (via pre-push hook during git push)