### PR TITLE
feat(structure): Phase 4 — metric badges on find_symbol/class_hierarchy

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -52,10 +52,22 @@ final class Analyzer(
   // --- structure / dependency metrics ---------------------------------------
 
   /** Multi-relational dependency metrics for the whole project: per in-project type, the coupling
-    * (Ca/Ce/instability) and cycle membership across the `extends`/`memberType`/`call`/`implicit`
-    * graphs and their combined overlay, plus a module rollup and the list of dependency cycles.
+    * (Ca/Ce/instability), layer, centrality and cycle membership across the
+    * `extends`/`memberType`/`call`/`implicit` graphs and their combined overlay, plus a module
+    * rollup, the module coupling surface, and the list of dependency cycles. Memoised — the whole
+    * graph is built once per analyzer and shared by [[structure]] and [[metricsOf]].
     */
-  def structure(): StructureResult = StructureMetrics(index).result()
+  def structure(): StructureResult = structureResult
+
+  private lazy val structureResult: StructureResult = StructureMetrics(index).result()
+
+  private lazy val structureBySymbol: Map[String, SymbolStructure] =
+    structureResult.symbols.iterator.map(s => s.symbol -> s).toMap
+
+  /** The structural metrics for one type symbol, if it is an in-project type node — for badging the
+    * results of other tools (find_symbol, class_hierarchy) with its layer/centrality/cycle status.
+    */
+  def metricsOf(symbol: String): Option[SymbolStructure] = structureBySymbol.get(symbol)
 
   // --- find-symbol ----------------------------------------------------------
 

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -34,11 +34,17 @@ object McpTools:
         ("limit", "integer", "max results (default 50)"),
         ("exact", "boolean", "match the display name exactly, case-insensitive (default false)"),
         ("kind", "string", "keep only this SymbolInformation kind, e.g. TRAIT, CLASS, METHOD"),
-        ("pathFilter", "string", "glob on the symbol's definition uri; `*` matches any chars")
+        ("pathFilter", "string", "glob on the symbol's definition uri; `*` matches any chars"),
+        (
+          "metrics",
+          "boolean",
+          "badge each result type with its structural layer/centrality/inCycle (default false)"
+        )
       ),
       List("query")
     ) { a =>
       val q = argStr(a, "query")
+      val withMetrics = argBool(a, "metrics", false)
       val results = az.findSymbol(
         q,
         argInt(a, "limit", 50),
@@ -53,9 +59,11 @@ object McpTools:
           "symbols" -> ujson.Arr.from(
             results.map(r =>
               jobj(
-                Some("symbol" -> ujson.Str(r.symbol)),
-                Some("name" -> ujson.Str(r.displayName)),
-                Some("kind" -> ujson.Str(r.kind))
+                (List(
+                  Some("symbol" -> ujson.Str(r.symbol)),
+                  Some("name" -> ujson.Str(r.displayName)),
+                  Some("kind" -> ujson.Str(r.kind))
+                ) ++ metricFields(az, r.symbol, withMetrics))*
               )
             )
           )
@@ -171,6 +179,11 @@ object McpTools:
           "include",
           "array",
           "sections to return: any of \"parents\", \"linearization\", \"knownSubtypes\" (default all)"
+        ),
+        (
+          "metrics",
+          "boolean",
+          "badge the queried type with its structural layer/centrality/inCycle (default false)"
         )
       ),
       List("symbol")
@@ -182,17 +195,20 @@ object McpTools:
         case None => notFound(symbol)
         case Some(h) =>
           jobj(
-            Some("symbol" -> ujson.Str(symbol)),
-            Some("name" -> ujson.Str(h.displayName)),
-            opt(want("parents") && h.parents.nonEmpty, "parents" -> refs(h.parents, detailed)),
-            opt(
-              want("linearization") && h.linearization.nonEmpty,
-              "linearization" -> refs(h.linearization, detailed)
-            ),
-            opt(
-              want("knownSubtypes") && h.knownSubtypes.nonEmpty,
-              "knownSubtypes" -> refs(h.knownSubtypes, detailed)
-            )
+            (List(
+              Some("symbol" -> ujson.Str(symbol)),
+              Some("name" -> ujson.Str(h.displayName))
+            ) ++ metricFields(az, symbol, argBool(a, "metrics", false)) ++ List(
+              opt(want("parents") && h.parents.nonEmpty, "parents" -> refs(h.parents, detailed)),
+              opt(
+                want("linearization") && h.linearization.nonEmpty,
+                "linearization" -> refs(h.linearization, detailed)
+              ),
+              opt(
+                want("knownSubtypes") && h.knownSubtypes.nonEmpty,
+                "knownSubtypes" -> refs(h.knownSubtypes, detailed)
+              )
+            ))*
           )
     },
     tool(
@@ -487,6 +503,25 @@ object McpTools:
 
   private def round2(d: Double): Double = math.round(d * 100.0) / 100.0
   private def round3(d: Double): Double = math.round(d * 1000.0) / 1000.0
+
+  /** Optional structural-metric fields (layer / centrality / inCycle) for a type symbol, for
+    * badging find_symbol / class_hierarchy results when `on`. Empty when off or the symbol is not a
+    * type node.
+    */
+  private def metricFields(
+      az: Analyzer,
+      symbol: String,
+      on: Boolean
+  ): List[Option[(String, ujson.Value)]] =
+    if !on then Nil
+    else
+      az.metricsOf(symbol).toList.flatMap { s =>
+        List(
+          Some("layer" -> ujson.Num(s.combined.layer)),
+          Some("centrality" -> ujson.Num(round3(s.combined.centrality))),
+          opt(s.combined.inCycle, "inCycle" -> ujson.Bool(true))
+        )
+      }
 
   private def loc(l: Location): String =
     s"${l.uri}:${l.range.start.line}:${l.range.start.character}"

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
@@ -105,6 +105,23 @@ class McpSuite extends munit.FunSuite:
     assertEquals(dims, Set("extends", "memberType", "call", "implicit"), dims.toString)
   }
 
+  test("metrics badge: find_symbol and class_hierarchy carry structural metrics on request") {
+    // off by default — no badge fields
+    val plain = call("find_symbol", ujson.Obj("query" -> "Animal", "kind" -> "TRAIT"))
+    assert(plain("symbols").arr.forall(!_.obj.contains("layer")), "no badge without metrics")
+
+    // on → each in-project type result gains layer + centrality
+    val badged =
+      call("find_symbol", ujson.Obj("query" -> "Animal", "kind" -> "TRAIT", "metrics" -> true))
+    val anyBadged =
+      badged("symbols").arr.exists(s => s.obj.contains("layer") && s.obj.contains("centrality"))
+    assert(anyBadged, badged.render())
+
+    // class_hierarchy badges the queried type
+    val h = call("class_hierarchy", ujson.Obj("symbol" -> Animal, "metrics" -> true))
+    assert(h.obj.contains("layer") && h.obj.contains("centrality"), h.render())
+  }
+
   test("notifications get no response") {
     val n = ujson.Obj("jsonrpc" -> "2.0", "method" -> "notifications/initialized")
     assertEquals(Mcp.handle(n, tools), None)


### PR DESCRIPTION
Opt-in `metrics` flag badges each in-project type result with layer/centrality/inCycle, powered by a memoized structure(). Off by default. Makes ordinary lookups architecture-aware.