### PR TITLE
feat(tools): document_outline + rename_plan

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -69,6 +69,89 @@ final class Analyzer(
     */
   def metricsOf(symbol: String): Option[SymbolStructure] = structureBySymbol.get(symbol)
 
+  // --- document outline -----------------------------------------------------
+
+  /** The declarations of one document, nested by enclosing scope, each with the compiler-resolved
+    * signature (explicit implicits, real types) — a structural map of a file so a caller can locate
+    * and understand its members without reading the whole source. `None` if the uri is not indexed.
+    */
+  def outline(uri: String): Option[List[OutlineEntry]] =
+    index.document(uri).map { doc =>
+      val defs = doc.occurrences.toList
+        .collect {
+          case occ
+              if occ.role == s.SymbolOccurrence.Role.DEFINITION && includeInOutline(occ.symbol) =>
+            occ.symbol -> occ.range.map(_.startLine).getOrElse(0)
+        }
+        .distinctBy(_._1)
+      val definedSet = defs.map(_._1).toSet
+      def parentOf(sym: String): Option[String] =
+        val o = index.owner(sym)
+        if definedSet.contains(o) then Some(o) else None
+      def build(sym: String, line: Int): OutlineEntry =
+        val kids = defs.filter((c, _) => parentOf(c).contains(sym)).sortBy(_._2)
+        OutlineEntry(
+          sym,
+          index.displayName(sym),
+          kindName(sym),
+          line,
+          outlineSignature(sym),
+          kids.map((c, l) => build(c, l))
+        )
+      defs.filter((sym, _) => parentOf(sym).isEmpty).sortBy(_._2).map((sym, l) => build(sym, l))
+    }
+
+  private val outlineKinds: Set[s.SymbolInformation.Kind] = Set(
+    s.SymbolInformation.Kind.CLASS,
+    s.SymbolInformation.Kind.TRAIT,
+    s.SymbolInformation.Kind.INTERFACE,
+    s.SymbolInformation.Kind.OBJECT,
+    s.SymbolInformation.Kind.METHOD,
+    s.SymbolInformation.Kind.MACRO,
+    s.SymbolInformation.Kind.TYPE,
+    s.SymbolInformation.Kind.FIELD
+  )
+
+  private def includeInOutline(symbol: String): Boolean =
+    index.info(symbol).exists { si =>
+      outlineKinds.contains(si.kind) && si.displayName.nonEmpty && si.displayName != "<init>"
+    }
+
+  /** A one-line signature for an outline entry, rendered from SemanticDB: a method's full clarified
+    * signature, a value's resolved type, or empty for a type (its name + kind already say enough).
+    */
+  private def outlineSignature(symbol: String): String =
+    index.info(symbol).map(_.signature) match
+      case Some(_: s.MethodSignature) => methodSignature(symbol).map(_.rendered).getOrElse("")
+      case Some(v: s.ValueSignature)  => s": ${renderType(v.tpe)}"
+      case _                          => ""
+
+  // --- rename plan ----------------------------------------------------------
+
+  /** The precise edits to rename `symbol` to `newName`: every compiler-resolved occurrence of its
+    * name (definitions and references), as `{uri, range, old→new}`. Because the occurrences come
+    * from SemanticDB, this never touches comments, strings, or unrelated same-named identifiers —
+    * the over-match a textual rename suffers. The MCP server is read-only, so this returns a plan
+    * for the caller to apply.
+    */
+  def renamePlan(symbol: String, newName: String): RenamePlan =
+    val oldName = index.displayName(symbol)
+    val edits = index.occurrences
+      .collect {
+        case (uri, occ) if occ.symbol == symbol =>
+          val r = occ.range.getOrElse(s.Range.defaultInstance)
+          RenameEdit(
+            uri,
+            Range(Position(r.startLine, r.startCharacter), Position(r.endLine, r.endCharacter)),
+            oldName,
+            newName
+          )
+      }
+      .distinct
+      .toList
+      .sortBy(e => (e.uri, e.range.start.line, e.range.start.character))
+    RenamePlan(symbol, oldName, newName, edits.size, edits)
+
   // --- find-symbol ----------------------------------------------------------
 
   /** Find global symbols whose display name matches `query` (case-insensitive), ranked exact >

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
@@ -165,6 +165,39 @@ case class StructureResult(
     cycles: List[DependencyCycle]
 ) derives ReadWriter
 
+// --- document outline -------------------------------------------------------
+
+/** One declaration in a file's outline: its symbol, name, kind, the 0-based line of its definition,
+  * and a `signature` rendered from SemanticDB — so types are the compiler-resolved ones and
+  * implicit parameter lists are explicit (the "clarified" view), not the source's possibly-inferred
+  * text. `children` nests members under their enclosing type/method.
+  */
+case class OutlineEntry(
+    symbol: String,
+    name: String,
+    kind: String,
+    line: Int,
+    signature: String,
+    children: List[OutlineEntry]
+) derives ReadWriter
+
+// --- rename plan ------------------------------------------------------------
+
+/** One edit in a rename: replace `oldText` in `range` of `uri` with `newText`. Ranges are the
+  * compiler-resolved name occurrences, so there is no grep over-match (comments/strings/unrelated
+  * same-named identifiers are never touched).
+  */
+case class RenameEdit(uri: String, range: Range, oldText: String, newText: String)
+    derives ReadWriter
+
+case class RenamePlan(
+    symbol: String,
+    fromName: String,
+    toName: String,
+    editCount: Int,
+    edits: List[RenameEdit]
+) derives ReadWriter
+
 // --- call-graph path-find ---------------------------------------------------
 
 case class CallEdge(from: SymbolRef, to: SymbolRef, at: Location) derives ReadWriter

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -60,6 +60,8 @@ object Mcp:
       |  the symbol/type at a source position               → type_at_position
       |  the symbol for a plain name                        → find_symbol
       |  what's important / where to start, dep cycles       → structure
+      |  a file's structure / where to edit (don't read it)  → document_outline
+      |  the exact edits to rename a symbol safely           → rename_plan
       |
       |Symbols: every tool except find_symbol and type_at_position takes a SemanticDB symbol string
       |(grammar: package `foo/`, type `Foo#`, term `foo.`, method `foo().`, overloads `foo().(+1)`).

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -488,8 +488,71 @@ object McpTools:
           })
         )
       )
+    },
+    tool(
+      "document_outline",
+      "USE INSTEAD OF reading a whole file. A structural map of a Scala file: its types and members " +
+        "nested by scope, each with kind, 0-based definition line, and a signature rendered from the " +
+        "compiler (explicit implicit/using params, real resolved types — not the source's inferred " +
+        "text). Use it to survey a file's API and locate where to edit without reading the source.",
+      List(
+        (
+          "uri",
+          "string",
+          "document uri as it appears in SemanticDB (path relative to project root)"
+        )
+      ),
+      List("uri")
+    ) { a =>
+      val uri = argStr(a, "uri")
+      az.outline(uri) match
+        case None => jobj(Some("uri" -> ujson.Str(uri)), Some("found" -> ujson.Bool(false)))
+        case Some(entries) =>
+          jobj(
+            Some("uri" -> ujson.Str(uri)),
+            Some("outline" -> ujson.Arr.from(entries.map(outlineJson)))
+          )
+    },
+    tool(
+      "rename_plan",
+      "The precise edits to rename a symbol everywhere it is used. Returns every compiler-resolved " +
+        "occurrence of the name (definitions + references) as `uri:line:col-col` ranges to replace " +
+        "with the new name — no grep over-match (comments, strings, unrelated same-named identifiers " +
+        "are never touched). The server is read-only: apply the returned edits yourself.",
+      List(
+        ("symbol", "string", "the symbol to rename"),
+        ("newName", "string", "the new simple name")
+      ),
+      List("symbol", "newName")
+    ) { a =>
+      val p = az.renamePlan(argStr(a, "symbol"), argStr(a, "newName"))
+      jobj(
+        Some("symbol" -> ujson.Str(p.symbol)),
+        Some("rename" -> ujson.Str(s"${p.fromName} -> ${p.toName}")),
+        Some("editCount" -> ujson.Num(p.editCount)),
+        Some(
+          "edits" -> strs(
+            p.edits.map(e =>
+              s"${e.uri}:${e.range.start.line}:${e.range.start.character}-${e.range.end.character}"
+            )
+          )
+        )
+      )
     }
   )
+
+  /** Render an outline entry recursively: name/kind/line, the signature and symbol, and any nested
+    * children — dropping empties for token economy.
+    */
+  private def outlineJson(e: OutlineEntry): ujson.Value =
+    jobj(
+      Some("name" -> ujson.Str(e.name)),
+      Some("kind" -> ujson.Str(e.kind)),
+      Some("line" -> ujson.Num(e.line)),
+      opt(e.signature.nonEmpty, "signature" -> ujson.Str(e.signature)),
+      Some("symbol" -> ujson.Str(e.symbol)),
+      opt(e.children.nonEmpty, "children" -> ujson.Arr.from(e.children.map(outlineJson)))
+    )
 
   // --- rendering helpers ----------------------------------------------------
 

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
@@ -39,14 +39,16 @@ class McpSuite extends munit.FunSuite:
     assert(instr.contains("find_symbol"), instr)
   }
 
-  test("tools/list exposes all eleven tools with schemas") {
+  test("tools/list exposes all thirteen tools with schemas") {
     val r = Mcp.handle(req("tools/list", ujson.Obj()), tools).get
     val names = r("result")("tools").arr.map(_("name").str).toSet
-    assertEquals(names.size, 11)
+    assertEquals(names.size, 13)
     assert(names.contains("find_symbol"), names.toString)
     assert(names.contains("find_usages"), names.toString)
     assert(names.contains("call_path"), names.toString)
     assert(names.contains("structure"), names.toString)
+    assert(names.contains("document_outline"), names.toString)
+    assert(names.contains("rename_plan"), names.toString)
     // every tool carries an object input schema
     assert(r("result")("tools").arr.forall(_("inputSchema")("type").str == "object"))
   }
@@ -120,6 +122,28 @@ class McpSuite extends munit.FunSuite:
     // class_hierarchy badges the queried type
     val h = call("class_hierarchy", ujson.Obj("symbol" -> Animal, "metrics" -> true))
     assert(h.obj.contains("layer") && h.obj.contains("centrality"), h.render())
+  }
+
+  test("document_outline maps a file's declarations with clarified signatures") {
+    // Derive the fixture file's uri from a definition location (uri:line:col), robust to the path.
+    val defLoc = call("find_usages", ujson.Obj("symbol" -> Animal))("definitions").arr.head.str
+    val uri = defLoc.split(":").dropRight(2).mkString(":")
+    val o = call("document_outline", ujson.Obj("uri" -> uri))
+
+    def flatten(arr: ujson.Value): Seq[ujson.Value] =
+      arr.arr.toSeq.flatMap(e => e +: e.obj.get("children").map(flatten).getOrElse(Nil))
+    val entries = flatten(o("outline"))
+    assert(entries.exists(_("name").str == "Animal"), o.render())
+    // a method/value entry renders a resolved signature (the clarified view)
+    assert(entries.exists(_.obj.get("signature").exists(_.str.contains(":"))), o.render())
+  }
+
+  test("rename_plan returns precise, resolved edits (no grep over-match)") {
+    val rp = call("rename_plan", ujson.Obj("symbol" -> Animal, "newName" -> "Creature"))
+    assertEquals(rp("rename").str, "Animal -> Creature")
+    assert(rp("editCount").num > 0, "expected occurrences to rename")
+    // edits are uri:line:col-col ranges (definition + references), not whole lines
+    assert(rp("edits").arr.forall(_.str.matches(""".+:\d+:\d+-\d+""")), rp.render())
   }
 
   test("notifications get no response") {
@@ -288,5 +312,5 @@ class McpSuite extends munit.FunSuite:
     // 4 lines in (one blank, one notification) → 2 responses out, with matching ids
     assertEquals(out.size, 2)
     assertEquals(ujson.read(out(0))("id").num, 1.0)
-    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 11)
+    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 13)
   }


### PR DESCRIPTION
Usage-study-driven (see docs/CLAUDE_INTERACTION_STUDY.md): edits outnumber reads 3.5:1 and files get re-read/grepped to locate members — unserved by the read-only query tools.

- `document_outline(uri)`: file declarations nested by scope, each with kind + line + a SemanticDB-**resolved** signature (explicit implicits, real types). Replaces whole-file reads/greps.
- `rename_plan(symbol, newName)`: every resolved name occurrence as `uri:line:col-col` edits — safe rename, no grep over-match.

Deferred: full body type-elaboration (needs PC), move/extract (need a refactoring engine).