### PR TITLE
docs: measured token/context cost comparison + reusable interaction-logging hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Read|Edit|Write|MultiEdit|Grep|Glob|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/log-scala-interaction.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/CLAUDE_INTERACTION_STUDY.md
+++ b/docs/CLAUDE_INTERACTION_STUDY.md
@@ -68,3 +68,88 @@ instructions helps habit; `document_outline` removes the *reason* to grep.
 2. definition **ranges** on symbols,
 3. `rename_plan` edit-assist,
 4. `imports` / module-dependency surface.
+
+## Collecting these logs in *any* project
+
+Two independent ways to gather the same data for a different codebase — a live hook going forward,
+and a one-off mine of transcripts you already have. Both are project-agnostic; nothing here is
+specific to ScalaSemantic.
+
+### A. Live capture — a PostToolUse hook (forward-looking)
+
+Claude Code fires a [hook](https://docs.claude.com/en/docs/claude-code/hooks) after every tool call.
+[`scripts/log-scala-interaction.py`](../scripts/log-scala-interaction.py) reads the hook's JSON
+payload on stdin, keeps only calls that touch a `.scala` target (Read/Edit/Write/MultiEdit by
+`file_path`; Grep/Glob by pattern/glob/path mentioning "scala"; Bash by `.scala` in the command), and
+appends one JSONL record `{ts, tool, op, target, cwd}`. It never blocks or fails a tool — any error
+exits 0 with nothing logged.
+
+To reuse in another project:
+
+1. Copy `scripts/log-scala-interaction.py` into that repo.
+2. Register it as a `PostToolUse` hook in `.claude/settings.json` (team-wide) or
+   `.claude/settings.local.json` (personal, gitignored):
+
+   ```json
+   {
+     "hooks": {
+       "PostToolUse": [
+         {
+           "matcher": "Read|Edit|Write|MultiEdit|Grep|Glob|Bash",
+           "hooks": [
+             { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/log-scala-interaction.py\"" }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+3. Open `/hooks` once (or restart Claude Code) so the new config is picked up.
+
+Logs land in `~/.claude/scala-interactions.jsonl` by default; override with the
+`SCALA_INTERACTION_LOG` env var (e.g. a per-project path). For a non-Scala language, change the
+`.scala` / `"scala"` filters in the script — the structure is otherwise generic.
+
+Quick look at what's been captured:
+
+```bash
+# counts by op (read / write / search / bash) — the edit:read ratio falls out of this
+jq -r .op ~/.claude/scala-interactions.jsonl | sort | uniq -c
+# most-touched files
+jq -r 'select(.op!="search" and .op!="bash") | .target' ~/.claude/scala-interactions.jsonl | sort | uniq -c | sort -rn | head
+```
+
+### B. Retroactive mine — existing session transcripts
+
+If you didn't have the hook installed, the history is still recoverable: Claude Code writes one JSONL
+transcript per session under `~/.claude/projects/<url-encoded-project-path>/*.jsonl`. Each line is a
+message; assistant tool calls carry `message.content[].type == "tool_use"` with `.name` and `.input`.
+This was the source for the study above.
+
+> Caveat: this transcript layout is Claude Code's internal format and can change between versions —
+> treat the filters below as best-effort, and eyeball a few records before trusting aggregate counts.
+
+Find the project's transcript directory (the path is the working directory with `/` → `-`):
+
+```bash
+ls ~/.claude/projects/ | grep -i <your-project-name>
+```
+
+Extract every Scala-touching tool call across all sessions for a project:
+
+```bash
+DIR=~/.claude/projects/-Users-you-IdeaProjects-your-project
+jq -c 'select(.message.content?) | .message.content[]
+        | select(.type=="tool_use")
+        | {tool: .name, input: .input}
+        | select(
+            (.input.file_path? // "" | endswith(".scala")) or
+            (.input.command?   // "" | test("\\.scala")) or
+            (([.input.pattern?, .input.glob?, .input.path?] | map(. // "") | join(" ")) | test("scala"; "i"))
+          )' "$DIR"/*.jsonl
+```
+
+From there, the same `jq … | sort | uniq -c` aggregations as in section A give the
+edit-vs-read ratio, the grep-vs-semantic-tool split, and the most-churned files — i.e. everything in
+"[The numbers that matter](#the-numbers-that-matter)" above, for *your* codebase.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -42,6 +42,90 @@ replacement for it — it's the semantic complement. This page is the honest tra
 The server's `initialize` instructions tell the agent to prefer the semantic tools for the second
 group and fall back to text search for the first.
 
+## Token & context cost (measured)
+
+For an agent, the cost that matters is *tokens* — both the dollar cost of each request and the
+finite context window the result occupies. The semantic tool wins on both, and the gap is large.
+
+### One worked measurement (reproducible on this repo)
+
+Question: *"where is `SemanticIndex#displayName` used?"*
+
+| | `find_usages` (tool) | `grep "displayName"` |
+|---|---|---|
+| Hits returned | **16** — exactly this symbol (1 def + 15 refs) | **87** matches |
+| Of those, the *right* symbol | 16 / 16 | ~16 / 87 — the other ~71 are a **different** `displayName` (scalameta's `SymbolInformation.displayName`, other members, unrelated call sites) |
+| Output size | **1,630 bytes** | **12,645 bytes** |
+| ≈ tokens (bytes ÷ 4) | **~407** | **~3,161** |
+| Ratio | 1× | **≈ 7.8×** |
+
+Reproduce:
+
+```bash
+git grep -n "displayName" -- '*.scala' | wc -c          # grep: 12645 bytes, 87 lines
+# tool: find_symbol "displayName" (exact, pathFilter *SemanticIndex*) → symbol
+#       find_usages <that symbol>                         # 1630 bytes, 16 exact hits
+```
+
+> **On the token numbers.** `bytes ÷ 4` is the standard rough heuristic, good enough for an
+> order-of-magnitude comparison. For exact, model-specific counts use Anthropic's token-counting
+> endpoint (`POST /v1/messages/count_tokens`,
+> [docs](https://platform.claude.com/docs/en/build-with-claude/token-counting)) — never a non-Claude
+> tokenizer like `tiktoken`, which mis-counts Claude tokens. The 7.8× ratio is robust to which
+> counter you use because it's the same text class on both sides.
+
+### The cost compounds — a tree of consequences
+
+The headline 7.8× is only the *first* request. The agent loop makes it worse for grep:
+
+```
+grep "displayName"  → 87 matches, ~12.6 KB (~3.2K tokens) into the conversation
+│
+├─ ~71 matches are the WRONG symbol
+│   └─ the model cannot tell which 16 are real from the text alone
+│       └─ it opens several files to disambiguate  → +thousands more tokens
+│
+├─ the result is now conversation history
+│   └─ the API is stateless: history is re-sent as INPUT tokens on EVERY later turn
+│       (until server-side compaction)  → the 7.8× payload is paid again and again
+│           └─ context window fills faster  → compaction triggers sooner
+│               └─ earlier turns get summarised away  → lost detail → worse answers
+│
+└─ silently MISSES renamed-on-import / re-exported / type-inferred uses (false negatives)
+
+find_usages(symbol)  → 16 exact uses, ~1.6 KB (~0.4K tokens)
+│
+├─ every entry is the real symbol  → no disambiguation file-reads
+├─ small payload re-sent each turn  → context grows slowly → compaction deferred
+└─ no false negatives (compiler-resolved, not text-matched)
+```
+
+### Does prompt caching erase the gap? No.
+
+[Prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) lets a stable
+history prefix be re-read at ~0.1× the input price instead of full price, so it does cut the *dollar*
+cost of re-sending a bloated grep result. But it does **not** cut the *context* cost:
+
+- A cached token still **occupies the context window**. A 7.8×-larger grep result still pushes the
+  conversation toward its limit and toward compaction just as fast — caching changes the price, not
+  the footprint.
+- The cache is **prefix-match with a 5-minute default TTL**: any earlier edit invalidates everything
+  after it, and an idle conversation loses the entry. Agent loops edit constantly, so the cache is
+  frequently cold exactly when a large result was just added.
+
+So caching narrows the *price* gap somewhat but leaves the *context-pressure* gap — the one that
+degrades answer quality — fully intact. Context windows are finite (1M tokens for Opus 4.x / Sonnet
+4.6, 200K for Haiku 4.5 —
+[models](https://platform.claude.com/docs/en/about-claude/models/overview)); a 7.8× result spends
+that budget 7.8× faster.
+
+### Bottom line
+
+For a symbol question, the tool returns a smaller, exact answer that needs no follow-up reads and
+stays small across the whole conversation. grep returns a larger, noisier answer that triggers more
+reads, re-bills its bulk every turn, and accelerates context exhaustion. The win is structural, not
+incidental.
+
 ## Limitations (read before trusting an answer)
 
 - **Index freshness.** Results reflect the last SemanticDB-emitting `compile`; the index loads once at

--- a/scripts/log-scala-interaction.py
+++ b/scripts/log-scala-interaction.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: append one JSONL record per Claude tool call that touches Scala code.
+
+Reads the hook payload (JSON) on stdin. Keeps only interactions that involve a `.scala` file:
+file ops by `file_path`, Grep/Glob by pattern/glob/path mentioning "scala", Bash by `.scala` in the
+command. Writes to $SCALA_INTERACTION_LOG (default ~/.claude/scala-interactions.jsonl). Never blocks
+or fails the tool — any error just exits 0 with nothing logged.
+
+See docs/CLAUDE_INTERACTION_STUDY.md for how to collect and analyse these logs.
+"""
+import sys, os, json, datetime
+
+
+def main() -> None:
+    try:
+        d = json.load(sys.stdin)
+    except Exception:
+        return
+    tool = d.get("tool_name", "")
+    inp = d.get("tool_input", {}) or {}
+    cwd = d.get("cwd", "")
+
+    def target():
+        fp = inp.get("file_path", "")
+        if tool in ("Read", "Edit", "Write", "MultiEdit", "NotebookEdit"):
+            return fp if isinstance(fp, str) and fp.endswith(".scala") else None
+        if tool in ("Grep", "Glob"):
+            blob = " ".join(str(inp.get(k, "")) for k in ("pattern", "glob", "path"))
+            return blob.strip() if "scala" in blob.lower() else None
+        if tool == "Bash":
+            cmd = inp.get("command", "")
+            return cmd if isinstance(cmd, str) and ".scala" in cmd else None
+        return None
+
+    t = target()
+    if not t:
+        return
+    op = {"Read": "read", "Grep": "search", "Glob": "search", "Bash": "bash"}.get(tool, "write")
+    rec = {
+        "ts": datetime.datetime.now().isoformat(timespec="seconds"),
+        "tool": tool,
+        "op": op,
+        "target": t[:500],
+        "cwd": cwd,
+    }
+    log = os.environ.get(
+        "SCALA_INTERACTION_LOG", os.path.expanduser("~/.claude/scala-interactions.jsonl")
+    )
+    os.makedirs(os.path.dirname(log), exist_ok=True)
+    with open(log, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass
+    sys.exit(0)


### PR DESCRIPTION
## What

Two related additions, both about understanding and proving ScalaSemantic's token efficiency.

### `docs/COMPARISON.md` — "Token & context cost (measured)"
A reproducible `find_usages` vs `grep` measurement on this repo:

| | `find_usages` | `grep "displayName"` |
|---|---|---|
| hits | 16 (exact) | 87 (~71 wrong symbol) |
| bytes | 1,630 | 12,645 |
| ≈ tokens | ~407 | ~3,161 (**≈7.8×**) |

Plus a **consequence tree** (grep's noise → disambiguation reads → stateless history re-billed every turn → faster compaction → lost context) and an honest note that **prompt caching cuts price, not context footprint**. Token-counting, caching, and context-window claims cite Anthropic docs.

### `docs/CLAUDE_INTERACTION_STUDY.md` — "Collecting these logs in any project"
Project-agnostic, reusable instructions:
- **A.** Install the `PostToolUse` hook (script + `settings.json` snippet, `SCALA_INTERACTION_LOG` override) in any repo.
- **B.** Retroactively mine existing `~/.claude/projects/*.jsonl` transcripts with a (validated) `jq` recipe.

### Tooling
- `scripts/log-scala-interaction.py` — the PostToolUse hook (filters to `.scala`, appends JSONL, never blocks a tool).
- `.claude/settings.json` — registers the hook.

## Notes
- All `jq` snippets syntax-checked.
- Empirical figures re-measured this turn against current `master` code.
- Conventional-Commit `docs:` title → omitted from generated release notes (correct: not user-facing to the published library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)