### PR TITLE
fix: mcpClientConfig prints config without forcing a compile

### DIFF
--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -206,16 +206,22 @@ object Mcp:
       .map(_.trim)
       .filter(_.nonEmpty)
       .map { spec =>
-        val raw =
-          val asFile = Paths.get(spec)
-          if Files.isRegularFile(asFile) then Files.readString(asFile) else spec
-        raw
-          .split("[\n" + java.io.File.pathSeparator + "]")
-          .iterator
-          .map(_.trim)
-          .filter(_.nonEmpty)
-          .map(Paths.get(_))
-          .toVector
+        // A spec with no path separator that names nothing on disk is a classpath FILE that hasn't
+        // been written yet (e.g. `mcpClientConfig` printed the path before `mcpClasspathFile` ran).
+        // Treat it as "no classpath" → index-only, rather than a bogus single-entry classpath.
+        val asFile = Paths.get(spec)
+        val missingFileRef =
+          !spec.contains(java.io.File.pathSeparator) && !Files.exists(asFile)
+        if missingFileRef then Vector.empty
+        else
+          val raw = if Files.isRegularFile(asFile) then Files.readString(asFile) else spec
+          raw
+            .split("[\n" + java.io.File.pathSeparator + "]")
+            .iterator
+            .map(_.trim)
+            .filter(_.nonEmpty)
+            .map(Paths.get(_))
+            .toVector
       }
       .filter(_.nonEmpty)
 

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -69,7 +69,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       val converter = fileConverter.value
       val cp = (Compile / fullClasspath).value
         .map(af => ClasspathCompat.toAbsolutePath(af.data, converter))
-      val out = installDir / s"${mcpServerName.value}-classpath.txt"
+      val out = classpathFile(mcpServerName.value)
       IO.write(out, cp.mkString("\n"))
       streams.value.log.info(s"MCP classpath written (${cp.size} entries): $out")
       out
@@ -82,8 +82,13 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       val log = streams.value.log
       val _ =
         mcpInstall.value // ensure the launcher exists before we print a command pointing at it
-      val argv =
-        resolvedCommand(mcpServerCommand.value, baseDirectory.value, mcpClasspathFile.value)
+      // Reference the classpath file by PATH only — do NOT depend on `mcpClasspathFile`, which
+      // evaluates `Compile / fullClasspath` and so forces a full compile. Printing a config entry
+      // must work even when the project does not compile. The server treats a not-yet-written
+      // classpath file as index-only; run `sbt mcpClasspathFile` once (needs a clean compile) to
+      // enable the live presentation-compiler backend.
+      val cpFile = classpathFile(mcpServerName.value)
+      val argv = resolvedCommand(mcpServerCommand.value, baseDirectory.value, cpFile)
       val argsJson = argv.tail.map(a => "\"" + a + "\"").mkString("[", ", ", "]")
       log.info(
         s"""|Register this in your MCP client (e.g. .mcp.json):
@@ -96,6 +101,11 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
             |  }
             |}""".stripMargin
       )
+      if (!cpFile.exists)
+        log.info(
+          "Server will run index-only. Run `sbt mcpClasspathFile` once (requires a successful " +
+            "compile) to enable the live presentation-compiler backend."
+        )
     },
     mcpRun := {
       val _ = mcpInstall.value
@@ -105,6 +115,12 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       if (exit != 0) sys.error(s"MCP server exited with code $exit")
     }
   )
+
+  /** Stable path of the classpath file for a given server name. Computed (not built) so config
+    * printing can reference it without triggering a compile; [[mcpClasspathFile]] writes it here.
+    */
+  private def classpathFile(serverName: String): File =
+    installDir / s"$serverName-classpath.txt"
 
   /** OS-specific launcher file name (the resource bundled in the plugin jar). */
   private def launcherName: String =


### PR DESCRIPTION
## Problem

On a project whose sources don't compile, `sbt mcpClientConfig` fails and prints nothing — so you can't even get the `.mcp.json` entry. Reproduced on a real host project: 4 genuine type errors in its `Main.scala` aborted the task before it printed anything.

Root cause: `mcpClientConfig` depended on `mcpClasspathFile`, which evaluates `Compile / fullClasspath` → forces a full compile. Printing a config block shouldn't require a clean build.

## Fix

- **Plugin** — `mcpClientConfig` references the classpath file **by path only** (new `classpathFile(name)` helper), no dependency on the compile-triggering task. Prints the entry regardless of build state and notes that `sbt mcpClasspathFile` (which does need a successful compile) enables the live presentation-compiler backend separately.
- **Server** — `resolveClasspath` treats a classpath-file path that doesn't exist yet as **index-only**, so a pasted config works before `mcpClasspathFile` has ever run, instead of booting the PC backend with a bogus single-entry classpath.

## Verify

- `sbtPlugin/compile`, `mcp/compile`, `mcp/Test/compile` — green.
- `mcp/test` — 22/22 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)