### PR TITLE
feat: warn when no SemanticDB exists yet on mcpClientConfig

### DIFF
--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -206,16 +206,22 @@ object Mcp:
       .map(_.trim)
       .filter(_.nonEmpty)
       .map { spec =>
-        val raw =
-          val asFile = Paths.get(spec)
-          if Files.isRegularFile(asFile) then Files.readString(asFile) else spec
-        raw
-          .split("[\n" + java.io.File.pathSeparator + "]")
-          .iterator
-          .map(_.trim)
-          .filter(_.nonEmpty)
-          .map(Paths.get(_))
-          .toVector
+        // A spec with no path separator that names nothing on disk is a classpath FILE that hasn't
+        // been written yet (e.g. `mcpClientConfig` printed the path before `mcpClasspathFile` ran).
+        // Treat it as "no classpath" → index-only, rather than a bogus single-entry classpath.
+        val asFile = Paths.get(spec)
+        val missingFileRef =
+          !spec.contains(java.io.File.pathSeparator) && !Files.exists(asFile)
+        if missingFileRef then Vector.empty
+        else
+          val raw = if Files.isRegularFile(asFile) then Files.readString(asFile) else spec
+          raw
+            .split("[\n" + java.io.File.pathSeparator + "]")
+            .iterator
+            .map(_.trim)
+            .filter(_.nonEmpty)
+            .map(Paths.get(_))
+            .toVector
       }
       .filter(_.nonEmpty)
 

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -69,7 +69,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       val converter = fileConverter.value
       val cp = (Compile / fullClasspath).value
         .map(af => ClasspathCompat.toAbsolutePath(af.data, converter))
-      val out = installDir / s"${mcpServerName.value}-classpath.txt"
+      val out = classpathFile(mcpServerName.value)
       IO.write(out, cp.mkString("\n"))
       streams.value.log.info(s"MCP classpath written (${cp.size} entries): $out")
       out
@@ -82,8 +82,13 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       val log = streams.value.log
       val _ =
         mcpInstall.value // ensure the launcher exists before we print a command pointing at it
-      val argv =
-        resolvedCommand(mcpServerCommand.value, baseDirectory.value, mcpClasspathFile.value)
+      // Reference the classpath file by PATH only — do NOT depend on `mcpClasspathFile`, which
+      // evaluates `Compile / fullClasspath` and so forces a full compile. Printing a config entry
+      // must work even when the project does not compile. The server treats a not-yet-written
+      // classpath file as index-only; run `sbt mcpClasspathFile` once (needs a clean compile) to
+      // enable the live presentation-compiler backend.
+      val cpFile = classpathFile(mcpServerName.value)
+      val argv = resolvedCommand(mcpServerCommand.value, baseDirectory.value, cpFile)
       val argsJson = argv.tail.map(a => "\"" + a + "\"").mkString("[", ", ", "]")
       log.info(
         s"""|Register this in your MCP client (e.g. .mcp.json):
@@ -96,6 +101,11 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
             |  }
             |}""".stripMargin
       )
+      if (!cpFile.exists)
+        log.info(
+          "Server will run index-only. Run `sbt mcpClasspathFile` once (requires a successful " +
+            "compile) to enable the live presentation-compiler backend."
+        )
     },
     mcpRun := {
       val _ = mcpInstall.value
@@ -105,6 +115,12 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       if (exit != 0) sys.error(s"MCP server exited with code $exit")
     }
   )
+
+  /** Stable path of the classpath file for a given server name. Computed (not built) so config
+    * printing can reference it without triggering a compile; [[mcpClasspathFile]] writes it here.
+    */
+  private def classpathFile(serverName: String): File =
+    installDir / s"$serverName-classpath.txt"
 
   /** OS-specific launcher file name (the resource bundled in the plugin jar). */
   private def launcherName: String =

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -106,6 +106,14 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
           "Server will run index-only. Run `sbt mcpClasspathFile` once (requires a successful " +
             "compile) to enable the live presentation-compiler backend."
         )
+      // The server answers from SemanticDB, which is compiler output. If the project has never been
+      // compiled, the index is empty and every query returns nothing — warn instead of letting that
+      // look like a broken server. Cheap filesystem check only; does not trigger a compile.
+      if (!hasSemanticdb(baseDirectory.value))
+        log.warn(
+          "No SemanticDB found under target/ — the server will start with an empty index and every " +
+            "query will return nothing. Run `sbt compile` once first so it has symbols to answer from."
+        )
     },
     mcpRun := {
       val _ = mcpInstall.value
@@ -121,6 +129,24 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
     */
   private def classpathFile(serverName: String): File =
     installDir / s"$serverName-classpath.txt"
+
+  /** True if any `*.semanticdb` file exists under `<baseDir>/target` — i.e. the project has been
+    * compiled at least once with SemanticDB on, so the server has something to index. Pure
+    * filesystem walk, bounded to `target/`; never triggers a compile. Best-effort: any error or a
+    * missing `target/` reads as "none".
+    */
+  private def hasSemanticdb(baseDir: File): Boolean = {
+    val target = baseDir / "target"
+    if (!target.isDirectory) false
+    else
+      try {
+        var stream: java.util.stream.Stream[java.nio.file.Path] = null
+        try {
+          stream = java.nio.file.Files.walk(target.toPath)
+          stream.anyMatch(p => p.getFileName.toString.endsWith(".semanticdb"))
+        } finally if (stream != null) stream.close()
+      } catch { case _: Throwable => false }
+  }
 
   /** OS-specific launcher file name (the resource bundled in the plugin jar). */
   private def launcherName: String =


### PR DESCRIPTION
Builds on #19 (contains its commit too; will reduce to a single commit once #19 merges).

## Why

The server answers from SemanticDB — compiler output. If the project has never been compiled, the index is empty and **every query returns nothing**, which looks like a broken server rather than "you haven't built yet."

## What

`mcpClientConfig` now does a cheap filesystem walk under `target/` for any `*.semanticdb` file and, if none exist, warns:

> No SemanticDB found under target/ — the server will start with an empty index and every query will return nothing. Run `sbt compile` once first so it has symbols to answer from.

Pure FS check, best-effort (missing `target/` or any error → "none"). **Does not trigger a compile** — consistent with #19.

## Verify

`sbtPlugin/compile` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)