### PR TITLE
docs: use x.y.z version placeholder instead of a pinned plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ Least manual: works on sbt 1 and sbt 2, enables SemanticDB, and generates the `.
 jar arrives on first spawn.
 
 ```scala
-// project/plugins.sbt
-addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "0.3.2")
+// project/plugins.sbt — replace x.y.z with the latest release (see the badge / releases page)
+addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "x.y.z")
 // build.sbt
 enablePlugins(ScalaSemanticMcpPlugin)
 ```
+
+Latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0) · [GitHub releases](https://github.com/MercurieVV/ScalaSemantic/releases/latest)
 
 `sbt mcpClientConfig` prints the entry; `sbt mcpRun` runs the server for testing.
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -49,11 +49,15 @@ argument. Pick by how much you want automated.
 minimal host build is one line:
 
 ```scala
-// project/plugins.sbt
-addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "0.3.2")
+// project/plugins.sbt — replace x.y.z with the latest release (see below)
+addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "x.y.z")
 // build.sbt
 enablePlugins(ScalaSemanticMcpPlugin)
 ```
+
+Use the latest published version in place of `x.y.z` — see the
+[Maven Central artifact](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)
+or the [latest GitHub release](https://github.com/MercurieVV/ScalaSemantic/releases/latest).
 
 The plugin enables SemanticDB and adds:
 
@@ -99,7 +103,7 @@ path automatically: if **coursier** (`cs`) is on PATH they `cs launch` the artif
 (resolves + caches like `npx`); otherwise they download the fat jar from the latest GitHub Release once
 (cached under `~/.cache/scalasemantic-mcp` / `%LOCALAPPDATA%`) and run `java -jar`. Download chatter
 goes to stderr; stdout stays pure JSON-RPC. Offline, they fall back to the newest cached jar. Pin a
-version with `SCALASEMANTIC_VERSION=v0.3.2`.
+version with `SCALASEMANTIC_VERSION=vX.Y.Z` (a real tag such as the latest release; default is newest).
 
 Install the launcher to a **stable path on PATH** (`~/.local/bin/scalasemantic-mcp`) so `.mcp.json`
 does not depend on where this repo is cloned — and, unlike the sbt dev launcher under `target/`, it

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,10 +38,10 @@ scripts/check-push-workflow.sh           # wait for CI, report the latest publis
 scripts/retry-last-tag.sh --push         # move the tag to HEAD to retry a release that failed early
 ```
 
-After a tag release publishes, GitHub Actions runs `scripts/update-doc-versions.sh vX.Y.Z` on
-`master` and commits updated dependency snippets in `README.md` and `docs/INTEGRATION.md`. This keeps
-the shown `addSbtPlugin` version and `SCALASEMANTIC_VERSION` pin aligned with the latest published
-artifact without making normal docs builds depend on Maven Central.
+Docs do not pin a concrete version: `README.md` and `docs/INTEGRATION.md` show an `x.y.z` placeholder
+and point readers at the Maven Central badge / latest GitHub release, so there is nothing to bump per
+release. `scripts/update-doc-versions.sh` is a retired no-op kept only so the existing post-release CI
+step keeps succeeding; remove that step from `ci.yml` whenever the workflow is next touched.
 
 ## Release notes
 

--- a/scripts/update-doc-versions.sh
+++ b/scripts/update-doc-versions.sh
@@ -1,36 +1,13 @@
 #!/usr/bin/env bash
 
-# Update documentation snippets that must show the latest published artifact version.
+# Retired no-op.
 #
-# Usage:
-#   scripts/update-doc-versions.sh 0.1.4
-#   scripts/update-doc-versions.sh v0.1.4
+# Docs no longer pin a concrete plugin version: README.md and docs/INTEGRATION.md show an `x.y.z`
+# placeholder and point readers at the Maven Central badge / latest GitHub release. There is nothing
+# to rewrite per release, so this script does nothing — it stays only so the existing post-release
+# CI step keeps succeeding without a workflow change.
 #
-# GitHub Actions passes the just-published tag version after `sbt ci-release` succeeds. Keeping this
-# as an explicit step avoids making normal docs rendering depend on network access or Maven Central
-# availability.
+# Usage (argument ignored): scripts/update-doc-versions.sh <version-or-tag>
 
 set -euo pipefail
-
-if [[ $# -ne 1 || -z "${1:-}" ]]; then
-  echo "Usage: $0 VERSION_OR_TAG" >&2
-  exit 2
-fi
-
-version="${1#v}"
-tag="v$version"
-
-case "$version" in
-  [0-9]*.[0-9]*.[0-9]*) ;;
-  *)
-    echo "Expected a release version like 0.1.4 or v0.1.4, got: $1" >&2
-    exit 2
-    ;;
-esac
-
-perl -0pi -e '
-  s/addSbtPlugin\("io\.github\.mercurievv" % "sbt-scalasemantic-mcp" % "[^"]+"\)/addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "'"$version"'")/g;
-  s/SCALASEMANTIC_VERSION=v[0-9]+\.[0-9]+\.[0-9]+/SCALASEMANTIC_VERSION='"$tag"'/g;
-' README.md docs/INTEGRATION.md
-
-echo "Updated docs to ScalaSemantic $version"
+echo "update-doc-versions.sh: retired no-op (docs use an x.y.z placeholder); nothing to do."


### PR DESCRIPTION
## Why

`README.md` and `docs/INTEGRATION.md` hardcoded the plugin version, which drifted to `0.3.2` while releases moved on to `0.3.4`. Keeping it accurate required a per-release doc bump (and the CI auto-bump step had been failing).

## What

- Replace the pinned version with an **`x.y.z` placeholder** in both the `addSbtPlugin` snippet and the `SCALASEMANTIC_VERSION` pin, plus a **Maven Central badge** and **latest-release** link so readers can find the real number.
- `scripts/update-doc-versions.sh` → **retired no-op** (its perl would otherwise rewrite the placeholder back to a number). Kept as a file so the existing post-release CI step keeps succeeding without a workflow edit.
- `RELEASING.md` updated to describe the placeholder approach and note the CI step can be dropped from `ci.yml` next time the workflow is touched.

Net: docs never go stale, no per-release doc maintenance.

> Note: removing the now-dead `update-doc-versions` job from `.github/workflows/ci.yml` needs workflow-scoped push and is left for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)