### PR TITLE
docs: fill plugin version via mdoc @VERSION@ (supersedes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ Least manual: works on sbt 1 and sbt 2, enables SemanticDB, and generates the `.
 jar arrives on first spawn.
 
 ```scala
-// project/plugins.sbt
-addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "0.3.2")
+// project/plugins.sbt — replace x.y.z with the latest release (see the badge / releases page)
+addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "x.y.z")
 // build.sbt
 enablePlugins(ScalaSemanticMcpPlugin)
 ```
+
+Latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0) · [GitHub releases](https://github.com/MercurieVV/ScalaSemantic/releases/latest)
 
 `sbt mcpClientConfig` prints the entry; `sbt mcpRun` runs the server for testing.
 

--- a/build.sbt
+++ b/build.sbt
@@ -258,6 +258,24 @@ addCommandAlias(
 // 2.9.0's snippet compiler cannot read the main build's bleeding-edge 3.8.4 TASTy, so it can neither
 // run on 3.8.4 nor `dependsOn` the analyzer. Site snippets are therefore illustrative Scala +
 // protocol JSON, not in-process analyzer calls. (Switch to live snippets once mdoc supports 3.8.x.)
+// Latest published release = highest `v*` git tag (strip the `v`). Feeds the docs `@VERSION@` site
+// variable so version snippets are filled at site-build time instead of hand-bumped. Best-effort:
+// if there are no tags or git is unavailable (e.g. a shallow CI checkout without tags), fall back to
+// the `x.y.z` placeholder so the build never fails on this.
+lazy val latestReleaseVersion: String =
+  try
+    scala.sys.process
+      .Process(Seq("git", "tag", "--list", "v*"))
+      .!!
+      .linesIterator
+      .map(_.trim.stripPrefix("v"))
+      .filter(_.matches("""\d+\.\d+\.\d+"""))
+      .toSeq
+      .sortBy { v => val p = v.split('.').map(_.toInt); (p(0), p(1), p(2)) }
+      .lastOption
+      .getOrElse("x.y.z")
+  catch case _: Throwable => "x.y.z"
+
 lazy val docs = (project in file("mdoc-docs"))
   .disablePlugins(wartremover.WartRemover)
   .settings(
@@ -269,6 +287,9 @@ lazy val docs = (project in file("mdoc-docs"))
     // resolve correctly.
     Compile / run / fork := true,
     Compile / run / baseDirectory := (ThisBuild / baseDirectory).value,
+    // Pass the latest release version to the forked DocsMain, which registers it as the mdoc
+    // `@VERSION@` site variable.
+    Compile / run / javaOptions += s"-Dscalasemantic.docs.version=$latestReleaseVersion",
     libraryDependencies += "org.scalameta" %% "mdoc" % "2.9.0"
   )
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -49,13 +49,14 @@ argument. Pick by how much you want automated.
 minimal host build is one line:
 
 ```scala
-// project/plugins.sbt — replace x.y.z with the latest release (see below)
-addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "x.y.z")
+// project/plugins.sbt
+addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "@VERSION@")
 // build.sbt
 enablePlugins(ScalaSemanticMcpPlugin)
 ```
 
-Use the latest published version in place of `x.y.z` — see the
+On the rendered docs site `@VERSION@` is filled with the latest published release at build time. If
+you are reading the raw source, take the current version from the
 [Maven Central artifact](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)
 or the [latest GitHub release](https://github.com/MercurieVV/ScalaSemantic/releases/latest).
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -49,11 +49,15 @@ argument. Pick by how much you want automated.
 minimal host build is one line:
 
 ```scala
-// project/plugins.sbt
-addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "0.3.2")
+// project/plugins.sbt — replace x.y.z with the latest release (see below)
+addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "x.y.z")
 // build.sbt
 enablePlugins(ScalaSemanticMcpPlugin)
 ```
+
+Use the latest published version in place of `x.y.z` — see the
+[Maven Central artifact](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)
+or the [latest GitHub release](https://github.com/MercurieVV/ScalaSemantic/releases/latest).
 
 The plugin enables SemanticDB and adds:
 
@@ -99,7 +103,7 @@ path automatically: if **coursier** (`cs`) is on PATH they `cs launch` the artif
 (resolves + caches like `npx`); otherwise they download the fat jar from the latest GitHub Release once
 (cached under `~/.cache/scalasemantic-mcp` / `%LOCALAPPDATA%`) and run `java -jar`. Download chatter
 goes to stderr; stdout stays pure JSON-RPC. Offline, they fall back to the newest cached jar. Pin a
-version with `SCALASEMANTIC_VERSION=v0.3.2`.
+version with `SCALASEMANTIC_VERSION=vX.Y.Z` (a real tag such as the latest release; default is newest).
 
 Install the launcher to a **stable path on PATH** (`~/.local/bin/scalasemantic-mcp`) so `.mcp.json`
 does not depend on where this repo is cloned — and, unlike the sbt dev launcher under `target/`, it

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,10 +38,10 @@ scripts/check-push-workflow.sh           # wait for CI, report the latest publis
 scripts/retry-last-tag.sh --push         # move the tag to HEAD to retry a release that failed early
 ```
 
-After a tag release publishes, GitHub Actions runs `scripts/update-doc-versions.sh vX.Y.Z` on
-`master` and commits updated dependency snippets in `README.md` and `docs/INTEGRATION.md`. This keeps
-the shown `addSbtPlugin` version and `SCALASEMANTIC_VERSION` pin aligned with the latest published
-artifact without making normal docs builds depend on Maven Central.
+Docs do not pin a concrete version: `README.md` and `docs/INTEGRATION.md` show an `x.y.z` placeholder
+and point readers at the Maven Central badge / latest GitHub release, so there is nothing to bump per
+release. `scripts/update-doc-versions.sh` is a retired no-op kept only so the existing post-release CI
+step keeps succeeding; remove that step from `ci.yml` whenever the workflow is next touched.
 
 ## Release notes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,10 +38,17 @@ scripts/check-push-workflow.sh           # wait for CI, report the latest publis
 scripts/retry-last-tag.sh --push         # move the tag to HEAD to retry a release that failed early
 ```
 
-Docs do not pin a concrete version: `README.md` and `docs/INTEGRATION.md` show an `x.y.z` placeholder
-and point readers at the Maven Central badge / latest GitHub release, so there is nothing to bump per
-release. `scripts/update-doc-versions.sh` is a retired no-op kept only so the existing post-release CI
-step keeps succeeding; remove that step from `ci.yml` whenever the workflow is next touched.
+Docs do not pin a concrete version, so there is nothing to bump per release:
+
+- `docs/INTEGRATION.md` (an mdoc page) uses the `@VERSION@` site variable, filled at site-build time
+  with the highest `v*` git tag (computed in `build.sbt` as `latestReleaseVersion`, passed to
+  `DocsMain` via `-Dscalasemantic.docs.version`). Always current on the rendered site; the raw source
+  shows the literal `@VERSION@`.
+- `README.md` (rendered raw by GitHub — no build step, so no `@VERSION@`) shows an `x.y.z` placeholder
+  plus the Maven Central badge / latest-release link for the real number.
+
+`scripts/update-doc-versions.sh` is a retired no-op kept only so the existing post-release CI step
+keeps succeeding; remove that step from `ci.yml` whenever the workflow is next touched.
 
 ## Release notes
 

--- a/mdoc-docs/src/main/scala/DocsMain.scala
+++ b/mdoc-docs/src/main/scala/DocsMain.scala
@@ -9,11 +9,15 @@
   */
 object DocsMain:
   def main(args: Array[String]): Unit =
+    // Latest release version, passed by the build as a -D property (falls back to a placeholder).
+    // Registered as the mdoc `@VERSION@` site variable so version snippets fill in at build time.
+    val version = Option(System.getProperty("scalasemantic.docs.version")).getOrElse("x.y.z")
     val settings = mdoc
       .MainSettings()
       .withIn(java.nio.file.Paths.get("docs"))
       .withOut(java.nio.file.Paths.get("website", "docs"))
       .withClasspath(System.getProperty("java.class.path"))
+      .withSiteVariables(Map("VERSION" -> version))
       .withArgs(args.toList)
     val exitCode = mdoc.Main.process(settings)
     if exitCode != 0 then sys.exit(exitCode)

--- a/scripts/update-doc-versions.sh
+++ b/scripts/update-doc-versions.sh
@@ -1,36 +1,13 @@
 #!/usr/bin/env bash
 
-# Update documentation snippets that must show the latest published artifact version.
+# Retired no-op.
 #
-# Usage:
-#   scripts/update-doc-versions.sh 0.1.4
-#   scripts/update-doc-versions.sh v0.1.4
+# Docs no longer pin a concrete plugin version: README.md and docs/INTEGRATION.md show an `x.y.z`
+# placeholder and point readers at the Maven Central badge / latest GitHub release. There is nothing
+# to rewrite per release, so this script does nothing — it stays only so the existing post-release
+# CI step keeps succeeding without a workflow change.
 #
-# GitHub Actions passes the just-published tag version after `sbt ci-release` succeeds. Keeping this
-# as an explicit step avoids making normal docs rendering depend on network access or Maven Central
-# availability.
+# Usage (argument ignored): scripts/update-doc-versions.sh <version-or-tag>
 
 set -euo pipefail
-
-if [[ $# -ne 1 || -z "${1:-}" ]]; then
-  echo "Usage: $0 VERSION_OR_TAG" >&2
-  exit 2
-fi
-
-version="${1#v}"
-tag="v$version"
-
-case "$version" in
-  [0-9]*.[0-9]*.[0-9]*) ;;
-  *)
-    echo "Expected a release version like 0.1.4 or v0.1.4, got: $1" >&2
-    exit 2
-    ;;
-esac
-
-perl -0pi -e '
-  s/addSbtPlugin\("io\.github\.mercurievv" % "sbt-scalasemantic-mcp" % "[^"]+"\)/addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "'"$version"'")/g;
-  s/SCALASEMANTIC_VERSION=v[0-9]+\.[0-9]+\.[0-9]+/SCALASEMANTIC_VERSION='"$tag"'/g;
-' README.md docs/INTEGRATION.md
-
-echo "Updated docs to ScalaSemantic $version"
+echo "update-doc-versions.sh: retired no-op (docs use an x.y.z placeholder); nothing to do."


### PR DESCRIPTION
Supersedes #22 (includes its commit). Close #22 in favour of this.

## What

Make the docs show the current plugin version with **no per-release maintenance**.

- **`docs/INTEGRATION.md`** (an mdoc page) → the `addSbtPlugin` snippet uses the mdoc **`@VERSION@`** site variable. It's filled at site-build time with the highest `v*` git tag:
  - `build.sbt` computes `latestReleaseVersion` (best-effort; falls back to `x.y.z` if tags are unavailable, e.g. a shallow CI checkout).
  - passed to the forked `DocsMain` via `-Dscalasemantic.docs.version`,
  - registered with `MainSettings.withSiteVariables(Map("VERSION" -> …))`.
- **`README.md`** stays an `x.y.z` placeholder + Maven Central badge / latest-release links — GitHub renders raw markdown, so no mdoc/`@VERSION@` there.
- **`scripts/update-doc-versions.sh`** → retired no-op (from #22); `RELEASING.md` documents the new flow.

## Verify

`sbt docs/run` renders `…sbt-scalasemantic-mcp" % "0.3.4"` (the latest tag) into `website/docs/INTEGRATION.md`. Build green.

## Note

The dead `update-doc-versions` CI job in `.github/workflows/ci.yml` now calls a no-op; remove it next time the workflow is touched (needs workflow-scope, left to maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)