### PR TITLE
fix: resumable launcher download, --prefetch, and opt-in logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,10 @@ Latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.gith
 **Optional launcher flags** — append to the `.mcp.json` `args` after the project root (the launcher
 forwards them to the server; equivalent env vars in parentheses):
 
-- `--prefetch` — download + cache the jar, then exit without serving. Run once before first use
-  (`scalasemantic-mcp --prefetch .`) so the **first connect hits a warm cache** instead of racing
-  the client's ~30s connection timeout while the ~88 MB jar downloads. `install.sh` does this for you.
-- `--log` (`SCALASEMANTIC_LOG`) — write a file log: a startup line + one line per tool call.
-- `--log-output` (`SCALASEMANTIC_LOG_OUTPUT`) — additionally log each JSON-RPC response sent to the
-  model. Logging is **off by default** (no file written); set the log path via `SCALASEMANTIC_LOG_FILE`.
-
+- `--prefetch` — download + cache the jar, then exit without serving.
+- `--log` (`SCALASEMANTIC_LOG`) — log a tool call input to file.
+- `--log-output` (`SCALASEMANTIC_LOG_OUTPUT`) — log a tool call output to file.
+- 
 ```json
 {
   "mcpServers": {

--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ Latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.gith
 - **Plain `java -jar`** — grab `scalasemantic-mcp.jar` from the
   [latest release](https://github.com/MercurieVV/ScalaSemantic/releases/latest) and run it directly.
 
+**Optional launcher flags** — append to the `.mcp.json` `args` after the project root (the launcher
+forwards them to the server; equivalent env vars in parentheses):
+
+- `--prefetch` — download + cache the jar, then exit without serving. Run once before first use
+  (`scalasemantic-mcp --prefetch .`) so the **first connect hits a warm cache** instead of racing
+  the client's ~30s connection timeout while the ~88 MB jar downloads. `install.sh` does this for you.
+- `--log` (`SCALASEMANTIC_LOG`) — write a file log: a startup line + one line per tool call.
+- `--log-output` (`SCALASEMANTIC_LOG_OUTPUT`) — additionally log each JSON-RPC response sent to the
+  model. Logging is **off by default** (no file written); set the log path via `SCALASEMANTIC_LOG_FILE`.
+
+```json
+{
+  "mcpServers": {
+    "scala-semantic": {
+      "command": "~/.local/bin/scalasemantic-mcp",
+      "args": ["/abs/path/to/project", "--log", "--log-output"]
+    }
+  }
+}
+```
+
 Full setup, generated config, and lifecycle: **[docs/INTEGRATION.md](docs/INTEGRATION.md)**.
 
 ## Tools

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/Main.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/Main.scala
@@ -4,14 +4,29 @@ import com.github.mercurievv.scalasemantic.mcp.Mcp
 import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
 
 /** Start the MCP server over stdio. Usage: `runMain com.github.mercurievv.scalasemantic.mcpServer
-  * [semanticdbRoot] [classpath]`.
+  * [semanticdbRoot] [classpath] [--log] [--log-output]`.
   *   - `semanticdbRoot` (default `.`): where it recursively finds emitted `*.semanticdb` files.
   *   - `classpath` (optional): the target project's compile classpath — a path-separated string or
   *     a file containing one — which enables the presentation-compiler backend for live overlay of
   *     uncompiled buffers (the tools' `source` argument). Also read from `SCALASEMANTIC_CLASSPATH`.
+  *
+  * Logging is OFF by default (no log file is written). Enable via flags — passed straight through
+  * the launcher from your `.mcp.json` args — or the matching env vars:
+  *   - `--log`        (or `SCALASEMANTIC_LOG=1`): diagnostic log (startup + per-tool-call lines).
+  *   - `--log-output` (or `SCALASEMANTIC_LOG_OUTPUT=1`): also log each JSON-RPC response sent to
+  *     the LLM. Implies a sink, so it works on its own. Flags are positional-order-independent.
   */
 @main def mcpServer(args: String*): Unit =
-  Mcp.serve(args.headOption.getOrElse("."), args.drop(1).headOption)
+  val (flags, positional) = args.partition(_.startsWith("--"))
+  def envOn(name: String): Boolean =
+    sys.env.get(name).map(_.trim.toLowerCase).exists(Set("1", "true", "yes", "on"))
+  val logOutputs = flags.contains("--log-output") || envOn("SCALASEMANTIC_LOG_OUTPUT")
+  val logEnabled = flags.contains("--log") || envOn("SCALASEMANTIC_LOG") || logOutputs
+  Mcp.serve(
+    positional.headOption.getOrElse("."),
+    positional.drop(1).headOption,
+    Mcp.LogConfig(enabled = logEnabled, logOutputs = logOutputs)
+  )
 
 /** Throwaway entrypoint: load a project's SemanticDB and print a summary. Usage: `run
   * [semanticdbRoot]` (defaults to `target`, i.e. dogfood on this build).

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -192,6 +192,17 @@ object Mcp:
     val shown = if argStr.length > 300 then argStr.take(300) + "…" else argStr
     log(s"call $name $shown")
 
+  /** Logging configuration, off by default. When `enabled` is false NO log file is created — the
+    * server is silent. `enabled` turns on diagnostic logging (startup line + one line per tool
+    * call); `logOutputs` additionally records each JSON-RPC response sent back to the client (i.e.
+    * what the LLM receives). `logOutputs` implies a sink, so it works even without `enabled`.
+    */
+  final case class LogConfig(enabled: Boolean = false, logOutputs: Boolean = false):
+    /** A sink is needed if either kind of logging is on. */
+    def active: Boolean = enabled || logOutputs
+  object LogConfig:
+    val off: LogConfig = LogConfig()
+
   /** Blocking stdio loop. Loads the SemanticDB index for `root` once, then serves requests.
     *
     * `classpath`, when given, enables the presentation-compiler second backend (live overlay of
@@ -199,10 +210,17 @@ object Mcp:
     * classpath, supplied as either a path-separated string or a path to a file containing one
     * (newline or path-separator delimited). Falls back to the `SCALASEMANTIC_CLASSPATH` env var.
     * Absent, the server is index-only and `source` arguments are ignored.
+    *
+    * `logging` controls the (opt-in) file log; see [[LogConfig]]. Default: no log file at all.
     */
-  def serve(root: String, classpath: Option[String] = None): Unit =
+  def serve(
+      root: String,
+      classpath: Option[String] = None,
+      logging: LogConfig = LogConfig.off
+  ): Unit =
     val rootPath = Paths.get(root).toAbsolutePath.nn
-    val log = fileLogger(rootPath)
+    // Only open a log sink when logging is requested, so the default run writes nothing.
+    val log: String => Unit = if logging.active then fileLogger(rootPath) else (_ => ())
     val backend = resolveClasspath(classpath).map { cp =>
       log(s"PC backend enabled (${cp.size} classpath entries)")
       new PresentationCompilerBackend(cp, workspace = Some(rootPath))
@@ -215,7 +233,12 @@ object Mcp:
     val reader = java.io.BufferedReader(java.io.InputStreamReader(System.in, "UTF-8"))
     val out = java.io.PrintStream(System.out, true, "UTF-8")
     val lines = Iterator.continually(Option(reader.readLine())).takeWhile(_.isDefined).flatten
-    process(lines, tools, logToolCall(log)).foreach(out.println)
+    // logToolCall logs inputs (when `enabled`); the tap below logs outputs (when `logOutputs`).
+    val onCall = if logging.enabled then logToolCall(log) else (_: String, _: ujson.Value) => ()
+    process(lines, tools, onCall).foreach { line =>
+      if logging.logOutputs then log(s"out $line")
+      out.println(line)
+    }
 
   /** Resolve the classpath spec (arg or `SCALASEMANTIC_CLASSPATH`) to a list of paths. A spec that
     * names an existing file is read as its contents (newline- or path-separator-delimited);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,11 @@ fi
 chmod +x "$DEST"
 
 echo "Installed: $DEST" >&2
+
+# Warm the cache now so the FIRST MCP connect hits a ready jar instead of racing the client's
+# (~30s) connection timeout while an ~88 MB jar downloads. Best-effort: never fail the install.
+echo "scalasemantic-mcp: prefetching the server jar (one-time download) ..." >&2
+"$DEST" --prefetch . 1>&2 || echo "scalasemantic-mcp: prefetch skipped (will download on first run)" >&2
 case ":$PATH:" in
   *":$BIN_DIR:"*) : ;;
   *) echo "NOTE: $BIN_DIR is not on PATH — add it, or use the absolute path below." >&2 ;;

--- a/scripts/scalasemantic-mcp.ps1
+++ b/scripts/scalasemantic-mcp.ps1
@@ -6,10 +6,13 @@
 #      run it with `java -jar`.
 # Download progress is suppressed so stdout carries only the JSON-RPC stream.
 #
-# Usage:   powershell -ExecutionPolicy Bypass -File scalasemantic-mcp.ps1 <semanticdb-root> [classpath]
-#   All arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional arg 2 =
-#   the compile classpath (a path-separated string or a file containing one) that enables the
-#   presentation-compiler backend for live overlay of uncompiled buffers.
+# Usage:   powershell -ExecutionPolicy Bypass -File scalasemantic-mcp.ps1 [--prefetch] <semanticdb-root> [classpath]
+#   --prefetch  Download + cache the artifact, then exit WITHOUT serving. Run this once before
+#               adding the server to your MCP config so the first real connect hits a warm cache
+#               instead of racing the client's connection timeout while an ~88 MB jar downloads.
+#   All other arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional
+#   arg 2 = the compile classpath (a path-separated string or a file containing one) that enables
+#   the presentation-compiler backend for live overlay of uncompiled buffers.
 # Requires: java on PATH (and optionally coursier). No sbt needed.
 #
 # Pin a version instead of "latest" with:  $env:SCALASEMANTIC_VERSION = "v0.1.4"
@@ -21,13 +24,25 @@ $Org      = 'io.github.mercurievv'
 $Artifact = 'scalasemantic-mcp_3'
 $Main     = 'com.github.mercurievv.scalasemantic.mcpServer'
 $Cache    = Join-Path $env:LOCALAPPDATA 'scalasemantic-mcp'
-$Root     = if ($args.Count -ge 1) { $args[0] } else { '.' }
+
+# --prefetch: warm the cache and exit, never serve (decouples the download from the first connect).
+$Prefetch = $false
+$Rest = @($args)
+if ($Rest.Count -ge 1 -and $Rest[0] -eq '--prefetch') {
+  $Prefetch = $true
+  $Rest = @($Rest[1..($Rest.Count - 1)])
+}
 
 # --- path 1: coursier (preferred) ----------------------------------------------------------------
 if (Get-Command cs -ErrorAction SilentlyContinue) {
   $ver = if ($env:SCALASEMANTIC_VERSION) { $env:SCALASEMANTIC_VERSION -replace '^v', '' } else { 'latest.release' }
+  if ($Prefetch) {
+    [Console]::Error.WriteLine("scalasemantic-mcp: prefetching ${Org}:${Artifact}:$ver via coursier")
+    & cs fetch "${Org}:${Artifact}:$ver"
+    exit $LASTEXITCODE
+  }
   [Console]::Error.WriteLine("scalasemantic-mcp: launching ${Org}:${Artifact}:$ver via coursier")
-  & cs launch "${Org}:${Artifact}:$ver" -M $Main -- @args
+  & cs launch "${Org}:${Artifact}:$ver" -M $Main -- @Rest
   exit $LASTEXITCODE
 }
 
@@ -42,12 +57,26 @@ if (-not $Tag) {
 
 $Jar = if ($Tag) { Join-Path $Cache "scalasemantic-mcp-$Tag.jar" } else { $null }
 
-# download if missing; fall back to newest cached jar when offline
+# download if missing; download is resumable + atomic (rename only on a verified-complete .tmp).
 if ($Tag -and -not (Test-Path $Jar)) {
   $Url = "https://github.com/$Repo/releases/download/$Tag/scalasemantic-mcp.jar"
+  $Tmp = "$Jar.tmp"
   [Console]::Error.WriteLine("scalasemantic-mcp: downloading $Tag ...")
-  Invoke-WebRequest $Url -OutFile "$Jar.tmp"
-  Move-Item -Force "$Jar.tmp" $Jar
+  # Resume a partial .tmp from a previous (e.g. timed-out) attempt via a byte-range request, so a
+  # slow first download completes across the client's auto-reconnect retries instead of restarting.
+  $headers = @{}
+  $have = 0
+  if (Test-Path $Tmp) { $have = (Get-Item $Tmp).Length; if ($have -gt 0) { $headers['Range'] = "bytes=$have-" } }
+  $ok = $false
+  try {
+    $resp = Invoke-WebRequest $Url -Headers $headers -OutFile $Tmp -PassThru
+    $ok = $true
+  } catch {
+    # HTTP 416 (Range Not Satisfiable) means the .tmp is already complete — accept it as done.
+    if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 416) { $ok = $true }
+    else { [Console]::Error.WriteLine("scalasemantic-mcp: download incomplete ($($_.Exception.Message)); will resume on next launch") }
+  }
+  if ($ok) { Move-Item -Force $Tmp $Jar }
 }
 if (-not $Jar -or -not (Test-Path $Jar)) {
   $Jar = Get-ChildItem -Path $Cache -Filter 'scalasemantic-mcp-*.jar' -ErrorAction SilentlyContinue |
@@ -56,5 +85,10 @@ if (-not $Jar -or -not (Test-Path $Jar)) {
   [Console]::Error.WriteLine("scalasemantic-mcp: offline — using cached $(Split-Path $Jar -Leaf)")
 }
 
-& java -jar $Jar @args
+if ($Prefetch) {
+  [Console]::Error.WriteLine("scalasemantic-mcp: prefetched $(Split-Path $Jar -Leaf)")
+  exit 0
+}
+
+& java -jar $Jar @Rest
 exit $LASTEXITCODE

--- a/scripts/scalasemantic-mcp.ps1
+++ b/scripts/scalasemantic-mcp.ps1
@@ -13,6 +13,10 @@
 #   All other arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional
 #   arg 2 = the compile classpath (a path-separated string or a file containing one) that enables
 #   the presentation-compiler backend for live overlay of uncompiled buffers.
+#   --log / --log-output  Forwarded to the server to turn on its (off-by-default) file log:
+#               --log writes a startup line + one line per tool call; --log-output additionally
+#               logs each JSON-RPC response sent to the LLM. (Env equivalents: SCALASEMANTIC_LOG,
+#               SCALASEMANTIC_LOG_OUTPUT; log file path via SCALASEMANTIC_LOG_FILE.)
 # Requires: java on PATH (and optionally coursier). No sbt needed.
 #
 # Pin a version instead of "latest" with:  $env:SCALASEMANTIC_VERSION = "v0.1.4"

--- a/scripts/scalasemantic-mcp.sh
+++ b/scripts/scalasemantic-mcp.sh
@@ -15,6 +15,10 @@
 #   All other arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional
 #   arg 2 = the compile classpath (a path-separated string or a file containing one) that enables
 #   the presentation-compiler backend for live overlay of uncompiled buffers.
+#   --log / --log-output  Forwarded to the server to turn on its (off-by-default) file log:
+#               --log writes a startup line + one line per tool call; --log-output additionally
+#               logs each JSON-RPC response sent to the LLM. (Env equivalents: SCALASEMANTIC_LOG,
+#               SCALASEMANTIC_LOG_OUTPUT; log file path via SCALASEMANTIC_LOG_FILE.)
 # Requires: java on PATH (and optionally coursier). No sbt needed.
 #
 # Pin a version instead of "latest" by exporting SCALASEMANTIC_VERSION=v0.1.4

--- a/scripts/scalasemantic-mcp.sh
+++ b/scripts/scalasemantic-mcp.sh
@@ -8,10 +8,13 @@
 #      run it with `java -jar`.
 # Either way, all progress goes to stderr so stdout carries only the JSON-RPC protocol stream.
 #
-# Usage:   scalasemantic-mcp.sh <semanticdb-root> [classpath]   (root defaults to ".")
-#   All arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional arg 2 =
-#   the compile classpath (a path-separated string or a file containing one) that enables the
-#   presentation-compiler backend for live overlay of uncompiled buffers.
+# Usage:   scalasemantic-mcp.sh [--prefetch] <semanticdb-root> [classpath]   (root defaults to ".")
+#   --prefetch  Download + cache the artifact, then exit WITHOUT serving. Run this once before
+#               adding the server to your MCP config so the first real connect hits a warm cache
+#               instead of racing the client's connection timeout while an ~88 MB jar downloads.
+#   All other arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional
+#   arg 2 = the compile classpath (a path-separated string or a file containing one) that enables
+#   the presentation-compiler backend for live overlay of uncompiled buffers.
 # Requires: java on PATH (and optionally coursier). No sbt needed.
 #
 # Pin a version instead of "latest" by exporting SCALASEMANTIC_VERSION=v0.1.4
@@ -22,12 +25,22 @@ ORG="io.github.mercurievv"
 ARTIFACT="scalasemantic-mcp_3"
 MAIN="com.github.mercurievv.scalasemantic.mcpServer"
 CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/scalasemantic-mcp"
-ROOT="${1:-.}"
+
+# --prefetch: warm the cache and exit, never serve (decouples the download from the first connect).
+PREFETCH=0
+if [ "${1:-}" = "--prefetch" ]; then
+  PREFETCH=1
+  shift
+fi
 
 # --- path 1: coursier (preferred) — resolves transitive deps from Central, caches, runs ----------
 if command -v cs >/dev/null 2>&1; then
   ver="${SCALASEMANTIC_VERSION:-latest.release}"
   ver="${ver#v}" # coursier wants the Maven version (0.1.4), not the git tag (v0.1.4)
+  if [ "$PREFETCH" -eq 1 ]; then
+    echo "scalasemantic-mcp: prefetching $ORG:$ARTIFACT:$ver via coursier" >&2
+    exec cs fetch "$ORG:$ARTIFACT:$ver"
+  fi
   echo "scalasemantic-mcp: launching $ORG:$ARTIFACT:$ver via coursier" >&2
   exec cs launch "$ORG:$ARTIFACT:$ver" -M "$MAIN" -- "$@"
 fi
@@ -35,37 +48,65 @@ fi
 # --- path 2: fat jar from GitHub Releases --------------------------------------------------------
 mkdir -p "$CACHE"
 
-# tiny fetch helper: $1=url $2=outfile ("-" = stdout). Status noise stays on stderr.
-fetch() {
-  if command -v curl >/dev/null 2>&1; then
-    if [ "$2" = "-" ]; then curl -fsSL "$1"; else curl -fsSL "$1" -o "$2"; fi
-  elif command -v wget >/dev/null 2>&1; then
-    if [ "$2" = "-" ]; then wget -qO- "$1"; else wget -qO "$2" "$1"; fi
-  else
-    echo "scalasemantic-mcp: need coursier, or curl/wget, on PATH" >&2; exit 1
+# fetch URL to stdout (used for the GitHub API call). Status noise stays on stderr.
+fetch_stdout() {
+  if command -v curl >/dev/null 2>&1; then curl -fsSL "$1"
+  elif command -v wget >/dev/null 2>&1; then wget -qO- "$1"
+  else echo "scalasemantic-mcp: need coursier, or curl/wget, on PATH" >&2; return 1
+  fi
+}
+
+# Resumable download of $1 to file $2. curl `-C -` / wget `-c` continue a partial `.tmp` from a
+# previous (e.g. timed-out) attempt instead of restarting, so a slow first download completes
+# across the client's auto-reconnect retries. Returns the tool's exit status.
+fetch_file() {
+  if command -v curl >/dev/null 2>&1; then curl -fsSL --retry 3 -C - "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then wget -q -c -O "$2" "$1"
+  else echo "scalasemantic-mcp: need coursier, or curl/wget, on PATH" >&2; return 1
   fi
 }
 
 # resolve version: explicit pin, else the latest release's tag_name
 TAG="${SCALASEMANTIC_VERSION:-}"
 if [ -z "$TAG" ]; then
-  TAG=$(fetch "https://api.github.com/repos/$REPO/releases/latest" - 2>/dev/null \
+  TAG=$(fetch_stdout "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
         | grep '"tag_name"' | head -1 | cut -d'"' -f4 || true)
 fi
 
 JAR="$CACHE/scalasemantic-mcp-${TAG:-unknown}.jar"
 
-# download if missing; fall back to newest cached jar when offline
+# download if missing; download is resumable + atomic (rename only on a verified-complete .tmp)
 if [ -n "$TAG" ] && [ ! -f "$JAR" ]; then
   URL="https://github.com/$REPO/releases/download/$TAG/scalasemantic-mcp.jar"
   echo "scalasemantic-mcp: downloading $TAG ..." >&2
-  fetch "$URL" "$JAR.tmp"
-  mv "$JAR.tmp" "$JAR"
+  rc=0
+  set +e
+  fetch_file "$URL" "$JAR.tmp"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] && [ -f "$JAR.tmp" ]; then
+    # A resume can fail with HTTP 416 when the .tmp is in fact already complete. Confirm by
+    # comparing sizes against the server's Content-Length; if they match, treat it as done.
+    remote=$(curl -fsSIL "$URL" 2>/dev/null | awk 'tolower($1) ~ /^content-length:/ {print $2}' | tr -d '\r' | tail -1)
+    local=$(wc -c < "$JAR.tmp" 2>/dev/null | tr -d ' ')
+    if [ -n "$remote" ] && [ "$remote" = "$local" ]; then rc=0; fi
+  fi
+  if [ "$rc" -eq 0 ]; then
+    mv -f "$JAR.tmp" "$JAR"
+  else
+    # Keep the partial `.tmp` so the next launch resumes it; fall through to any cached jar.
+    echo "scalasemantic-mcp: download incomplete (rc=$rc); will resume on next launch" >&2
+  fi
 fi
 if [ ! -f "$JAR" ]; then
   JAR=$(ls -t "$CACHE"/scalasemantic-mcp-*.jar 2>/dev/null | head -1 || true)
   [ -n "$JAR" ] || { echo "scalasemantic-mcp: cannot resolve a release and no cached jar found" >&2; exit 1; }
   echo "scalasemantic-mcp: offline — using cached $(basename "$JAR")" >&2
+fi
+
+if [ "$PREFETCH" -eq 1 ]; then
+  echo "scalasemantic-mcp: prefetched $(basename "$JAR")" >&2
+  exit 0
 fi
 
 exec java -jar "$JAR" "$@"


### PR DESCRIPTION
Two related improvements to how the MCP server is launched and operated.

## 1. First-connect timeout (resumable download + `--prefetch`)
The launcher fetched the ~88 MB fat jar lazily on the **first MCP connect**. On a slow link this exceeds the client's ~30s connection timeout (observed: a 91s cold start → `connection timed out after 30000ms`), and the killed download left a partial `.tmp` that the next attempt **discarded**, so it could loop forever.

- **Resumable + atomic download**: `curl -C -` / `wget -c` continue the per-version `.tmp` across the client's reconnect retries; rename only on a verified-complete file. A 416 on an already-complete `.tmp` is recovered via a Content-Length size check.
- **`--prefetch` flag**: download + cache then exit without serving (`cs fetch` on the coursier path). `install.sh` now prefetches at install time so the first real connect hits a warm cache.
- Mirrored in the PowerShell launcher (Range-header resume + 416 handling).

Tested against the real release jar: warm prefetch instant; resume from a 20 MB partial → byte-identical 88 MB jar; already-complete `.tmp` recovered with no leftover.

## 2. Opt-in logging (`--log` / `--log-output`)
The server unconditionally wrote a file log. Now silent by default — no log file unless requested:

- `--log` (env `SCALASEMANTIC_LOG`): startup line + one line per tool call.
- `--log-output` (env `SCALASEMANTIC_LOG_OUTPUT`): additionally log each JSON-RPC response sent to the LLM; implies a sink so it works alone.

Flags are positional-order-independent and pass straight through the launcher from `.mcp.json` args. Verified on the assembled jar: default writes nothing, `--log` logs calls, `--log-output` logs responses, env vars honored.