### PR TITLE
feat: serve cached MCP server instantly + background self-update; prefetch on mcpClientConfig

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -114,6 +114,14 @@ the client's ~30s startup timeout) leaves a partial `.tmp` that the next launch 
 restarting, and the cached jar is only swapped in once complete. So a slow first download converges
 across the client's reconnect retries instead of looping.
 
+Cold start is **instant once anything is cached**: when a (non-pinned) launch finds a cached jar it
+serves that one *immediately* — zero download latency — and forks a detached background updater that
+fetches the latest release for the **next** launch. So the very first launch on an empty cache still
+blocks on the download (warm it ahead of time with `--prefetch`, or `sbt mcpClientConfig`, which
+prefetches for you), and after a new release the launcher keeps serving the previous version for one
+more session before the background update takes effect. Pinning with `SCALASEMANTIC_VERSION` disables
+the background updater — you get exactly that version every launch.
+
 Install the launcher to a **stable path on PATH** (`~/.local/bin/scalasemantic-mcp`) so `.mcp.json`
 does not depend on where this repo is cloned — and, unlike the sbt dev launcher under `target/`, it
 survives `sbt clean`:

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -78,24 +78,25 @@ Scala 3.8.4 server, which is why it is sbt-1/2 and build-tool portable.
 
 #### What `mcpClientConfig` generates
 
-The task takes `mcpServerCommand` and appends the project's base directory as the trailing argument.
-With the default `mcpServerCommand` (the launcher `mcpInstall` writes) it emits:
+The task takes `mcpServerCommand`, then appends the project's base directory, the classpath file, and
+the logging flags. With the default `mcpServerCommand` (the launcher `mcpInstall` writes) it emits:
 
 ```json
 {
   "mcpServers": {
     "scala-semantic": {
-      "command": "/abs/path/to/<project>/target/.../scalasemantic-mcp.sh",
-      "args": ["/abs/path/to/this/project"]
+      "command": "~/.local/bin/scalasemantic-mcp",
+      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"]
     }
   }
 }
 ```
 
-`command` = `mcpServerCommand.head`; `args` = the rest of `mcpServerCommand` plus the auto-appended
-project root. So overriding `mcpServerCommand := Seq("java", "-jar", "/abs/scalasemantic-mcp.jar")`
-would instead yield `"command": "java"`,
-`"args": ["-jar", "/abs/scalasemantic-mcp.jar", "/abs/path/to/this/project"]`.
+`command` = `mcpServerCommand.head`; `args` = the rest of `mcpServerCommand`, then the auto-appended
+project root and classpath file, then `--log --log-output` (the server's [logging](#logging) is off
+unless these are present — drop them for the silent default). So overriding
+`mcpServerCommand := Seq("java", "-jar", "/abs/scalasemantic-mcp.jar")` would instead yield
+`"command": "java"` with `"-jar", "/abs/scalasemantic-mcp.jar"` leading those same trailing args.
 Generation logic: [`ScalaSemanticMcpPlugin.scala`](../sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala).
 
 ### Option B — auto-download launcher

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -5,7 +5,9 @@ you don't run it as a daemon. Integrating means two things: make the project emi
 register a launch command scoped to that project's root. Because the unit is a plain process, the
 same approach works from any build tool.
 
-The server speaks newline-delimited JSON-RPC 2.0 on **stdout** and logs to **stderr**. Point it at a
+The server speaks newline-delimited JSON-RPC 2.0 on **stdout**; **stderr** carries only launcher
+download chatter. The server's own diagnostic logging is **off by default** (nothing is written) and,
+when enabled, goes to a *file* rather than the streams — see [Logging](#logging). Point it at a
 directory that contains emitted `*.semanticdb` files (the target project must be compiled with
 SemanticDB enabled).
 
@@ -106,6 +108,11 @@ path automatically: if **coursier** (`cs`) is on PATH they `cs launch` the artif
 goes to stderr; stdout stays pure JSON-RPC. Offline, they fall back to the newest cached jar. Pin a
 version with `SCALASEMANTIC_VERSION=vX.Y.Z` (a real tag such as the latest release; default is newest).
 
+The fat-jar download is **resumable and atomic**: an interrupted download (e.g. a connection killed by
+the client's ~30s startup timeout) leaves a partial `.tmp` that the next launch *continues* rather than
+restarting, and the cached jar is only swapped in once complete. So a slow first download converges
+across the client's reconnect retries instead of looping.
+
 Install the launcher to a **stable path on PATH** (`~/.local/bin/scalasemantic-mcp`) so `.mcp.json`
 does not depend on where this repo is cloned — and, unlike the sbt dev launcher under `target/`, it
 survives `sbt clean`:
@@ -114,6 +121,10 @@ survives `sbt clean`:
 curl -fsSL https://raw.githubusercontent.com/MercurieVV/ScalaSemantic/master/scripts/install.sh | sh
 # or, from a checkout:  scripts/install.sh
 ```
+
+`install.sh` also **prefetches** the jar so the first real MCP connect hits a warm cache. If you wire
+the launcher up by other means, warm it once yourself with `scalasemantic-mcp --prefetch .` — otherwise
+the first connect races the download against the client's connection timeout.
 
 ```json
 {
@@ -147,6 +158,31 @@ directly — no script in between:
 > launch the jar (or the script that wraps it) so stdout carries only protocol messages. To build the
 > jar locally instead of downloading: `sbt "mcp/assembly"`.
 
+## Logging
+
+The server is **silent by default** — no log file is created. Turn it on with flags (appended to the
+`.mcp.json` `args`, after the project root — the launcher forwards them to the server) or the matching
+env vars:
+
+| Flag | Env | Logs |
+|---|---|---|
+| `--log` | `SCALASEMANTIC_LOG=1` | a startup line + one line per tool call (name + arguments) |
+| `--log-output` | `SCALASEMANTIC_LOG_OUTPUT=1` | additionally, each JSON-RPC response sent to the model; implies a sink, so it works on its own |
+
+Flags are position-independent. The log file defaults to `<root>/scala-semantic-mcp.log`; override the
+path with `SCALASEMANTIC_LOG_FILE`. Each line is timestamped and flushed, so `tail -f` shows it live.
+
+```json
+{
+  "mcpServers": {
+    "scala-semantic": {
+      "command": "/abs/home/.local/bin/scalasemantic-mcp",
+      "args": ["/abs/path/to/project-to-analyze", "--log-output"]
+    }
+  }
+}
+```
+
 ## Manual stdio check
 
 ```sh
@@ -158,6 +194,6 @@ printf '%s\n' \
  | java -jar scalasemantic-mcp.jar .
 ```
 
-Expect four JSON-RPC responses on stdout (stderr carries the startup log). The `initialize` response
-carries an `instructions` field; `find_symbol` turns the name `Animal` into the symbol string the
-`class_hierarchy` call then uses.
+Expect four JSON-RPC responses on stdout (with logging off by default, nothing else is emitted; add
+`--log`/`--log-output` to trace to a file). The `initialize` response carries an `instructions` field;
+`find_symbol` turns the name `Animal` into the symbol string the `class_hierarchy` call then uses.

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/Main.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/Main.scala
@@ -12,7 +12,7 @@ import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
   *
   * Logging is OFF by default (no log file is written). Enable via flags — passed straight through
   * the launcher from your `.mcp.json` args — or the matching env vars:
-  *   - `--log`        (or `SCALASEMANTIC_LOG=1`): diagnostic log (startup + per-tool-call lines).
+  *   - `--log` (or `SCALASEMANTIC_LOG=1`): diagnostic log (startup + per-tool-call lines).
   *   - `--log-output` (or `SCALASEMANTIC_LOG_OUTPUT=1`): also log each JSON-RPC response sent to
   *     the LLM. Implies a sink, so it works on its own. Flags are positional-order-independent.
   */

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -93,7 +93,9 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
           log.warn(s"MCP server prefetch returned $rc; it will download on first connect instead.")
       } catch {
         case scala.util.control.NonFatal(e) =>
-          log.warn(s"MCP server prefetch skipped (${e.getMessage}); it will download on first connect.")
+          log.warn(
+            s"MCP server prefetch skipped (${e.getMessage}); it will download on first connect."
+          )
       }
       // Reference the classpath file by PATH only — do NOT depend on `mcpClasspathFile`, which
       // evaluates `Compile / fullClasspath` and so forces a full compile. Printing a config entry
@@ -101,7 +103,12 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       // classpath file as index-only; run `sbt mcpClasspathFile` once (needs a clean compile) to
       // enable the live presentation-compiler backend.
       val cpFile = classpathFile(mcpServerName.value)
-      val argv = resolvedCommand(mcpServerCommand.value, baseDirectory.value, cpFile)
+      // Enable the server's file log in the generated config: `--log` (startup + per-tool-call) and
+      // `--log-output` (also each response sent to the model). Flags are position-independent; drop
+      // them from the printed `.mcp.json` if you prefer the silent default.
+      val argv =
+        resolvedCommand(mcpServerCommand.value, baseDirectory.value, cpFile) ++
+          Seq("--log", "--log-output")
       val argsJson = argv.tail.map(a => "\"" + a + "\"").mkString("[", ", ", "]")
       log.info(
         s"""|Register this in your MCP client (e.g. .mcp.json):

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -80,8 +80,21 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
     mcpServerCommand := launcherCommand(installDir / launcherName),
     mcpClientConfig := {
       val log = streams.value.log
-      val _ =
+      val launcher =
         mcpInstall.value // ensure the launcher exists before we print a command pointing at it
+      // Blocking prefetch: download + cache the server jar NOW, while the user is setting up, so the
+      // first real client connect hits a warm cache instead of racing its connect timeout while the
+      // ~88 MB jar downloads. The launcher's `--prefetch` fetches + caches, then exits without
+      // serving. Best-effort — config printing must still work offline.
+      try {
+        log.info("Prefetching the MCP server (one-time download; may take a moment)...")
+        val rc = Process(launcherCommand(launcher) :+ "--prefetch").!
+        if (rc != 0)
+          log.warn(s"MCP server prefetch returned $rc; it will download on first connect instead.")
+      } catch {
+        case scala.util.control.NonFatal(e) =>
+          log.warn(s"MCP server prefetch skipped (${e.getMessage}); it will download on first connect.")
+      }
       // Reference the classpath file by PATH only — do NOT depend on `mcpClasspathFile`, which
       // evaluates `Compile / fullClasspath` and so forces a full compile. Printing a config entry
       // must work even when the project does not compile. The server treats a not-yet-written

--- a/scripts/scalasemantic-mcp.ps1
+++ b/scripts/scalasemantic-mcp.ps1
@@ -6,6 +6,12 @@
 #      run it with `java -jar`.
 # Download progress is suppressed so stdout carries only the JSON-RPC stream.
 #
+# Cold-start strategy (jar path): once ANY version is cached, a launch serves the newest cached jar
+# IMMEDIATELY and forks a detached background updater that fetches the latest release for the NEXT
+# launch. So the download never races the client's connect timeout after the first time. The very
+# first launch (empty cache) still blocks on the download — run `--prefetch` once, or `sbt
+# mcpClientConfig` (which prefetches for you), to warm the cache ahead of the first real connect.
+#
 # Usage:   powershell -ExecutionPolicy Bypass -File scalasemantic-mcp.ps1 [--prefetch] <semanticdb-root> [classpath]
 #   --prefetch  Download + cache the artifact, then exit WITHOUT serving. Run this once before
 #               adding the server to your MCP config so the first real connect hits a warm cache
@@ -19,7 +25,8 @@
 #               SCALASEMANTIC_LOG_OUTPUT; log file path via SCALASEMANTIC_LOG_FILE.)
 # Requires: java on PATH (and optionally coursier). No sbt needed.
 #
-# Pin a version instead of "latest" with:  $env:SCALASEMANTIC_VERSION = "v0.1.4"
+# Pin a version instead of "latest" with:  $env:SCALASEMANTIC_VERSION = "v0.1.4"  (pinned launches
+# skip the background updater — you get exactly that version).
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue' # keep Invoke-WebRequest's progress bar off the streams
 
@@ -29,9 +36,63 @@ $Artifact = 'scalasemantic-mcp_3'
 $Main     = 'com.github.mercurievv.scalasemantic.mcpServer'
 $Cache    = Join-Path $env:LOCALAPPDATA 'scalasemantic-mcp'
 
+New-Item -ItemType Directory -Force -Path $Cache | Out-Null
+
+# newest cached fat jar (most recently modified), or $null if none.
+function Get-NewestCached {
+  Get-ChildItem -Path $Cache -Filter 'scalasemantic-mcp-*.jar' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+}
+
+# resolve the release tag to use: explicit pin, else the latest release's tag_name (may be $null).
+function Resolve-Tag {
+  if ($env:SCALASEMANTIC_VERSION) { return $env:SCALASEMANTIC_VERSION }
+  try { (Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest").tag_name } catch { $null }
+}
+
+# Download release $Tag's fat jar into the cache if not already present. Resumable + atomic: writes
+# a `.tmp` (byte-range resume) and renames only on a complete download. $true on success/cached.
+function Get-Release([string]$Tag) {
+  $jar = Join-Path $Cache "scalasemantic-mcp-$Tag.jar"
+  if (Test-Path $jar) { return $true }
+  $url = "https://github.com/$Repo/releases/download/$Tag/scalasemantic-mcp.jar"
+  $tmp = "$jar.tmp"
+  [Console]::Error.WriteLine("scalasemantic-mcp: downloading $Tag ...")
+  # Resume a partial .tmp from a previous (e.g. timed-out) attempt via a byte-range request.
+  $headers = @{}
+  if (Test-Path $tmp) { $have = (Get-Item $tmp).Length; if ($have -gt 0) { $headers['Range'] = "bytes=$have-" } }
+  try {
+    Invoke-WebRequest $url -Headers $headers -OutFile $tmp -PassThru | Out-Null
+    Move-Item -Force $tmp $jar
+    return $true
+  } catch {
+    # HTTP 416 (Range Not Satisfiable) means the .tmp is already complete — accept it as done.
+    if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 416) {
+      Move-Item -Force $tmp $jar; return $true
+    }
+    [Console]::Error.WriteLine("scalasemantic-mcp: download incomplete ($($_.Exception.Message)); will resume on next launch")
+    return $false
+  }
+}
+
+$Rest = @($args)
+
+# --bg-fetch: internal mode forked (detached) by a cached-serve launch to fetch the latest release
+# for the NEXT launch, then exit. A lock file keeps concurrent launches from racing the same `.tmp`.
+if ($Rest.Count -ge 1 -and $Rest[0] -eq '--bg-fetch') {
+  $lock = Join-Path $Cache '.bgfetch.lock'
+  try {
+    $fs = [System.IO.File]::Open($lock, 'CreateNew', 'Write', 'None')
+    try {
+      $tag = Resolve-Tag
+      if ($tag) { [void](Get-Release $tag) }
+    } finally { $fs.Close(); Remove-Item $lock -ErrorAction SilentlyContinue }
+  } catch { } # lock held by another launch — let it do the update
+  exit 0
+}
+
 # --prefetch: warm the cache and exit, never serve (decouples the download from the first connect).
 $Prefetch = $false
-$Rest = @($args)
 if ($Rest.Count -ge 1 -and $Rest[0] -eq '--prefetch') {
   $Prefetch = $true
   $Rest = @($Rest[1..($Rest.Count - 1)])
@@ -51,42 +112,28 @@ if (Get-Command cs -ErrorAction SilentlyContinue) {
 }
 
 # --- path 2: fat jar from GitHub Releases --------------------------------------------------------
-New-Item -ItemType Directory -Force -Path $Cache | Out-Null
+$Cached = Get-NewestCached
 
-# resolve version: explicit pin, else the latest release's tag_name
-$Tag = $env:SCALASEMANTIC_VERSION
-if (-not $Tag) {
-  try { $Tag = (Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest").tag_name } catch { $Tag = $null }
-}
-
-$Jar = if ($Tag) { Join-Path $Cache "scalasemantic-mcp-$Tag.jar" } else { $null }
-
-# download if missing; download is resumable + atomic (rename only on a verified-complete .tmp).
-if ($Tag -and -not (Test-Path $Jar)) {
-  $Url = "https://github.com/$Repo/releases/download/$Tag/scalasemantic-mcp.jar"
-  $Tmp = "$Jar.tmp"
-  [Console]::Error.WriteLine("scalasemantic-mcp: downloading $Tag ...")
-  # Resume a partial .tmp from a previous (e.g. timed-out) attempt via a byte-range request, so a
-  # slow first download completes across the client's auto-reconnect retries instead of restarting.
-  $headers = @{}
-  $have = 0
-  if (Test-Path $Tmp) { $have = (Get-Item $Tmp).Length; if ($have -gt 0) { $headers['Range'] = "bytes=$have-" } }
-  $ok = $false
+if (-not $Prefetch -and -not $env:SCALASEMANTIC_VERSION -and $Cached) {
+  # Cached jar present and not pinned: serve it NOW (zero download latency) and fork a detached
+  # updater that pulls the latest release for the next launch. The child runs hidden so it does not
+  # hold the JSON-RPC stdout stream.
+  $Jar = $Cached
   try {
-    $resp = Invoke-WebRequest $Url -Headers $headers -OutFile $Tmp -PassThru
-    $ok = $true
-  } catch {
-    # HTTP 416 (Range Not Satisfiable) means the .tmp is already complete — accept it as done.
-    if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 416) { $ok = $true }
-    else { [Console]::Error.WriteLine("scalasemantic-mcp: download incomplete ($($_.Exception.Message)); will resume on next launch") }
+    Start-Process -FilePath 'powershell' `
+      -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath, '--bg-fetch') `
+      -WindowStyle Hidden | Out-Null
+  } catch { } # best-effort updater; serving the cached jar is what matters
+} else {
+  # No cache (must block once), or pinned (fetch exactly that version), or prefetch (warm fully).
+  $Tag = Resolve-Tag
+  if ($Tag) { [void](Get-Release $Tag) }
+  $Jar = if ($Tag) { Join-Path $Cache "scalasemantic-mcp-$Tag.jar" } else { $null }
+  if (-not $Jar -or -not (Test-Path $Jar)) {
+    $Jar = Get-NewestCached
+    if (-not $Jar) { throw "scalasemantic-mcp: cannot resolve a release and no cached jar found" }
+    [Console]::Error.WriteLine("scalasemantic-mcp: offline — using cached $(Split-Path $Jar -Leaf)")
   }
-  if ($ok) { Move-Item -Force $Tmp $Jar }
-}
-if (-not $Jar -or -not (Test-Path $Jar)) {
-  $Jar = Get-ChildItem -Path $Cache -Filter 'scalasemantic-mcp-*.jar' -ErrorAction SilentlyContinue |
-         Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
-  if (-not $Jar) { throw "scalasemantic-mcp: cannot resolve a release and no cached jar found" }
-  [Console]::Error.WriteLine("scalasemantic-mcp: offline — using cached $(Split-Path $Jar -Leaf)")
 }
 
 if ($Prefetch) {

--- a/scripts/scalasemantic-mcp.sh
+++ b/scripts/scalasemantic-mcp.sh
@@ -8,6 +8,12 @@
 #      run it with `java -jar`.
 # Either way, all progress goes to stderr so stdout carries only the JSON-RPC protocol stream.
 #
+# Cold-start strategy (jar path): once ANY version is cached, a launch serves the newest cached jar
+# IMMEDIATELY and forks a detached background updater that fetches the latest release for the NEXT
+# launch. So the download never races the client's connect timeout after the first time. The very
+# first launch (empty cache) still blocks on the download — run `--prefetch` once, or `sbt
+# mcpClientConfig` (which prefetches for you), to warm the cache ahead of the first real connect.
+#
 # Usage:   scalasemantic-mcp.sh [--prefetch] <semanticdb-root> [classpath]   (root defaults to ".")
 #   --prefetch  Download + cache the artifact, then exit WITHOUT serving. Run this once before
 #               adding the server to your MCP config so the first real connect hits a warm cache
@@ -21,7 +27,8 @@
 #               SCALASEMANTIC_LOG_OUTPUT; log file path via SCALASEMANTIC_LOG_FILE.)
 # Requires: java on PATH (and optionally coursier). No sbt needed.
 #
-# Pin a version instead of "latest" by exporting SCALASEMANTIC_VERSION=v0.1.4
+# Pin a version instead of "latest" by exporting SCALASEMANTIC_VERSION=v0.1.4 (pinned launches skip
+# the background updater — you get exactly that version).
 set -eu
 
 REPO="MercurieVV/ScalaSemantic"
@@ -29,6 +36,77 @@ ORG="io.github.mercurievv"
 ARTIFACT="scalasemantic-mcp_3"
 MAIN="com.github.mercurievv.scalasemantic.mcpServer"
 CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/scalasemantic-mcp"
+
+mkdir -p "$CACHE"
+
+# fetch URL to stdout (used for the GitHub API call). Status noise stays on stderr.
+fetch_stdout() {
+  if command -v curl >/dev/null 2>&1; then curl -fsSL "$1"
+  elif command -v wget >/dev/null 2>&1; then wget -qO- "$1"
+  else echo "scalasemantic-mcp: need coursier, or curl/wget, on PATH" >&2; return 1
+  fi
+}
+
+# Resumable download of $1 to file $2. curl `-C -` / wget `-c` continue a partial `.tmp` from a
+# previous (e.g. timed-out) attempt instead of restarting, so a slow first download completes
+# across the client's auto-reconnect retries. Returns the tool's exit status.
+fetch_file() {
+  if command -v curl >/dev/null 2>&1; then curl -fsSL --retry 3 -C - "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then wget -q -c -O "$2" "$1"
+  else echo "scalasemantic-mcp: need coursier, or curl/wget, on PATH" >&2; return 1
+  fi
+}
+
+# newest cached fat jar (most recently modified), or empty if none.
+newest_cached() { ls -t "$CACHE"/scalasemantic-mcp-*.jar 2>/dev/null | head -1 || true; }
+
+# resolve the release tag to use: explicit pin, else the latest release's tag_name (may be empty).
+resolve_tag() {
+  if [ -n "${SCALASEMANTIC_VERSION:-}" ]; then printf '%s' "$SCALASEMANTIC_VERSION"; return 0; fi
+  fetch_stdout "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4 || true
+}
+
+# Download release $1's fat jar into the cache if not already present. Resumable + atomic: writes a
+# `.tmp` and renames only on a verified-complete download. Returns 0 on success (or already cached).
+download_release() {
+  _tag="$1"
+  _jar="$CACHE/scalasemantic-mcp-$_tag.jar"
+  [ -f "$_jar" ] && return 0
+  _url="https://github.com/$REPO/releases/download/$_tag/scalasemantic-mcp.jar"
+  echo "scalasemantic-mcp: downloading $_tag ..." >&2
+  set +e
+  fetch_file "$_url" "$_jar.tmp"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] && [ -f "$_jar.tmp" ]; then
+    # A resume can fail with HTTP 416 when the .tmp is in fact already complete. Confirm by
+    # comparing sizes against the server's Content-Length; if they match, treat it as done.
+    remote=$(curl -fsSIL "$_url" 2>/dev/null | awk 'tolower($1) ~ /^content-length:/ {print $2}' | tr -d '\r' | tail -1)
+    local=$(wc -c < "$_jar.tmp" 2>/dev/null | tr -d ' ')
+    if [ -n "$remote" ] && [ "$remote" = "$local" ]; then rc=0; fi
+  fi
+  if [ "$rc" -eq 0 ]; then
+    mv -f "$_jar.tmp" "$_jar"
+    return 0
+  fi
+  # Keep the partial `.tmp` so the next attempt resumes it.
+  echo "scalasemantic-mcp: download incomplete (rc=$rc); will resume on next launch" >&2
+  return 1
+}
+
+# --bg-fetch: internal mode forked (detached) by a cached-serve launch to fetch the latest release
+# for the NEXT launch, then exit. A mkdir-based lock keeps concurrent launches from racing the same
+# `.tmp`. Never serves, never touches stdout.
+if [ "${1:-}" = "--bg-fetch" ]; then
+  _lock="$CACHE/.bgfetch.lock"
+  if mkdir "$_lock" 2>/dev/null; then
+    trap 'rmdir "$_lock" 2>/dev/null || true' EXIT INT TERM
+    _tag=$(resolve_tag)
+    [ -n "$_tag" ] && download_release "$_tag" || true
+  fi
+  exit 0
+fi
 
 # --prefetch: warm the cache and exit, never serve (decouples the download from the first connect).
 PREFETCH=0
@@ -50,62 +128,24 @@ if command -v cs >/dev/null 2>&1; then
 fi
 
 # --- path 2: fat jar from GitHub Releases --------------------------------------------------------
-mkdir -p "$CACHE"
+CACHED=$(newest_cached)
 
-# fetch URL to stdout (used for the GitHub API call). Status noise stays on stderr.
-fetch_stdout() {
-  if command -v curl >/dev/null 2>&1; then curl -fsSL "$1"
-  elif command -v wget >/dev/null 2>&1; then wget -qO- "$1"
-  else echo "scalasemantic-mcp: need coursier, or curl/wget, on PATH" >&2; return 1
+if [ "$PREFETCH" -eq 0 ] && [ -z "${SCALASEMANTIC_VERSION:-}" ] && [ -n "$CACHED" ]; then
+  # Cached jar present and not pinned: serve it NOW (zero download latency) and fork a detached
+  # updater that pulls the latest release for the next launch. `( … & )` double-detaches so the
+  # exec below does not wait on it; its fds are redirected away from the JSON-RPC stdout stream.
+  JAR="$CACHED"
+  ( "$0" --bg-fetch >/dev/null 2>&1 </dev/null & ) >/dev/null 2>&1 || true
+else
+  # No cache (must block once), or pinned (fetch exactly that version), or prefetch (warm fully).
+  TAG=$(resolve_tag)
+  if [ -n "$TAG" ]; then download_release "$TAG" || true; fi
+  JAR="$CACHE/scalasemantic-mcp-${TAG:-unknown}.jar"
+  if [ ! -f "$JAR" ]; then
+    JAR=$(newest_cached)
+    [ -n "$JAR" ] || { echo "scalasemantic-mcp: cannot resolve a release and no cached jar found" >&2; exit 1; }
+    echo "scalasemantic-mcp: offline — using cached $(basename "$JAR")" >&2
   fi
-}
-
-# Resumable download of $1 to file $2. curl `-C -` / wget `-c` continue a partial `.tmp` from a
-# previous (e.g. timed-out) attempt instead of restarting, so a slow first download completes
-# across the client's auto-reconnect retries. Returns the tool's exit status.
-fetch_file() {
-  if command -v curl >/dev/null 2>&1; then curl -fsSL --retry 3 -C - "$1" -o "$2"
-  elif command -v wget >/dev/null 2>&1; then wget -q -c -O "$2" "$1"
-  else echo "scalasemantic-mcp: need coursier, or curl/wget, on PATH" >&2; return 1
-  fi
-}
-
-# resolve version: explicit pin, else the latest release's tag_name
-TAG="${SCALASEMANTIC_VERSION:-}"
-if [ -z "$TAG" ]; then
-  TAG=$(fetch_stdout "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
-        | grep '"tag_name"' | head -1 | cut -d'"' -f4 || true)
-fi
-
-JAR="$CACHE/scalasemantic-mcp-${TAG:-unknown}.jar"
-
-# download if missing; download is resumable + atomic (rename only on a verified-complete .tmp)
-if [ -n "$TAG" ] && [ ! -f "$JAR" ]; then
-  URL="https://github.com/$REPO/releases/download/$TAG/scalasemantic-mcp.jar"
-  echo "scalasemantic-mcp: downloading $TAG ..." >&2
-  rc=0
-  set +e
-  fetch_file "$URL" "$JAR.tmp"
-  rc=$?
-  set -e
-  if [ "$rc" -ne 0 ] && [ -f "$JAR.tmp" ]; then
-    # A resume can fail with HTTP 416 when the .tmp is in fact already complete. Confirm by
-    # comparing sizes against the server's Content-Length; if they match, treat it as done.
-    remote=$(curl -fsSIL "$URL" 2>/dev/null | awk 'tolower($1) ~ /^content-length:/ {print $2}' | tr -d '\r' | tail -1)
-    local=$(wc -c < "$JAR.tmp" 2>/dev/null | tr -d ' ')
-    if [ -n "$remote" ] && [ "$remote" = "$local" ]; then rc=0; fi
-  fi
-  if [ "$rc" -eq 0 ]; then
-    mv -f "$JAR.tmp" "$JAR"
-  else
-    # Keep the partial `.tmp` so the next launch resumes it; fall through to any cached jar.
-    echo "scalasemantic-mcp: download incomplete (rc=$rc); will resume on next launch" >&2
-  fi
-fi
-if [ ! -f "$JAR" ]; then
-  JAR=$(ls -t "$CACHE"/scalasemantic-mcp-*.jar 2>/dev/null | head -1 || true)
-  [ -n "$JAR" ] || { echo "scalasemantic-mcp: cannot resolve a release and no cached jar found" >&2; exit 1; }
-  echo "scalasemantic-mcp: offline — using cached $(basename "$JAR")" >&2
 fi
 
 if [ "$PREFETCH" -eq 1 ]; then


### PR DESCRIPTION
Removes the jar download from the serve path so a launch never races the MCP client's connect timeout. Builds on the resumable-download + `--prefetch` work merged in #25.

## Launcher (`.sh` + `.ps1`)
Once **any** version is cached, a launch:
- serves the **newest cached jar immediately** (zero download latency), and
- forks a **detached background updater** (`--bg-fetch`, lock-guarded, resumable, atomic) that pulls the latest release for the **next** launch.

Empty cache → blocks on the download once (as before). Pinned `SCALASEMANTIC_VERSION` → fetches exactly that version and **skips** the background update.

## sbt plugin
`mcpClientConfig` now runs a **blocking `--prefetch`** at setup time, so the jar is cached before the first client connect instead of downloading on it. Best-effort — config printing still works offline. The generated `.mcp.json` also now includes `--log`/`--log-output`.

## Tested
- `sh -n` clean; sbt plugin compiles.
- `--bg-fetch` offline-safe: resolved + downloaded latest release, lock auto-cleaned, no leftover `.tmp`.
- Cached-serve branch execs `java -jar <cached>` instantly and forks the updater silently (no stdout corruption).

## Cold start after this
- sbt user → prefetch at setup ⇒ warm first connect.
- every later launch → instant serve, self-updates one version behind in the background.
- non-sbt first connect (empty cache) → still blocks once; run `--prefetch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)