### PR TITLE
build: bump-version tags origin/master directly so WIP never blocks a release

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,34 +8,21 @@
 #
 # Rules:
 # - Uses the highest existing v* semver tag if present, else FIRST_VERSION (scripts/config.sh).
-# - Switches to RELEASE_BRANCH (master by default), fast-forwards it from origin, and tags that commit.
+# - Tags the latest REMOTE RELEASE_BRANCH commit (origin/master by default) directly — it never
+#   switches branches or touches your working tree, so unrelated WIP on a feature branch does NOT
+#   block a release. Under the PR workflow this puts the tag on the merged commit, never a stale
+#   checkout or feature branch.
 # - Creates the tag locally; with --push, also pushes it to origin (which triggers the release).
 
 set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config.sh"
 
-usage() { sed -n '3,12p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '3,15p' "$0" | sed 's/^# \{0,1\}//'; }
 
-require_clean_git() {
-  if [[ -n "$(git status --short)" ]]; then
-    echo "Git worktree is not clean. Commit or stash changes before tagging." >&2
-    exit 1
-  fi
-}
-
-# Releases are cut from the latest remote release branch commit, so under a PR workflow the tag lands
-# on the merged commit, never a stale checkout or feature branch.
-switch_to_latest_release_branch() {
-  git fetch -q --tags origin "$RELEASE_BRANCH:refs/remotes/origin/$RELEASE_BRANCH"
-
-  if git show-ref --verify --quiet "refs/heads/${RELEASE_BRANCH}"; then
-    git switch -q "$RELEASE_BRANCH"
-  else
-    git switch -q --track -c "$RELEASE_BRANCH" "origin/${RELEASE_BRANCH}"
-  fi
-
-  git merge --ff-only -q "origin/${RELEASE_BRANCH}" || {
-    echo "${RELEASE_BRANCH} cannot fast-forward to origin/${RELEASE_BRANCH}. Resolve it before tagging." >&2
+# Update origin/RELEASE_BRANCH (and tags) without disturbing the current branch or working tree.
+fetch_release_branch() {
+  git fetch -q --tags origin "$RELEASE_BRANCH:refs/remotes/origin/$RELEASE_BRANCH" || {
+    echo "Failed to fetch origin/${RELEASE_BRANCH}." >&2
     exit 1
   }
 }
@@ -69,8 +56,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-require_clean_git
-switch_to_latest_release_branch
+fetch_release_branch
 
 current="$(latest_version)"
 if [[ -z "$current" ]]; then
@@ -85,8 +71,8 @@ if git rev-parse -q --verify "refs/tags/${new_tag}" >/dev/null; then
   exit 1
 fi
 
-git tag -a "$new_tag" -m "Release ${new_tag}" "HEAD"
-echo "Created tag ${new_tag} on ${RELEASE_BRANCH} ($(git rev-parse --short HEAD))"
+git tag -a "$new_tag" -m "Release ${new_tag}" "origin/${RELEASE_BRANCH}"
+echo "Created tag ${new_tag} on ${RELEASE_BRANCH} ($(git rev-parse --short "origin/${RELEASE_BRANCH}"))"
 
 if [[ "$push_tag" == "true" ]]; then
   git push origin "$new_tag"


### PR DESCRIPTION
## Problem
`scripts/bump-version.sh` called `require_clean_git` **on the current branch, before switching to master**. Running it from a feature branch with any uncommitted WIP aborted with:

```
Git worktree is not clean. Commit or stash changes before tagging.
```

— even though the release tag lands on master, not the feature branch. The clean-gate only existed because the script then did `git switch master` (which a dirty tree can break).

## Fix
Tag `origin/$RELEASE_BRANCH` **directly** — no branch switch, no working-tree dependency:

- `fetch_release_branch` updates `origin/master` + tags without touching the current branch.
- `git tag -a … origin/$RELEASE_BRANCH` tags the latest merged master commit.
- Removed `require_clean_git` and `switch_to_latest_release_branch`.

Net: a dirty/feature-branch checkout no longer blocks a release, and the tag still lands exactly on the latest merged master commit (the PR-workflow intent stated in the script's own header).

## Tested
`bash -n` clean; ran `bump-version.sh patch` with a deliberately dirty `README.md` → created `v0.3.6` on master commit `238b468` (= `origin/master`) with no clean-tree complaint. Local tag deleted, README restored. No `--push`, so nothing was released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)