### PR TITLE
feat(mcp): add annotated_source — read a Scala file with compiler insertions made explicit

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -126,6 +126,119 @@ final class Analyzer(
       case Some(v: s.ValueSignature)  => s": ${renderType(v.tpe)}"
       case _                          => ""
 
+  // --- annotated source -----------------------------------------------------
+
+  /** The compiler insertions invisible in the source of `uri`, as positioned annotations: the
+    * implicit arguments / conversions the compiler synthesised and the type arguments it inferred
+    * (both from SemanticDB `synthetics`), plus the inferred result/value type of every definition
+    * the source left unascribed. This is exactly what a plain text read of the file MISSES.
+    *
+    * `sourceLines` is the file's current text split on newlines — used only to drop a definition's
+    * inferred-type note when the source already states the type. `None` if `uri` is not indexed.
+    */
+  def sourceAnnotations(
+      uri: String,
+      sourceLines: IndexedSeq[String]
+  ): Option[List[SourceAnnotation]] =
+    index.document(uri).map { doc =>
+      val synthetic = doc.synthetics.iterator.flatMap(syntheticAnnotation).toList
+      val defTypes = doc.occurrences.iterator.flatMap(defTypeAnnotation(_, sourceLines)).toList
+      (synthetic ++ defTypes).distinct.sortBy(a => (a.line, a.character, a.kind))
+    }
+
+  /** An implicit-insertion or inferred-type-argument annotation for one synthetic, anchored at the
+    * synthetic's source range. The `kind` distinguishes notes whose range is a precise call site
+    * (`inferred-type-args`, `implicit-conversion`) from the using-argument note, whose range is the
+    * zero-width enclosing point and so carries no trustworthy column. `None` for synthetics we do
+    * not surface.
+    */
+  private def syntheticAnnotation(syn: s.Synthetic): Option[SourceAnnotation] =
+    val r = syn.range.getOrElse(s.Range.defaultInstance)
+    syn.tree match
+      case t: s.TypeApplyTree if t.typeArguments.nonEmpty =>
+        Some(
+          SourceAnnotation(
+            r.startLine,
+            r.startCharacter,
+            "inferred-type-args",
+            t.typeArguments.map(renderType).mkString("[", ", ", "]")
+          )
+        )
+      case app: s.ApplyTree =>
+        app.function match
+          // using-args appended to a visible call: the function IS the original expression, so the
+          // range is the enclosing point, not where the args belong — no reliable column.
+          case _: s.OriginalTree =>
+            val args = app.arguments.iterator.flatMap(insertedName).toList
+            Option.when(args.nonEmpty)(
+              SourceAnnotation(
+                r.startLine,
+                r.startCharacter,
+                "implicit",
+                args.mkString("(using ", ", ", ")")
+              )
+            )
+          // an implicit conversion wraps the original expression: the range pins the converted
+          // expression, so the column is meaningful.
+          case fn =>
+            insertedName(fn).map(c =>
+              SourceAnnotation(r.startLine, r.startCharacter, "implicit-conversion", s"$c(…)")
+            )
+      case _ => None
+
+  /** Best-effort display name of an inserted implicit tree (a given/implicit reference). */
+  private def insertedName(tree: s.Tree): Option[String] =
+    tree match
+      case t: s.IdTree        => Some(index.displayName(t.symbol))
+      case t: s.SelectTree    => t.id.flatMap(insertedName)
+      case t: s.TypeApplyTree => insertedName(t.function)
+      case t: s.ApplyTree     => insertedName(t.function)
+      case _                  => None
+
+  private val annotatedDefKinds: Set[s.SymbolInformation.Kind] =
+    Set(s.SymbolInformation.Kind.METHOD, s.SymbolInformation.Kind.FIELD)
+
+  /** The inferred result/value type of a definition occurrence, as a `: T` note — but only when the
+    * source line did not already ascribe a type (so explicitly-typed definitions stay un-noted).
+    */
+  private def defTypeAnnotation(
+      occ: s.SymbolOccurrence,
+      sourceLines: IndexedSeq[String]
+  ): Option[SourceAnnotation] =
+    if occ.role != s.SymbolOccurrence.Role.DEFINITION then None
+    else
+      index
+        .info(occ.symbol)
+        .filter(si => annotatedDefKinds.contains(si.kind) && si.displayName != "<init>")
+        .flatMap { si =>
+          val tpe = si.signature match
+            case m: s.MethodSignature => m.returnType
+            case v: s.ValueSignature  => v.tpe
+            case _                    => s.Type.Empty
+          val rendered = renderType(tpe)
+          val r = occ.range.getOrElse(s.Range.defaultInstance)
+          val line = sourceLines.lift(r.startLine).getOrElse("")
+          if rendered.isEmpty || alreadyAscribed(line, r.startCharacter) then None
+          else
+            Some(SourceAnnotation(r.startLine, r.startCharacter, "inferred-type", s": $rendered"))
+        }
+
+  /** Whether the definition whose name starts at `nameStart` on `line` already has an explicit type
+    * ascription: a top-level `:` (outside any `()`/`[]` group) before the `=` of its body.
+    */
+  private def alreadyAscribed(line: String, nameStart: Int): Boolean =
+    @annotation.tailrec
+    def scan(i: Int, depth: Int): Boolean =
+      if i >= line.length then false
+      else
+        line.charAt(i) match
+          case '=' if depth == 0 => false
+          case ':' if depth == 0 => true
+          case '(' | '['         => scan(i + 1, depth + 1)
+          case ')' | ']'         => scan(i + 1, depth - 1)
+          case _                 => scan(i + 1, depth)
+    nameStart >= 0 && nameStart < line.length && scan(nameStart, 0)
+
   // --- rename plan ----------------------------------------------------------
 
   /** The precise edits to rename `symbol` to `newName`: every compiler-resolved occurrence of its

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
@@ -181,6 +181,19 @@ case class OutlineEntry(
     children: List[OutlineEntry]
 ) derives ReadWriter
 
+// --- annotated source -------------------------------------------------------
+
+/** One compiler insertion that is invisible in a file's source text, anchored at a 0-based `(line,
+  * character)`. `kind` is one of `implicit` (a synthesised using-argument; its `character` is the
+  * enclosing point, NOT a precise column), `implicit-conversion` (an inserted conversion, precise
+  * `character`), `inferred-type-args` (type arguments the compiler inferred for a call, precise
+  * `character`), or `inferred-type` (the result/value type of a definition the source left
+  * unascribed). `text` is the rendered insertion, e.g. `(using sh)`, `toSeq(…)`, `[String]`, or `:
+  * Future[Int]`.
+  */
+case class SourceAnnotation(line: Int, character: Int, kind: String, text: String)
+    derives ReadWriter
+
 // --- rename plan ------------------------------------------------------------
 
 /** One edit in a rename: replace `oldText` in `range` of `uri` with `newText`. Ranges are the

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -61,6 +61,7 @@ object Mcp:
       |  the symbol for a plain name                        → find_symbol
       |  what's important / where to start, dep cycles       → structure
       |  a file's structure / where to edit (don't read it)  → document_outline
+      |  the full text of a .scala file (read it THIS way)   → annotated_source
       |  the exact edits to rename a symbol safely           → rename_plan
       |
       |Symbols: every tool except find_symbol and type_at_position takes a SemanticDB symbol string

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -514,6 +514,39 @@ object McpTools:
           )
     },
     tool(
+      "annotated_source",
+      "READ A SCALA FILE THIS WAY — use instead of cat/head/sed/Read for *.scala. Returns the file's " +
+        "source with the compiler's invisible insertions made explicit inline: the implicit " +
+        "arguments & conversions it synthesised, the type arguments it inferred, and the inferred " +
+        "result/value type of every definition the source left unascribed. Each note is appended to " +
+        "its line after `⟹` (with `col N`, 1-based, when it pins a precise spot); lines are 1-based. " +
+        "A plain text read MISSES all of this — this shows what the compiler actually sees. Pass " +
+        "`annotationsOnly` to get just the annotated lines. Pick the `format` for your need: " +
+        "`annotated` (default, densest — gutter + `⟹` notes, NOT valid Scala), `compilable` (notes as " +
+        "`// ⟹` comments, no gutter — valid pasteable Scala), or `plain` (the raw file, no notes). In " +
+        "`annotated`/`plain` the gutter is a READ-ONLY view: never paste it into code; edit the real " +
+        "file at `uri` (gutter numbers map 1:1).",
+      ("uri", "string", "document uri as it appears in SemanticDB (path relative to project root)")
+        :: SourceView.params,
+      List("uri")
+    ) { a =>
+      val uri = argStr(a, "uri")
+      val file = root.resolve(uri)
+      if !java.nio.file.Files.isRegularFile(file) then notFoundUri(uri)
+      else
+        val lines = java.nio.file.Files.readString(file).split("\n", -1).toIndexedSeq
+        az.sourceAnnotations(uri, lines) match
+          case None => notFoundUri(uri)
+          case Some(anns) =>
+            SourceView.result(
+              uri,
+              lines,
+              anns,
+              argStr(a, "format"),
+              argBool(a, "annotationsOnly", false)
+            )
+    },
+    tool(
       "rename_plan",
       "The precise edits to rename a symbol everywhere it is used. Returns every compiler-resolved " +
         "occurrence of the name (definitions + references) as `uri:line:col-col` ranges to replace " +
@@ -555,6 +588,105 @@ object McpTools:
     )
 
   // --- rendering helpers ----------------------------------------------------
+
+  /** Shared rendering for any tool that returns a WHOLE source file enriched with positioned
+    * [[SourceAnnotation]]s. Tools differ only in how they COMPUTE the annotations; the
+    * format/gutter/legend/`col N` handling and the result envelope live here so they are written
+    * once. A new source-returning tool just appends [[params]] to its schema and calls [[result]].
+    */
+  private object SourceView:
+
+    /** The schema entries every source-returning tool shares (append after its own `uri` entry). */
+    val params: List[(String, String, String)] = List(
+      (
+        "format",
+        "string",
+        "annotated (default, gutter + ⟹ notes) | compilable (// ⟹ comments, valid Scala) | plain"
+      ),
+      (
+        "annotationsOnly",
+        "boolean",
+        "return only the lines that carry an annotation, not the whole file (default false)"
+      )
+    )
+
+    /** The full tool result: the rendered `source` plus `format`, `annotationCount`, and `legend`.
+      * `format`/`annotationsOnly` arrive pre-parsed from the caller (which owns the `ujson`
+      * argument helpers) so this object stays self-contained — depending only on `ujson` and the
+      * model, never back on [[McpTools]] (which would form a dependency cycle).
+      */
+    def result(
+        uri: String,
+        lines: IndexedSeq[String],
+        anns: List[SourceAnnotation],
+        format: String,
+        annotationsOnly: Boolean
+    ): ujson.Value =
+      val fmt = normalize(format)
+      ujson.Obj(
+        "uri" -> ujson.Str(uri),
+        "format" -> ujson.Str(fmt),
+        "annotationCount" -> ujson.Num(anns.size),
+        "legend" -> ujson.Str(legend(fmt)),
+        "source" -> ujson.Str(render(lines, anns, fmt, annotationsOnly))
+      )
+
+    private def normalize(format: String): String =
+      format match
+        case "compilable" => "compilable"
+        case "plain"      => "plain"
+        case _            => "annotated"
+
+    /** Weave source lines and annotations into one string per the chosen format. */
+    private def render(
+        lines: IndexedSeq[String],
+        anns: List[SourceAnnotation],
+        fmt: String,
+        annotationsOnly: Boolean
+    ): String =
+      val byLine = anns.groupBy(_.line)
+      // `plain` shows no notes, so `annotationsOnly` would be empty — ignore it there.
+      val onlyAnnotated = fmt != "plain" && annotationsOnly
+      val gutter = fmt != "compilable" // a line-number gutter is not valid Scala
+      lines.iterator.zipWithIndex
+        .flatMap { case (src, i) =>
+          val notes = byLine.getOrElse(i, Nil)
+          if onlyAnnotated && notes.isEmpty then None
+          else
+            val base = if gutter then f"${i + 1}%5d  $src" else src
+            if notes.isEmpty || fmt == "plain" then Some(base)
+            else
+              val joined = notes.map(noteText).mkString("; ")
+              Some(if fmt == "compilable" then s"$base  // ⟹ $joined" else s"$base   ⟹ $joined")
+        }
+        .mkString("\n")
+
+    /** Kinds whose `character` is a precise call site, so a `col N` prefix points the reader at the
+      * exact call the note applies to (vs. the using-arg note, whose range is only the enclosing
+      * point).
+      */
+    private val preciseColKinds = Set("inferred-type-args", "implicit-conversion")
+
+    /** An annotation's display text, prefixed with a 1-based `col N` when its column is
+      * trustworthy.
+      */
+    private def noteText(n: SourceAnnotation): String =
+      if preciseColKinds.contains(n.kind) then s"col ${n.character + 1} ${n.text}" else n.text
+
+    private def legend(fmt: String): String =
+      val markers =
+        "Notes show compiler insertions invisible in the source: `(using …)` implicit args, " +
+          "`name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type; `col N` " +
+          "(1-based) pins the call a note applies to."
+      fmt match
+        case "compilable" =>
+          s"Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. $markers"
+        case "plain" =>
+          "The raw file with a 1-based line-number gutter (a READ-ONLY view — edit the real file " +
+            "at uri, not this). No annotations in this format."
+        case _ =>
+          s"READ-ONLY view, NOT valid Scala — do NOT paste into code; edit the real file at uri " +
+            s"(gutter line numbers map 1:1). ⟹ marks each note. $markers"
 
   /** Keep a module when no `pathFilter` is given, or when the glob (`*` = any chars) matches it. */
   private def moduleGlob(a: ujson.Value, module: String): Boolean =
@@ -621,6 +753,9 @@ object McpTools:
 
   private def notFound(symbol: String): ujson.Value =
     jobj(Some("symbol" -> ujson.Str(symbol)), Some("found" -> ujson.Bool(false)))
+
+  private def notFoundUri(uri: String): ujson.Value =
+    jobj(Some("uri" -> ujson.Str(uri)), Some("found" -> ujson.Bool(false)))
 
   /** Build an object from optional fields, dropping the absent ones (token discipline). */
   private def jobj(fields: Option[(String, ujson.Value)]*): ujson.Value =

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
@@ -39,15 +39,16 @@ class McpSuite extends munit.FunSuite:
     assert(instr.contains("find_symbol"), instr)
   }
 
-  test("tools/list exposes all thirteen tools with schemas") {
+  test("tools/list exposes all fourteen tools with schemas") {
     val r = Mcp.handle(req("tools/list", ujson.Obj()), tools).get
     val names = r("result")("tools").arr.map(_("name").str).toSet
-    assertEquals(names.size, 13)
+    assertEquals(names.size, 14)
     assert(names.contains("find_symbol"), names.toString)
     assert(names.contains("find_usages"), names.toString)
     assert(names.contains("call_path"), names.toString)
     assert(names.contains("structure"), names.toString)
     assert(names.contains("document_outline"), names.toString)
+    assert(names.contains("annotated_source"), names.toString)
     assert(names.contains("rename_plan"), names.toString)
     // every tool carries an object input schema
     assert(r("result")("tools").arr.forall(_("inputSchema")("type").str == "object"))
@@ -136,6 +137,45 @@ class McpSuite extends munit.FunSuite:
     assert(entries.exists(_("name").str == "Animal"), o.render())
     // a method/value entry renders a resolved signature (the clarified view)
     assert(entries.exists(_.obj.get("signature").exists(_.str.contains(":"))), o.render())
+  }
+
+  test("annotated_source surfaces compiler insertions invisible in the source text") {
+    // Resolve the fixtures file uri from a definition location, robust to the on-disk path.
+    val defLoc = call("find_usages", ujson.Obj("symbol" -> Show))("definitions").arr.head.str
+    val uri = defLoc.split(":").dropRight(2).mkString(":")
+    val r = call("annotated_source", ujson.Obj("uri" -> uri))
+    assert(r("annotationCount").num > 0, r.render())
+    val src = r("source").str
+    // numbered lines + the annotation marker for the compiler's invisible work
+    assert(src.linesIterator.exists(_.contains("⟹")), src)
+    // Sample.scala's `listShow` body inserts an inferred type arg and a synthesised using-arg.
+    assert(src.contains("[") && src.contains("using"), src)
+
+    // annotationsOnly trims to just the carrying lines (each one keeps the marker).
+    val only = call("annotated_source", ujson.Obj("uri" -> uri, "annotationsOnly" -> true))
+    assert(only("source").str.linesIterator.forall(_.contains("⟹")), only("source").str)
+  }
+
+  test("annotated_source format: plain strips notes, compilable comments them out") {
+    val defLoc = call("find_usages", ujson.Obj("symbol" -> Show))("definitions").arr.head.str
+    val uri = defLoc.split(":").dropRight(2).mkString(":")
+
+    // plain: the raw file, no annotation markers at all
+    val plain = call("annotated_source", ujson.Obj("uri" -> uri, "format" -> "plain"))
+    assertEquals(plain("format").str, "plain")
+    assert(!plain("source").str.contains("⟹"), "plain must carry no notes")
+
+    // compilable: notes become trailing `// ⟹` comments and the gutter is dropped
+    val comp = call("annotated_source", ujson.Obj("uri" -> uri, "format" -> "compilable"))
+    val src = comp("source").str
+    assert(src.contains("// ⟹"), src)
+    // no line-number gutter → the first source line starts at column 0, not padded digits
+    assert(!src.linesIterator.next().matches("""\s+\d+\s+\S.*"""), src.linesIterator.next())
+  }
+
+  test("annotated_source reports found:false for an unknown uri") {
+    val r = call("annotated_source", ujson.Obj("uri" -> "does/not/exist.scala"))
+    assertEquals(r("found").bool, false)
   }
 
   test("rename_plan returns precise, resolved edits (no grep over-match)") {
@@ -338,5 +378,5 @@ class McpSuite extends munit.FunSuite:
     // 4 lines in (one blank, one notification) → 2 responses out, with matching ids
     assertEquals(out.size, 2)
     assertEquals(ujson.read(out(0))("id").num, 1.0)
-    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 13)
+    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 14)
   }


### PR DESCRIPTION
## What

New MCP tool **`annotated_source`** — read a `*.scala` file instead of `cat`/`Read`. Returns the source enriched inline with the compiler's *invisible* insertions, pulled from SemanticDB:

- synthesised **implicit/using args** and **implicit conversions**
- **inferred type arguments** for calls
- **inferred result/value type** of every definition the source left unascribed (with a depth-aware ascription check so explicitly-typed defs stay un-noted)

A plain text read misses all of this. Example (real output on the fixtures):

```
   40    given listShow[A](using s: Show[A]): Show[List[A]] with   ⟹ (using s)
   41      def show(a: List[A]): String = a.map(s.show).mkString(",")   ⟹ col 36 [String]
```

## Notes & format

- Each note is appended after `⟹`, with a 1-based `col N` on notes whose synthetic range pins a precise call (inferred type args, conversions); using-args stay bare since their range is only the enclosing point.
- A **`format`** param picks the view: `annotated` (default, gutter + `⟹`, densest), `compilable` (notes as `// ⟹` comments, no gutter — valid pasteable Scala), `plain` (raw file). The description + per-format `legend` make clear the `annotated`/`plain` views are READ-ONLY and must not be pasted into code.
- The format/gutter/legend/`col N` rendering is extracted into a self-contained `SourceView` so future source-returning tools reuse it.

## Tests

- mcp 26/26, analysis 57/57.
- Dogfooding caught a real dependency cycle introduced by the first cut of `SourceView` (it called back into `McpTools`); fixed by making `SourceView` depend only on `ujson` + the model. `AnalyzerStructureSuite` (no-cycle assertion) now green.