### PR TITLE
chore: format on commit (pre-commit hook), verify-only pre-push

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# Auto-format the commit so it is born clean: scalafmt rewrites the sources, then we re-stage them
+# so the fixes land INSIDE this commit (a pre-commit hook stages into the in-progress commit, so
+# there is no post-commit drift and no extra commit — unlike formatting in pre-push). pre-push then
+# only VERIFIES (scalafmtCheckAll), catching anything that slipped past (e.g. a --no-verify commit).
+# Skip with: git commit --no-verify, or PRECOMMIT_SKIP=1 git commit.
+[ "${PRECOMMIT_SKIP:-0}" = "1" ] && exit 0
+echo "[pre-commit] formatting staged Scala (sbt scalafmtAll)..."
+sbt -batch scalafmtAll || exit 1
+# Re-stage tracked files scalafmt may have rewritten so the formatting is part of this commit.
+git add -u

--- a/build.sbt
+++ b/build.sbt
@@ -297,6 +297,9 @@ lazy val root = (project in file("."))
   .aggregate(core, pc, analysis, mcp, sbtPlugin)
   .settings(name := "ScalaSemantic", publish / skip := true)
 
-// Pre-push gate. A command alias (not a task) so clean/format/fix/test aggregate across all
-// modules. `testOnly *` forces the full suite (sbt 2.0 `test` is cached testQuick — see docs/research/plan.md).
-addCommandAlias("prePush", "clean; scalafmtAll; scalafixAll; Test/testOnly *")
+// Pre-push gate. A command alias (not a task) so the steps aggregate across all modules. This is a
+// VERIFY-ONLY gate (mirrors CI): scalafmtCheckAll + scalafixAll --check FAIL the push on drift rather
+// than silently rewriting files (a pre-push rewrite lands post-commit and never gets pushed — CI then
+// rejects it). Formatting is applied earlier by the pre-commit hook; here we only confirm it stuck.
+// `testOnly *` forces the full suite (sbt 2.0 `test` is cached testQuick — see docs/research/plan.md).
+addCommandAlias("prePush", "clean; scalafmtCheckAll; scalafixAll --check; Test/testOnly *")


### PR DESCRIPTION
## Why

The `prePush` gate ran `scalafmtAll` (mutate, not check). That fix landed in the working tree **after** the commit object was created, so it was never pushed — and CI's `scalafmtCheckAll` (verify) then rejected the unformatted commit (exactly what happened on #29). A pre-push hook also can't fix this by auto-committing: `git push` resolves the SHA to send **before** the hook runs, so a hook-made commit isn't shipped this round.

## What

Move formatting to where the fix lands *inside* the commit, and make the push gate verify-only:

- **`.githooks/pre-commit`** — runs `sbt scalafmtAll` then `git add -u`, so formatting is part of the commit being created. A pre-commit hook stages into the in-progress commit (doesn't create a new one), so there's no post-commit drift, no extra commit, and no loop. Skip with `PRECOMMIT_SKIP=1`.
- **`prePush` alias** → `clean; scalafmtCheckAll; scalafixAll --check; Test/testOnly *` — **verify-only**, fails the push on drift instead of silently rewriting. Mirrors CI, so green-locally ⇒ green-in-CI.

## Verified

- `scalafmtCheckAll` + `scalafixAll --check` accepted and green on master.
- This very commit was created through the new pre-commit hook; the push went through the new verify-only gate.