### PR TITLE
chore(scripts): bump-* scripts always push the tag (release on run)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ PR-based: branch protection on master, squash-merge PRs with **Conventional-Comm
 for everything else). Version is the git tag (`vX.Y.Z`); pushing a tag publishes to Maven Central
 via `sbt-ci-release`.
 
-Cut a release on demand from a synced master: `scripts/bump-{fix,minor,major}.sh --push` (guarded to
-refuse anything but an up-to-date master). The tag push drives CI: Maven publish + the GitHub Release.
+Cut a release on demand: `scripts/bump-{fix,minor,major}.sh` tags the latest `origin/master` commit
+and pushes the tag (no opt-in — pushing is unconditional). The tag push drives CI: Maven publish +
+the GitHub Release.
 
 **Release notes are GENERATED — never hand-edit them.** [`scripts/changelog.sh`](scripts/changelog.sh)
 keeps only user-facing Conventional-Commit types (`feat`/`fix`/`perf` + breaking) and OMITS

--- a/docs/project/releasing.md
+++ b/docs/project/releasing.md
@@ -31,11 +31,11 @@ If you supply a value that is *already* base64, set `PGP_SECRET_BASE64_ENCODE=fa
 ## Cut a release
 
 Development is PR-based (branch protection on `master`, squash-merge). A release is just a tag on the
-latest `origin/master` commit; the bump script switches to `master`, fetches the latest remote commit,
-fast-forwards, tags it, and optionally pushes the tag:
+latest `origin/master` commit; the bump script tags that remote commit directly and pushes the tag
+(unconditionally — pushing is the whole point):
 
 ```sh
-scripts/bump-version.sh minor --push     # or bump-fix/bump-minor/bump-major — tags vX.Y.Z and pushes
+scripts/bump-version.sh minor            # or bump-fix/bump-minor/bump-major — tags vX.Y.Z and pushes
 scripts/check-push-workflow.sh           # wait for CI, report the latest published version
 scripts/retry-last-tag.sh --push         # move the tag to HEAD to retry a release that failed early
 ```

--- a/docs/research/plan.md
+++ b/docs/research/plan.md
@@ -65,7 +65,7 @@ Three sbt modules, one per layer: `mcp` → `analysis` → `core`.
 - **Version from tags:** sbt-dynver — a `vX.Y.Z` tag publishes `X.Y.Z`. No manual version.
 - **Workflow:** `.github/workflows/ci.yml` — build+test on push/PR; `publish` job on `v*` tags runs `sbt ci-release`. Central host via `SONATYPE_CREDENTIAL_HOST=central.sonatype.com` env (the `sonatypeCredentialHost` setting isn't exposed in build.sbt here). Secrets: `SONATYPE_USERNAME`/`PASSWORD` (Central token), `PGP_SECRET`/`PASSPHRASE`.
 - **Scope:** `core`, `analysis`, `mcp`, `sbt-plugin` publish; `root` aggregate has `publish/skip := true`.
-- **Release ergonomics:** `scripts/bump-version.sh [patch|minor|major] --push`, `scripts/retry-last-tag.sh --push`.
+- **Release ergonomics:** `scripts/bump-version.sh [patch|minor|major]` (tags origin/master + pushes), `scripts/retry-last-tag.sh --push`.
 
 ## Backlog
 - **`reload` MCP tool** (later): re-read `*.semanticdb` from disk without restarting the server (re-run `SemanticIndex.fromProject`). SemanticDB only updates on compile, and the server loads the index once at startup — a reload tool pairs with `sbt ~compile` for near-live analysis.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,7 +4,7 @@
 # (sbt-dynver derives the published version from the tag).
 #
 # Usage:
-#   scripts/bump-version.sh [patch|minor|major] [--push]
+#   scripts/bump-version.sh [patch|minor|major]
 #
 # Rules:
 # - Uses the highest existing v* semver tag if present, else FIRST_VERSION (scripts/config.sh).
@@ -12,7 +12,8 @@
 #   switches branches or touches your working tree, so unrelated WIP on a feature branch does NOT
 #   block a release. Under the PR workflow this puts the tag on the merged commit, never a stale
 #   checkout or feature branch.
-# - Creates the tag locally; with --push, also pushes it to origin (which triggers the release).
+# - Creates the tag AND pushes it to origin, which triggers the release. Pushing is unconditional —
+#   there is no opt-in. (`--push` is still accepted for backwards compatibility, but is now a no-op.)
 
 set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config.sh"
@@ -45,12 +46,11 @@ next_version() {
 }
 
 bump_type="${1:-}"
-push_tag="false"
 [[ "$bump_type" == "-h" || "$bump_type" == "--help" || -z "$bump_type" ]] && { usage; exit 0; }
 shift || true
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --push) push_tag="true"; shift ;;
+    --push) shift ;; # deprecated no-op: pushing (and thus releasing) is now unconditional
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
@@ -74,7 +74,5 @@ fi
 git tag -a "$new_tag" -m "Release ${new_tag}" "origin/${RELEASE_BRANCH}"
 echo "Created tag ${new_tag} on ${RELEASE_BRANCH} ($(git rev-parse --short "origin/${RELEASE_BRANCH}"))"
 
-if [[ "$push_tag" == "true" ]]; then
-  git push origin "$new_tag"
-  echo "Pushed ${new_tag} to origin (release workflow will run)"
-fi
+git push origin "$new_tag"
+echo "Pushed ${new_tag} to origin (release workflow will run)"

--- a/scripts/setup-gh-repo.sh
+++ b/scripts/setup-gh-repo.sh
@@ -69,4 +69,4 @@ done
 gh api -H "Accept: application/vnd.github+json" --method PUT "/repos/${REPO}/vulnerability-alerts" >/dev/null
 echo "Enabled vulnerability alerts and dependency graph"
 
-echo "Done. Repo ${REPO} is ready for tag-driven releases (scripts/bump-version.sh ... --push)."
+echo "Done. Repo ${REPO} is ready for tag-driven releases (scripts/bump-version.sh patch|minor|major)."


### PR DESCRIPTION
## What

`scripts/bump-{fix,minor,major}.sh` now **creates the `vX.Y.Z` tag on the latest `origin/master` commit AND pushes it**, which triggers the release. Pushing is unconditional — no `--push` opt-in.

- The `--push` flag is still accepted as a deprecated no-op, so existing callers/docs don't break.
- Tagging still targets `origin/master` directly (unchanged) — no branch switch, working tree untouched, WIP never blocks a release.

## Why

`--push` being opt-in meant a bare `bump-fix.sh` created the tag locally but never released it (the tag just sat unpushed). Running a bump script should *be* the release.

## Docs

Dropped `--push` from the bump examples in `CLAUDE.md`, `docs/project/releasing.md`, `docs/research/plan.md`, and `scripts/setup-gh-repo.sh`. (`retry-last-tag.sh --push` is unchanged — different tool, still explicit.)