### PR TITLE
Clarify technical MCP flow in ScalaSemantic article

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ For a Scala developer, that means an agent can answer questions like:
 - which `given` can satisfy a type;
 - how one method can call another across the project.
 
-It is exposed over [MCP](https://modelcontextprotocol.io), so clients such as Claude Code can call it
-as a local tool while you keep using your normal Scala build.
+It is exposed over [MCP](https://modelcontextprotocol.io), so clients such as Claude Code, Codex, and
+Gemini CLI can call it as a local tool while you keep using your normal Scala build.
 
 📖 **Documentation site: <https://mercurievv.github.io/ScalaSemantic/>** (mdoc-checked, so its code
 samples are executed at build time).
@@ -43,14 +43,14 @@ Full trade-offs, including where `grep` wins:
 Your MCP client spawns the server over stdio. Two things are needed (only a **JVM** — no coursier, no sbt):
 
 1. the target project **compiled with SemanticDB** (`semanticdbEnabled := true`);
-2. a `.mcp.json` entry that launches the server with that project's root as its argument.
+2. MCP client config that launches the server with that project's root as its argument.
 
 Pick one setup:
 
 ### sbt plugin — recommended
 
-Least manual: works on sbt 1 and sbt 2, enables SemanticDB, and generates the `.mcp.json` for you; the
-jar arrives on first spawn.
+Least manual: works on sbt 1 and sbt 2, enables SemanticDB, and generates MCP client config for you;
+the jar arrives on first spawn.
 
 ```scala
 // project/plugins.sbt — replace x.y.z with the latest release (see the badge / releases page)
@@ -61,16 +61,20 @@ enablePlugins(ScalaSemanticMcpPlugin)
 
 Latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0) · [GitHub releases](https://github.com/MercurieVV/ScalaSemantic/releases/latest)
 
-`sbt mcpClientConfig` prints the entry; `sbt mcpRun` runs the server for testing.
+`sbt mcpClientConfig` prints the config; `sbt mcpRun` runs the server for testing. The default
+`mcpClient := "claude"` emits `.mcp.json`-style JSON. Set `mcpClient := "codex"` for Codex
+`config.toml`, `mcpClient := "gemini"` for Gemini CLI JSON, `mcpClient := "cline"` for Cline,
+`mcpClient := "roo"` for Roo Code, `mcpClient := "continue"` for Continue YAML, or
+`mcpClient := "generic-json"` for other MCP clients.
 
 ### Any build tool / OS
 
 - **Auto-download launcher** — `curl -fsSL .../scripts/install.sh | sh` (Windows: `…ps1`), then set
-  `.mcp.json` `command` to `~/.local/bin/scalasemantic-mcp`. Fetches + caches the fat jar on first run.
+  your MCP client `command` to `~/.local/bin/scalasemantic-mcp`. Fetches + caches the fat jar on first run.
 - **Plain `java -jar`** — grab `scalasemantic-mcp.jar` from the
   [latest release](https://github.com/MercurieVV/ScalaSemantic/releases/latest) and run it directly.
 
-**Optional launcher flags** — append to the `.mcp.json` `args` after the project root (the launcher
+**Optional launcher flags** — append to the MCP client `args` after the project root (the launcher
 forwards them to the server; equivalent env vars in parentheses):
 
 - `--prefetch` — download + cache the jar, then exit without serving.

--- a/docs/articles/it-hurts-to-watch-ai-grep-my-scala.md
+++ b/docs/articles/it-hurts-to-watch-ai-grep-my-scala.md
@@ -47,6 +47,81 @@ Most answers come from SemanticDB, so they reflect your last build. If the build
 
 The presentation compiler can also inspect code you just typed and have not built yet, but not every tool uses it yet. And nothing here tries to understand comments or arbitrary plain text. For those, grep is still the right tool — and the server can tell the AI when to use it.
 
+## How it works, technically
+
+ScalaSemantic is deliberately boring infrastructure.
+
+It is a local MCP server. Your AI client starts it as a normal process over stdio, then sends JSON-RPC tool calls to it. There is no daemon to manage, no editor plugin protocol to reverse-engineer, and no dependency on a specific AI vendor. Claude Code, Codex, Gemini CLI, Cline, Roo Code, Continue, or any other MCP client can spawn the same process.
+
+The main input is SemanticDB. When your Scala project compiles with SemanticDB enabled, the compiler writes `*.semanticdb` files containing resolved symbols, definitions, references, types, and synthetics. ScalaSemantic loads those files, walks the documents, and builds an in-memory index that can answer questions about the compiled program.
+
+That index is why the tools can be more precise than text search:
+
+- `find_symbol` maps a plain name to real SemanticDB symbols.
+- `find_usages` finds references to that exact symbol, not just the same text.
+- `class_hierarchy` follows inheritance relationships.
+- `method_signature` renders the compiler-known signature.
+- `resolve_implicits` and `trace_implicit_chain` expose given/implicit relationships.
+- `call_path` uses recorded relationships to find a path between methods.
+- `annotated_source` can show compiler insertions that are not obvious in the source text.
+
+I kept the server read-only on purpose. It does not run your build, mutate files, or try to be an IDE. The build tool remains responsible for compiling. The MCP server reads the compiler output and answers semantic questions from it. That boundary matters: it makes the tool predictable, easy to launch from different AI clients, and safe to point at real projects.
+
+There is a second path for fresher local context: if the server gets the target project's compile classpath, it can create a presentation-compiler backend. That is useful for position-local tools, because an AI client may send source text from an unsaved or not-yet-compiled buffer. SemanticDB remains the durable project-wide index; the presentation compiler is the overlay for live source.
+
+The implementation is split around that boundary:
+
+- `core` loads and indexes SemanticDB.
+- `analysis` turns that index into semantic queries and compact result models.
+- `pc` wraps the Scala presentation compiler for live source overlays.
+- `mcp` exposes those queries as stdio MCP tools.
+- `sbt-plugin` makes host projects emit SemanticDB and prints the MCP client configuration.
+
+The annoying part was not the algorithm. The annoying part was the integration shape. An AI client needs clean stdout for JSON-RPC, so `sbt run` is wrong because sbt writes logs to stdout. The server must run as its own JVM. The launcher exists mostly to make that boring: it downloads or resolves the server, keeps protocol output clean, and lets the MCP client start it like any other stdio server.
+
+## Minimal setup for an sbt project
+
+For sbt, use the plugin. It enables SemanticDB, installs the launcher, warms the server cache, writes the compile classpath file used by the presentation-compiler backend, and prints the config for your MCP client.
+
+Add the plugin:
+
+```scala
+// project/plugins.sbt
+addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "x.y.z")
+```
+
+Enable it:
+
+```scala
+// build.sbt
+enablePlugins(ScalaSemanticMcpPlugin)
+```
+
+Then compile and ask the plugin for client config:
+
+```sh
+sbt compile
+sbt mcpClientConfig
+```
+
+By default it prints Claude-style `.mcp.json`. Pick another client with `mcpClient`:
+
+```scala
+mcpClient := "claude"       // default
+mcpClient := "codex"        // Codex config.toml
+mcpClient := "gemini"       // Gemini CLI settings JSON
+mcpClient := "cline"        // Cline MCP JSON
+mcpClient := "roo"          // Roo Code MCP JSON
+mcpClient := "continue"     // Continue config.yaml
+mcpClient := "generic-json" // standard mcpServers JSON
+```
+
+The generated config points the AI client at the launcher and passes two important arguments: the project root, where SemanticDB is loaded from, and a classpath file, which enables the presentation-compiler overlay. Paste the printed config into your client, restart the client/session, and ask a Scala question that should use semantic information.
+
+For non-sbt projects, the same rule applies: make the build emit SemanticDB, install or download the launcher, and register it as a stdio MCP server with the project root as the first argument. The integration guide has the manual config shapes.
+
+One practical note: recompile when the code changes. The project-wide answers come from compiler output on disk. If the AI asks a question about code you have not compiled yet, the answer can be stale unless the relevant tool can use the presentation-compiler overlay.
+
 ## The point
 
 Here is the part I keep thinking about.

--- a/docs/articles/it-hurts-to-watch-ai-grep-my-scala.md
+++ b/docs/articles/it-hurts-to-watch-ai-grep-my-scala.md
@@ -45,43 +45,71 @@ It is not magic.
 
 Most answers come from SemanticDB, so they reflect your last build. If the build is stale, the data can be stale too.
 
-The presentation compiler can also inspect code you just typed and have not built yet, but not every tool uses it yet. And nothing here tries to understand comments or arbitrary plain text. For those, grep is still the right tool — and the server can tell the AI when to use it.
+The presentation compiler can also inspect code you just typed and have not built yet, but not every tool uses it yet. And nothing here tries to understand comments or arbitrary plain text. For those, grep is still the right tool — and ScalaSemantic can tell the AI when to use it.
+
+## The point
+
+Here is the part I keep thinking about.
+
+We spent years building compilers that understand our code precisely. Then we handed the code to AI assistants and let them read it with the simplest tool available.
+
+That is a little strange.
+
+The structured knowledge already exists. Someone just had to connect it.
+
+So I connected it.
+
+Now the AI can ask the compiler. It is faster, cheaper, and stops embarrassing itself in front of my code.
+
+A small win. But an honest one.
 
 ## How it works, technically
 
-ScalaSemantic is deliberately boring infrastructure.
+### Query flow
 
-It is a local MCP server. Your AI client starts it as a normal process over stdio, then sends JSON-RPC tool calls to it. There is no daemon to manage, no editor plugin protocol to reverse-engineer, and no dependency on a specific AI vendor. Claude Code, Codex, Gemini CLI, Cline, Roo Code, Continue, or any other MCP client can spawn the same process.
+```text
+LLM                              asks a Scala question
+  -> MCP client                  chooses a tool and validates arguments
+  -> stdio JSON-RPC              sends the tool call as protocol messages
+  -> ScalaSemantic               runs the semantic query
+  -> SemanticDB / live compiler  provides compiler facts
+  -> filter + transform          keeps only the useful result
+  -> compact MCP response        returns JSON
+  -> LLM context                 receives exact symbols, locations, signatures, or relationships
+```
 
-The main input is SemanticDB. When your Scala project compiles with SemanticDB enabled, the compiler writes `*.semanticdb` files containing resolved symbols, definitions, references, types, and synthetics. ScalaSemantic loads those files, walks the documents, and builds an in-memory index that can answer questions about the compiled program.
+Read the diagram left to right. After initialization, `tools/call` runs one query with JSON arguments. The result goes back as compact JSON inside the MCP response, ready to be added to the model's context.
 
-That index is why the tools can be more precise than text search:
+Once the request reaches ScalaSemantic, **the answer comes from compiler facts, not source-text matches.** With `SemanticDB` enabled, scalac records the semantic view of each source file: definitions, references, symbols, signatures, inferred types, and synthetics. The relationships in that compiler data are the important part: they tell us what the code means after name resolution, type inference, and desugaring. That is why the tool starts from SemanticDB instead of an AST or grep output: the hard Scala work has already been done by the compiler.
 
-- `find_symbol` maps a plain name to real SemanticDB symbols.
-- `find_usages` finds references to that exact symbol, not just the same text.
-- `class_hierarchy` follows inheritance relationships.
-- `method_signature` renders the compiler-known signature.
-- `resolve_implicits` and `trace_implicit_chain` expose given/implicit relationships.
-- `call_path` uses recorded relationships to find a path between methods.
-- `annotated_source` can show compiler insertions that are not obvious in the source text.
+That leads to the core lookup model: **most tools operate on SemanticDB symbols.** A symbol is not just a method name like `run`; it includes the owner and descriptor, so two unrelated `run` methods are different values. This makes the protocol a little more explicit, but it prevents the model from guessing which overloaded, imported, inherited, or renamed thing the user meant. The usual LLM flow is therefore resolve first, then query:
 
-I kept the server read-only on purpose. It does not run your build, mutate files, or try to be an IDE. The build tool remains responsible for compiling. The MCP server reads the compiler output and answers semantic questions from it. That boundary matters: it makes the tool predictable, easy to launch from different AI clients, and safe to point at real projects.
+1. call `find_symbol` or `type_at_position` to get the exact SemanticDB symbol;
+2. pass that symbol to a narrower tool such as `find_usages`, `method_signature`, `class_hierarchy`, or `call_path`.
 
-There is a second path for fresher local context: if the server gets the target project's compile classpath, it can create a presentation-compiler backend. That is useful for position-local tools, because an AI client may send source text from an unsaved or not-yet-compiled buffer. SemanticDB remains the durable project-wide index; the presentation compiler is the overlay for live source.
+The tools line up with that model:
 
-The implementation is split around that boundary:
+- `find_symbol` resolves a human name to candidate SemanticDB symbols.
+- `find_usages` returns occurrences of that exact symbol.
+- `method_signature` renders the signature recorded by the compiler.
+- `class_hierarchy`, `members`, and `call_path` derive relationships from the resolved symbol graph.
+- `resolve_implicits`, `trace_implicit_chain`, and `annotated_source` expose compiler-inserted or inferred information that is easy to miss in the written source.
 
-- `core` loads and indexes SemanticDB.
-- `analysis` turns that index into semantic queries and compact result models.
-- `pc` wraps the Scala presentation compiler for live source overlays.
-- `mcp` exposes those queries as stdio MCP tools.
-- `sbt-plugin` makes host projects emit SemanticDB and prints the MCP client configuration.
+The compiled SemanticDB path covers the project-wide view. **The presentation compiler path covers code that has changed since the last compile.** When ScalaSemantic has the project's compile classpath, it can ask the presentation compiler to produce SemanticDB for the current buffer text. Position-local tools can use that regenerated document directly; tools that still need project context can overlay that document on top of the compiled project view. This split keeps whole-project queries stable while still letting local questions see unsaved or not-yet-compiled edits.
 
-The annoying part was not the algorithm. The annoying part was the integration shape. An AI client needs clean stdout for JSON-RPC, so `sbt run` is wrong because sbt writes logs to stdout. The server must run as its own JVM. The launcher exists mostly to make that boring: it downloads or resolves the server, keeps protocol output clean, and lets the MCP client start it like any other stdio server.
+That boundary is intentional. **The build tool remains responsible for compiling.** ScalaSemantic reads compiler output, answers semantic questions, and returns compact JSON through MCP. It does not try to become a second build tool or a hidden IDE. That makes failures easier to reason about: if project-wide data is stale, recompile; if a live-buffer query needs current text, use the presentation compiler path.
+
+The response is usually **compressed first and expanded only when useful**. By default, locations become `uri:line:col`, signatures are one rendered line, related symbols are display names, and empty fields are dropped. Some tools can then explode that view on request: `detailed` returns structured fields, `include` selects result sections, `find_usages` pages with `limit`/`offset`, and `annotated_source` can render as `annotated`, `compilable`, or `plain` with optional `annotationsOnly`. The point is token control: the LLM gets the smallest precise answer first, but can ask for the richer Scala-shaped view when it needs to edit or reason deeper.
+
+### Initialization
+
+MCP initialization is separate from the query itself. The client starts ScalaSemantic as a local stdio process and speaks JSON-RPC to it. `initialize` returns instructions, and `tools/list` returns tool names plus JSON Schemas. This keeps ScalaSemantic independent from any one AI client: Claude Code, Codex, Gemini CLI, Cline, Roo Code, Continue, or another MCP client can all use the same process.
+
+The launcher exists mostly to keep the process boundary clean: an AI client needs protocol-only stdout, while `sbt run` writes build logs there, so ScalaSemantic runs as its own JVM process. Logs and diagnostics must stay away from stdout because stdout is the JSON-RPC transport. Boring process isolation matters here: one stray log line can corrupt the protocol stream.
 
 ## Minimal setup for an sbt project
 
-For sbt, use the plugin. It enables SemanticDB, installs the launcher, warms the server cache, writes the compile classpath file used by the presentation-compiler backend, and prints the config for your MCP client.
+For sbt, use the plugin. It enables SemanticDB, installs the launcher, warms the ScalaSemantic cache, writes the compile classpath file used by the presentation-compiler backend, and prints the config for your MCP client.
 
 Add the plugin:
 
@@ -104,39 +132,17 @@ sbt compile
 sbt mcpClientConfig
 ```
 
-By default it prints Claude-style `.mcp.json`. Pick another client with `mcpClient`:
+By default it prints Claude-style `.mcp.json`, which you paste into your client config manually for now. Pick another client with `mcpClient`:
 
 ```scala
-mcpClient := "claude"       // default
-mcpClient := "codex"        // Codex config.toml
-mcpClient := "gemini"       // Gemini CLI settings JSON
-mcpClient := "cline"        // Cline MCP JSON
-mcpClient := "roo"          // Roo Code MCP JSON
-mcpClient := "continue"     // Continue config.yaml
-mcpClient := "generic-json" // standard mcpServers JSON
+mcpClient := "codex"
 ```
 
-The generated config points the AI client at the launcher and passes two important arguments: the project root, where SemanticDB is loaded from, and a classpath file, which enables the presentation-compiler overlay. Paste the printed config into your client, restart the client/session, and ask a Scala question that should use semantic information.
+Supported values: `claude` (default), `codex`, `gemini`, `cline`, `roo`, `continue`, `generic-json`.
 
-For non-sbt projects, the same rule applies: make the build emit SemanticDB, install or download the launcher, and register it as a stdio MCP server with the project root as the first argument. The integration guide has the manual config shapes.
+Paste the generated config into your MCP client and restart the session. For non-sbt projects, emit SemanticDB and register ScalaSemantic with the project root.
 
-One practical note: recompile when the code changes. The project-wide answers come from compiler output on disk. If the AI asks a question about code you have not compiled yet, the answer can be stale unless the relevant tool can use the presentation-compiler overlay.
-
-## The point
-
-Here is the part I keep thinking about.
-
-We spent years building compilers that understand our code precisely. Then we handed the code to AI assistants and let them read it with the simplest tool available.
-
-That is a little strange.
-
-The structured knowledge already exists. Someone just had to connect it.
-
-So I connected it.
-
-Now the AI can ask the compiler. It is faster, cheaper, and stops embarrassing itself in front of my code.
-
-A small win. But an honest one.
+Important note. Recompile when code changes; project-wide answers come from compiler output on disk.
 
 ---
 

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -1,9 +1,9 @@
 # Integration
 
-An MCP **stdio** server is spawned by the MCP client (e.g. Claude Code), which owns its lifecycle —
-you don't run it as a daemon. Integrating means two things: make the project emit SemanticDB, and
-register a launch command scoped to that project's root. Because the unit is a plain process, the
-same approach works from any build tool.
+An MCP **stdio** server is spawned by the MCP client (for example Claude Code, Codex, Gemini CLI, or
+another coding agent), which owns its lifecycle — you don't run it as a daemon. Integrating means two
+things: make the project emit SemanticDB, and register a launch command scoped to that project's root.
+Because the unit is a plain process, the same approach works from any build tool.
 
 The server speaks newline-delimited JSON-RPC 2.0 on **stdout**; **stderr** carries only launcher
 download chatter. The server's own diagnostic logging is **off by default** (nothing is written) and,
@@ -33,18 +33,18 @@ file is what every launch option below runs with `java -jar`.
 
 ## Three ways to launch
 
-All three end at the same place: a `.mcp.json` entry that runs the server with the project root as its
-argument. Pick by how much you want automated.
+All three end at the same place: MCP client configuration that runs the server with the project root
+as its argument. Pick by how much you want automated.
 
 | | A — sbt plugin | B — auto-download script | C — plain `java -jar` |
 |---|---|---|---|
 | Get the jar | launcher downloads + caches it | script downloads + caches it | you download it once |
-| Write `.mcp.json` | `sbt mcpClientConfig` generates it | by hand (point at script) | by hand (point at `java`) |
+| Write client config | `sbt mcpClientConfig` generates it | by hand (point at script) | by hand (point at `java`) |
 | Enable SemanticDB | plugin does it | you (one line) | you (one line) |
 | Stays up to date | yes — pulls latest each launch | yes — pulls latest each launch | manual re-download |
 | Works with | sbt (1 and 2) | any OS / build tool | any OS / build tool |
 
-### Option A — sbt plugin (recommended; generates the `.mcp.json` for you)
+### Option A — sbt plugin (recommended; generates the client config for you)
 
 `io.github.mercurievv:sbt-scalasemantic-mcp` is cross-published for sbt 1 and sbt 2. The same
 `addSbtPlugin` line works in both; sbt resolves the matching plugin artifact for your build. The
@@ -65,7 +65,8 @@ or the [latest GitHub release](https://github.com/MercurieVV/ScalaSemantic/relea
 The plugin enables SemanticDB and adds:
 
 - `sbt mcpInstall` — writes the bundled auto-download launcher (Option B's script) into `target/`.
-- `sbt mcpClientConfig` — runs `mcpInstall`, then prints the `.mcp.json` entry pointing at that script.
+- `sbt mcpClientConfig` — runs `mcpInstall`, then prints the selected MCP client config pointing at
+  that script.
 - `sbt mcpRun` — runs the server in the foreground (stdio) for manual testing.
 
 So `enablePlugins` + `sbt mcpClientConfig` + paste is the whole setup — no jar to download by hand; the
@@ -73,13 +74,26 @@ written launcher fetches the server on first spawn (coursier if present, else th
 jar). To pin a fixed binary instead, override `mcpServerCommand`, e.g.
 `mcpServerCommand := Seq("java", "-jar", "/abs/path/to/scalasemantic-mcp.jar")`.
 
+Choose the generated client format with `mcpClient`:
+
+```scala
+mcpClient := "claude"       // default: Claude Code .mcp.json-style JSON
+mcpClient := "codex"        // Codex config.toml
+mcpClient := "gemini"       // Gemini CLI settings JSON
+mcpClient := "cline"        // Cline MCP JSON
+mcpClient := "roo"          // Roo Code MCP JSON
+mcpClient := "continue"     // Continue config.yaml
+mcpClient := "generic-json" // other MCP clients using the standard mcpServers JSON shape
+```
+
 The plugin only enables SemanticDB and shells out to `mcpServerCommand` — it never links against the
 Scala 3.8.4 server, which is why it is sbt-1/2 and build-tool portable.
 
 #### What `mcpClientConfig` generates
 
 The task takes `mcpServerCommand`, then appends the project's base directory, the classpath file, and
-the logging flags. With the default `mcpServerCommand` (the launcher `mcpInstall` writes) it emits:
+the logging flags. With the default `mcpServerCommand` (the launcher `mcpInstall` writes) and
+`mcpClient := "claude"` it emits:
 
 ```json
 {
@@ -99,6 +113,85 @@ unless these are present — drop them for the silent default). So overriding
 `"command": "java"` with `"-jar", "/abs/scalasemantic-mcp.jar"` leading those same trailing args.
 Generation logic:
 [`ScalaSemanticMcpPlugin.scala`](https://github.com/MercurieVV/ScalaSemantic/blob/master/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala).
+
+With `mcpClient := "codex"` it emits TOML for `~/.codex/config.toml` or a trusted project's
+`.codex/config.toml`:
+
+```toml
+[mcp_servers.scala-semantic]
+command = "~/.local/bin/scalasemantic-mcp"
+args = ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"]
+startup_timeout_sec = 60
+tool_timeout_sec = 60
+```
+
+The explicit timeouts avoid first-launch failures when the launcher has to resolve or download the
+server jar. `sbt mcpClientConfig` also prefetches the jar on a best-effort basis before printing the
+config.
+
+With `mcpClient := "gemini"` it emits JSON for Gemini CLI `~/.gemini/settings.json` or
+`.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "scala-semantic": {
+      "command": "~/.local/bin/scalasemantic-mcp",
+      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"],
+      "timeout": 60000
+    }
+  }
+}
+```
+
+With `mcpClient := "cline"` it emits JSON for Cline's MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "scala-semantic": {
+      "command": "~/.local/bin/scalasemantic-mcp",
+      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+With `mcpClient := "roo"` it emits JSON for Roo Code's global `mcp_settings.json` or project
+`.roo/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "scala-semantic": {
+      "command": "~/.local/bin/scalasemantic-mcp",
+      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"],
+      "disabled": false,
+      "alwaysAllow": [],
+      "timeout": 60
+    }
+  }
+}
+```
+
+With `mcpClient := "continue"` it emits YAML for Continue `config.yaml`:
+
+```yaml
+name: ScalaSemantic MCP
+version: 1.0.0
+schema: v1
+mcpServers:
+  - name: "scala-semantic"
+    command: "~/.local/bin/scalasemantic-mcp"
+    args:
+      - "/abs/path/to/this/project"
+      - "~/.local/bin/scala-semantic-classpath.txt"
+      - "--log"
+      - "--log-output"
+    connectionTimeout: 60000
+```
 
 ### Option B — auto-download launcher
 
@@ -125,7 +218,7 @@ prefetches for you), and after a new release the launcher keeps serving the prev
 more session before the background update takes effect. Pinning with `SCALASEMANTIC_VERSION` disables
 the background updater — you get exactly that version every launch.
 
-Install the launcher to a **stable path on PATH** (`~/.local/bin/scalasemantic-mcp`) so `.mcp.json`
+Install the launcher to a **stable path on PATH** (`~/.local/bin/scalasemantic-mcp`) so client config
 does not depend on where this repo is cloned — and, unlike the sbt dev launcher under `target/`, it
 survives `sbt clean`:
 

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -14,16 +14,16 @@ import scala.sys.process.Process
   * server binary need not be installed ahead of time. The same approach works on sbt 1, sbt 2,
   * other build tools, and a bare shell.
   *
-  * Lifecycle is client-managed: an MCP stdio server is spawned by the MCP client (e.g. Claude
-  * Code).
+  * Lifecycle is client-managed: an MCP stdio server is spawned by the MCP client (for example
+  * Claude Code, Codex, Gemini CLI, or another MCP-capable coding agent).
   *
   * Usage in a host build — minimal:
   * {{{
   *   enablePlugins(ScalaSemanticMcpPlugin)
   * }}}
-  * then `sbt mcpClientConfig` prints a ready-to-paste `.mcp.json` entry. Override
-  * `mcpServerCommand` to point at a fixed jar or `cs` instead of the bundled launcher if you
-  * prefer.
+  * then `sbt mcpClientConfig` prints ready-to-paste MCP client configuration. Set `mcpClient` to
+  * choose the output format. Override `mcpServerCommand` to point at a fixed jar or `cs` instead of
+  * the bundled launcher if you prefer.
   */
 object ScalaSemanticMcpPlugin extends AutoPlugin {
 
@@ -37,6 +37,10 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       )
     val mcpServerName =
       settingKey[String]("name to register this server under in the MCP client")
+    val mcpClient =
+      settingKey[String](
+        "MCP client config dialect to print: claude, codex, gemini, cline, roo, continue, or generic-json"
+      )
     @transient
     val mcpInstall =
       taskKey[File](
@@ -49,8 +53,10 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
         "write this project's compile classpath to a stable file and return it; the server reads " +
           "it to enable the presentation-compiler backend (live overlay of uncompiled buffers)"
       )
+    @transient
     val mcpClientConfig =
-      taskKey[Unit]("print the .mcp.json entry that registers this project's MCP server")
+      taskKey[Unit]("print the selected MCP client config that registers this project's server")
+    @transient
     val mcpRun =
       taskKey[Unit]("run the MCP server in the foreground (stdio) against this project")
   }
@@ -60,6 +66,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
   override def projectSettings = Seq(
     semanticdbEnabled := true,
     mcpServerName := "scala-semantic",
+    mcpClient := "claude",
     mcpInstall := writeLauncher(installDir, streams.value.log),
     mcpClasspathFile := {
       // The PC backend needs the target project's COMPILE classpath (deps + its own output) to
@@ -109,18 +116,8 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       val argv =
         resolvedCommand(mcpServerCommand.value, baseDirectory.value, cpFile) ++
           Seq("--log", "--log-output")
-      val argsJson = argv.tail.map(a => "\"" + a + "\"").mkString("[", ", ", "]")
-      log.info(
-        s"""|Register this in your MCP client (e.g. .mcp.json):
-            |{
-            |  "mcpServers": {
-            |    "${mcpServerName.value}": {
-            |      "command": "${argv.head}",
-            |      "args": $argsJson
-            |    }
-            |  }
-            |}""".stripMargin
-      )
+      val rendered = renderClientConfig(mcpClient.value, mcpServerName.value, argv)
+      log.info(s"Register this in ${rendered.destination}:\n${rendered.config}")
       if (!cpFile.exists)
         log.info(
           "Server will run index-only. Run `sbt mcpClasspathFile` once (requires a successful " +
@@ -222,4 +219,131 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
           "launch argv, e.g. Seq(\"java\",\"-jar\",\"scalasemantic-mcp.jar\")."
       )
     else command :+ baseDir.getAbsolutePath :+ classpathFile.getAbsolutePath
+
+  private final case class RenderedConfig(destination: String, config: String)
+
+  private def renderClientConfig(
+      client: String,
+      serverName: String,
+      argv: Seq[String]
+  ): RenderedConfig = {
+    val normalized = client.trim.toLowerCase.replace('_', '-')
+    normalized match {
+      case "codex" | "openai" | "openai-codex" =>
+        RenderedConfig(
+          "Codex config.toml (for example ~/.codex/config.toml or .codex/config.toml)",
+          renderCodexToml(serverName, argv)
+        )
+      case "claude" | "claude-code" | "anthropic" =>
+        RenderedConfig("Claude Code .mcp.json", renderMcpJson(serverName, argv, Nil))
+      case "gemini" | "google" | "google-gemini" | "gemini-cli" =>
+        RenderedConfig(
+          "Gemini CLI settings.json (for example ~/.gemini/settings.json or .gemini/settings.json)",
+          renderMcpJson(serverName, argv, Seq("timeout" -> "60000"))
+        )
+      case "cline" =>
+        RenderedConfig(
+          "Cline MCP JSON (for example ~/.cline/mcp.json or the IDE MCP settings JSON)",
+          renderMcpJson(serverName, argv, Seq("disabled" -> "false", "autoApprove" -> "[]"))
+        )
+      case "roo" | "roo-code" =>
+        RenderedConfig(
+          "Roo Code MCP JSON (for example .roo/mcp.json or global mcp_settings.json)",
+          renderMcpJson(
+            serverName,
+            argv,
+            Seq("disabled" -> "false", "alwaysAllow" -> "[]", "timeout" -> "60")
+          )
+        )
+      case "continue" | "continue-dev" =>
+        RenderedConfig("Continue config.yaml", renderContinueYaml(serverName, argv))
+      case "generic" | "generic-json" | "json" | "oss" | "open-source" | "free" =>
+        RenderedConfig("a generic MCP client JSON config", renderMcpJson(serverName, argv, Nil))
+      case other =>
+        sys.error(
+          s"Unsupported mcpClient '$other'. Use one of: " +
+            "claude, codex, gemini, cline, roo, continue, generic-json."
+        )
+    }
+  }
+
+  private def renderMcpJson(
+      serverName: String,
+      argv: Seq[String],
+      extraFields: Seq[(String, String)]
+  ): String = {
+    val argsJson = argv.tail.map(jsonString).mkString("[", ", ", "]")
+    val extra =
+      extraFields.map { case (name, value) => s",\n      ${jsonString(name)}: $value" }.mkString
+    s"""|{
+        |  "mcpServers": {
+        |    ${jsonString(serverName)}: {
+        |      "command": ${jsonString(argv.head)},
+        |      "args": $argsJson$extra
+        |    }
+        |  }
+        |}""".stripMargin
+  }
+
+  private def renderCodexToml(serverName: String, argv: Seq[String]): String = {
+    val argsToml = argv.tail.map(tomlString).mkString("[", ", ", "]")
+    s"""|[mcp_servers.${tomlKey(serverName)}]
+        |command = ${tomlString(argv.head)}
+        |args = $argsToml
+        |startup_timeout_sec = 60
+        |tool_timeout_sec = 60""".stripMargin
+  }
+
+  private def renderContinueYaml(serverName: String, argv: Seq[String]): String = {
+    val args =
+      if (argv.tail.isEmpty) ""
+      else argv.tail.map(a => s"\n      - ${yamlString(a)}").mkString("\n    args:", "", "")
+    s"""|name: ScalaSemantic MCP
+        |version: 1.0.0
+        |schema: v1
+        |mcpServers:
+        |  - name: ${yamlString(serverName)}
+        |    command: ${yamlString(argv.head)}$args
+        |    connectionTimeout: 60000""".stripMargin
+  }
+
+  private def tomlKey(value: String): String =
+    if (value.matches("[A-Za-z0-9_-]+")) value else tomlString(value)
+
+  private def jsonString(value: String): String =
+    "\"" + value.flatMap {
+      case '"'          => "\\\""
+      case '\\'         => "\\\\"
+      case '\b'         => "\\b"
+      case '\f'         => "\\f"
+      case '\n'         => "\\n"
+      case '\r'         => "\\r"
+      case '\t'         => "\\t"
+      case c if c < ' ' => "\\u%04x".format(c.toInt)
+      case c            => c.toString
+    } + "\""
+
+  private def tomlString(value: String): String =
+    "\"" + value.flatMap {
+      case '"'  => "\\\""
+      case '\\' => "\\\\"
+      case '\b' => "\\b"
+      case '\t' => "\\t"
+      case '\n' => "\\n"
+      case '\f' => "\\f"
+      case '\r' => "\\r"
+      case c    => c.toString
+    } + "\""
+
+  private def yamlString(value: String): String =
+    "\"" + value.flatMap {
+      case '"'  => "\\\""
+      case '\\' => "\\\\"
+      case '\b' => "\\b"
+      case '\t' => "\\t"
+      case '\n' => "\\n"
+      case '\f' => "\\f"
+      case '\r' => "\\r"
+      case c    => c.toString
+    } + "\""
 }


### PR DESCRIPTION
## Summary
- restructure the technical section around query flow and MCP initialization
- explain why SemanticDB symbols, compiler facts, and presentation compiler overlays are used
- shorten setup/client configuration wording

## Verification
- git diff --check
- not run: test suite (docs-only change)