### PR TITLE
feat(sbt-plugin): mcpClientConfig writes + merges config into project-local files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,6 +195,9 @@ lazy val sbtPlugin = (project in file("sbt-plugin"))
         case _      => "2.0.0"
       }
     },
+    // munit unit-tests the pure config-merge helpers (no sbt/scripted machinery needed). munit 1.2.3
+    // is published for both the 2.12 and 3 plugin axes, so `%%` resolves on each cross-build.
+    libraryDependencies += munit,
     // Bundle the auto-download launcher scripts into the plugin jar so `mcpInstall` can write them
     // into a host project's target dir. Single source of truth = top-level scripts/.
     Compile / resourceGenerators += Def.task {

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -39,12 +39,12 @@ as its argument. Pick by how much you want automated.
 | | A — sbt plugin | B — auto-download script | C — plain `java -jar` |
 |---|---|---|---|
 | Get the jar | launcher downloads + caches it | script downloads + caches it | you download it once |
-| Write client config | `sbt mcpClientConfig` generates it | by hand (point at script) | by hand (point at `java`) |
+| Write client config | `sbt mcpClientConfig` writes + merges it | by hand (point at script) | by hand (point at `java`) |
 | Enable SemanticDB | plugin does it | you (one line) | you (one line) |
 | Stays up to date | yes — pulls latest each launch | yes — pulls latest each launch | manual re-download |
 | Works with | sbt (1 and 2) | any OS / build tool | any OS / build tool |
 
-### Option A — sbt plugin (recommended; generates the client config for you)
+### Option A — sbt plugin (recommended; writes the client config for you)
 
 `io.github.mercurievv:sbt-scalasemantic-mcp` is cross-published for sbt 1 and sbt 2. The same
 `addSbtPlugin` line works in both; sbt resolves the matching plugin artifact for your build. The
@@ -65,11 +65,12 @@ or the [latest GitHub release](https://github.com/MercurieVV/ScalaSemantic/relea
 The plugin enables SemanticDB and adds:
 
 - `sbt mcpInstall` — writes the bundled auto-download launcher (Option B's script) into `target/`.
-- `sbt mcpClientConfig` — runs `mcpInstall`, then prints the selected MCP client config pointing at
-  that script.
+- `sbt mcpClientConfig` — runs `mcpInstall`, then writes the selected MCP client config (pointing at
+  that script) into a project-local file, merging this server's entry into any existing file without
+  disturbing other servers or settings.
 - `sbt mcpRun` — runs the server in the foreground (stdio) for manual testing.
 
-So `enablePlugins` + `sbt mcpClientConfig` + paste is the whole setup — no jar to download by hand; the
+So `enablePlugins` + `sbt mcpClientConfig` is the whole setup — no config to paste, no jar to download by hand; the
 written launcher fetches the server on first spawn (coursier if present, else the GitHub-Release fat
 jar). To pin a fixed binary instead, override `mcpServerCommand`, e.g.
 `mcpServerCommand := Seq("java", "-jar", "/abs/path/to/scalasemantic-mcp.jar")`.
@@ -89,11 +90,24 @@ mcpClient := "generic-json" // other MCP clients using the standard mcpServers J
 The plugin only enables SemanticDB and shells out to `mcpServerCommand` — it never links against the
 Scala 3.8.4 server, which is why it is sbt-1/2 and build-tool portable.
 
-#### What `mcpClientConfig` generates
+#### What `mcpClientConfig` writes
 
 The task takes `mcpServerCommand`, then appends the project's base directory, the classpath file, and
-the logging flags. With the default `mcpServerCommand` (the launcher `mcpInstall` writes) and
-`mcpClient := "claude"` it emits:
+the logging flags. It writes the result into a project-local file chosen by `mcpClient`, merging
+just this server's entry into any existing file (other servers and unrelated settings are left
+untouched):
+
+| `mcpClient` | file written |
+|---|---|
+| `claude`, `generic-json` | `.mcp.json` |
+| `codex` | `.codex/config.toml` |
+| `gemini` | `.gemini/settings.json` |
+| `cline` | `.cline/mcp.json` |
+| `roo` | `.roo/mcp.json` |
+| `continue` | `.continue/config.yaml` |
+
+With the default `mcpServerCommand` (the launcher `mcpInstall` writes) and
+`mcpClient := "claude"` the `.mcp.json` entry is:
 
 ```json
 {
@@ -114,8 +128,8 @@ unless these are present — drop them for the silent default). So overriding
 Generation logic:
 [`ScalaSemanticMcpPlugin.scala`](https://github.com/MercurieVV/ScalaSemantic/blob/master/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala).
 
-With `mcpClient := "codex"` it emits TOML for `~/.codex/config.toml` or a trusted project's
-`.codex/config.toml`:
+With `mcpClient := "codex"` it writes TOML into the project's `.codex/config.toml` (copy the table
+into `~/.codex/config.toml` if you prefer a user-global Codex config):
 
 ```toml
 [mcp_servers.scala-semantic]
@@ -126,11 +140,10 @@ tool_timeout_sec = 60
 ```
 
 The explicit timeouts avoid first-launch failures when the launcher has to resolve or download the
-server jar. `sbt mcpClientConfig` also prefetches the jar on a best-effort basis before printing the
+server jar. `sbt mcpClientConfig` also prefetches the jar on a best-effort basis before writing the
 config.
 
-With `mcpClient := "gemini"` it emits JSON for Gemini CLI `~/.gemini/settings.json` or
-`.gemini/settings.json`:
+With `mcpClient := "gemini"` it writes JSON into the project's `.gemini/settings.json`:
 
 ```json
 {
@@ -144,7 +157,7 @@ With `mcpClient := "gemini"` it emits JSON for Gemini CLI `~/.gemini/settings.js
 }
 ```
 
-With `mcpClient := "cline"` it emits JSON for Cline's MCP settings:
+With `mcpClient := "cline"` it writes JSON into the project's `.cline/mcp.json`:
 
 ```json
 {
@@ -159,8 +172,8 @@ With `mcpClient := "cline"` it emits JSON for Cline's MCP settings:
 }
 ```
 
-With `mcpClient := "roo"` it emits JSON for Roo Code's global `mcp_settings.json` or project
-`.roo/mcp.json`:
+With `mcpClient := "roo"` it writes JSON into the project's `.roo/mcp.json` (copy the entry into the
+global `mcp_settings.json` if you want it Roo-wide):
 
 ```json
 {
@@ -176,7 +189,7 @@ With `mcpClient := "roo"` it emits JSON for Roo Code's global `mcp_settings.json
 }
 ```
 
-With `mcpClient := "continue"` it emits YAML for Continue `config.yaml`:
+With `mcpClient := "continue"` it writes YAML into the project's `.continue/config.yaml`:
 
 ```yaml
 name: ScalaSemantic MCP

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -358,6 +358,15 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
   @tailrec private def skipWs(s: String, i: Int, limit: Int): Int =
     if (i < limit && s.charAt(i).isWhitespace) skipWs(s, i + 1, limit) else i
 
+  /** Normalize to exactly one trailing newline so re-running the merge on its own output is a
+    * fixpoint (the append and replace paths would otherwise differ only in the EOF newline).
+    */
+  private def withTrailingNewline(s: String): String =
+    s.replaceAll("\\R+\\z", "") + "\n"
+
+  /** Number of leading space characters on a line (its YAML indentation depth). */
+  private def leadingSpaces(line: String): Int = line.takeWhile(_ == ' ').length
+
   /** Index just past the value (object/array/string/primitive) that starts at `vs`. */
   private def jsonValueEnd(s: String, vs: Int, limit: Int): Int =
     s.charAt(vs) match {
@@ -457,23 +466,25 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
   private def mergeToml(existing: Option[String], serverName: String, argv: Seq[String]): String = {
     val fresh = renderCodexToml(serverName, argv)
     val src = existing.getOrElse("")
-    if (src.trim.isEmpty) fresh
-    else {
-      val header = s"[mcp_servers.${tomlKey(serverName)}]"
-      val lines = src.split("\n", -1).toVector
-      val idx = lines.indexWhere(_.trim == header)
-      if (idx < 0) {
-        val sep = if (src.endsWith("\n")) "" else "\n"
-        src + sep + "\n" + fresh + "\n"
-      } else {
-        // The table runs until the next `[...]` table header, or EOF.
-        val end = lines.indexWhere(_.trim.startsWith("["), idx + 1) match {
-          case -1 => lines.length
-          case e  => e
+    val body =
+      if (src.trim.isEmpty) fresh
+      else {
+        val header = s"[mcp_servers.${tomlKey(serverName)}]"
+        val lines = src.split("\n", -1).toVector
+        val idx = lines.indexWhere(_.trim == header)
+        if (idx < 0) {
+          val sep = if (src.endsWith("\n")) "" else "\n"
+          src + sep + "\n" + fresh
+        } else {
+          // The table runs until the next `[...]` table header, or EOF.
+          val end = lines.indexWhere(_.trim.startsWith("["), idx + 1) match {
+            case -1 => lines.length
+            case e  => e
+          }
+          (lines.take(idx) ++ fresh.split("\n", -1) ++ lines.drop(end)).mkString("\n")
         }
-        (lines.take(idx) ++ fresh.split("\n", -1) ++ lines.drop(end)).mkString("\n")
       }
-    }
+    withTrailingNewline(body)
   }
 
   // --- YAML (Continue) --------------------------------------------------------------------------
@@ -499,34 +510,40 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
   private def mergeYaml(existing: Option[String], serverName: String, argv: Seq[String]): String = {
     val fresh = renderContinueYaml(serverName, argv)
     val src = existing.getOrElse("")
-    if (src.trim.isEmpty) fresh
-    else {
-      val item = continueItem(serverName, argv)
-      val lines = src.split("\n", -1).toVector
-      val msIdx = lines.indexWhere(_.matches("""mcpServers:\s*"""))
-      if (msIdx < 0) {
-        val sep = if (src.endsWith("\n")) "" else "\n"
-        src + sep + "mcpServers:\n" + item + "\n"
-      } else {
-        // The list block runs while lines stay indented (or blank).
-        val blockEnd =
-          lines.indexWhere(l => !l.startsWith(" ") && l.trim.nonEmpty, msIdx + 1) match {
-            case -1 => lines.length
-            case e  => e
+    val body =
+      if (src.trim.isEmpty) fresh
+      else {
+        val item = continueItem(serverName, argv)
+        val lines = src.split("\n", -1).toVector
+        val msIdx = lines.indexWhere(_.matches("""mcpServers:\s*"""))
+        if (msIdx < 0) {
+          val sep = if (src.endsWith("\n")) "" else "\n"
+          src + sep + "mcpServers:\n" + item
+        } else {
+          // The list block runs while lines stay indented (or blank).
+          val blockEnd =
+            lines.indexWhere(l => !l.startsWith(" ") && l.trim.nonEmpty, msIdx + 1) match {
+              case -1 => lines.length
+              case e  => e
+            }
+          val nameLine = s"- name: ${yamlString(serverName)}"
+          val itemIdx = (msIdx + 1 until blockEnd).find(i => lines(i).trim == nameLine)
+          itemIdx match {
+            case Some(s0) =>
+              // This item ends at the next sibling list item — a `- ` at the SAME indentation as
+              // this one (deeper `- ` lines are the item's own `args:` sequence) — or the block end.
+              val indent = leadingSpaces(lines(s0))
+              val e = (s0 + 1 until blockEnd)
+                .find(i => leadingSpaces(lines(i)) == indent && lines(i).trim.startsWith("- "))
+                .getOrElse(blockEnd)
+              (lines.take(s0) ++ item.split("\n", -1) ++ lines.drop(e)).mkString("\n")
+            case None =>
+              (lines.take(msIdx + 1) ++ item.split("\n", -1) ++ lines.drop(msIdx + 1))
+                .mkString("\n")
           }
-        val nameLine = s"- name: ${yamlString(serverName)}"
-        val itemIdx = (msIdx + 1 until blockEnd).find(i => lines(i).trim == nameLine)
-        itemIdx match {
-          case Some(s0) =>
-            // This item ends at the next list item (`- ...`) or the block end.
-            val e =
-              (s0 + 1 until blockEnd).find(i => lines(i).trim.startsWith("- ")).getOrElse(blockEnd)
-            (lines.take(s0) ++ item.split("\n", -1) ++ lines.drop(e)).mkString("\n")
-          case None =>
-            (lines.take(msIdx + 1) ++ item.split("\n", -1) ++ lines.drop(msIdx + 1)).mkString("\n")
         }
       }
-    }
+    withTrailingNewline(body)
   }
 
   private def tomlKey(value: String): String =

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -315,7 +315,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
   /** Insert-or-replace this server under the top-level `mcpServers` object, preserving everything
     * else. Falls back to a fresh document if the file is absent/blank or not a JSON object.
     */
-  private def mergeJson(
+  private[sbtplugin] def mergeJson(
       existing: Option[String],
       serverName: String,
       argv: Seq[String],
@@ -463,7 +463,11 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
   /** Replace the `[mcp_servers.<name>]` table (header through the line before the next `[...]`
     * table, or EOF) if present, else append it. Other tables stay put.
     */
-  private def mergeToml(existing: Option[String], serverName: String, argv: Seq[String]): String = {
+  private[sbtplugin] def mergeToml(
+      existing: Option[String],
+      serverName: String,
+      argv: Seq[String]
+  ): String = {
     val fresh = renderCodexToml(serverName, argv)
     val src = existing.getOrElse("")
     val body =
@@ -507,7 +511,11 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
         |${continueItem(serverName, argv)}""".stripMargin
 
   /** Insert-or-replace this server's list item under `mcpServers:`, else append the block. */
-  private def mergeYaml(existing: Option[String], serverName: String, argv: Seq[String]): String = {
+  private[sbtplugin] def mergeYaml(
+      existing: Option[String],
+      serverName: String,
+      argv: Seq[String]
+  ): String = {
     val fresh = renderContinueYaml(serverName, argv)
     val src = existing.getOrElse("")
     val body =

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -3,6 +3,7 @@ package com.github.mercurievv.scalasemantic.sbtplugin
 import sbt.*
 import sbt.Keys.*
 
+import scala.annotation.tailrec
 import scala.sys.process.Process
 
 /** Opt-in sbt plugin that wires the ScalaSemanticMCP server to a host project.
@@ -21,9 +22,11 @@ import scala.sys.process.Process
   * {{{
   *   enablePlugins(ScalaSemanticMcpPlugin)
   * }}}
-  * then `sbt mcpClientConfig` prints ready-to-paste MCP client configuration. Set `mcpClient` to
-  * choose the output format. Override `mcpServerCommand` to point at a fixed jar or `cs` instead of
-  * the bundled launcher if you prefer.
+  * then `sbt mcpClientConfig` writes the MCP client configuration into a project-local file
+  * (`.mcp.json`, `.codex/config.toml`, …), merging this server's entry into any existing file
+  * without disturbing other servers or settings. Set `mcpClient` to choose the output format.
+  * Override `mcpServerCommand` to point at a fixed jar or `cs` instead of the bundled launcher if
+  * you prefer.
   */
 object ScalaSemanticMcpPlugin extends AutoPlugin {
 
@@ -39,7 +42,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       settingKey[String]("name to register this server under in the MCP client")
     val mcpClient =
       settingKey[String](
-        "MCP client config dialect to print: claude, codex, gemini, cline, roo, continue, or generic-json"
+        "MCP client config dialect to write: claude, codex, gemini, cline, roo, continue, or generic-json"
       )
     @transient
     val mcpInstall =
@@ -55,7 +58,10 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       )
     @transient
     val mcpClientConfig =
-      taskKey[Unit]("print the selected MCP client config that registers this project's server")
+      taskKey[Unit](
+        "write/merge the selected MCP client config (project-local file) that registers this " +
+          "project's server"
+      )
     @transient
     val mcpRun =
       taskKey[Unit]("run the MCP server in the foreground (stdio) against this project")
@@ -116,8 +122,20 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       val argv =
         resolvedCommand(mcpServerCommand.value, baseDirectory.value, cpFile) ++
           Seq("--log", "--log-output")
-      val rendered = renderClientConfig(mcpClient.value, mcpServerName.value, argv)
-      log.info(s"Register this in ${rendered.destination}:\n${rendered.config}")
+      val serverName = mcpServerName.value
+      val target = targetFor(mcpClient.value)
+      val outFile = baseDirectory.value / target.relPath
+      val existing = if (outFile.exists) Some(IO.read(outFile)) else None
+      val merged = target.fmt match {
+        case JsonFmt => mergeJson(existing, serverName, argv, target.extraJson)
+        case TomlFmt => mergeToml(existing, serverName, argv)
+        case YamlFmt => mergeYaml(existing, serverName, argv)
+      }
+      // IO.write creates parent dirs. Merge inserts/replaces only this server's entry, leaving any
+      // other servers and unrelated settings in the file untouched.
+      IO.write(outFile, merged)
+      val verb = if (existing.isEmpty) "Wrote" else "Merged into"
+      log.info(s"$verb MCP config for server '$serverName': $outFile")
       if (!cpFile.exists)
         log.info(
           "Server will run index-only. Run `sbt mcpClasspathFile` once (requires a successful " +
@@ -220,45 +238,45 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       )
     else command :+ baseDir.getAbsolutePath :+ classpathFile.getAbsolutePath
 
-  private final case class RenderedConfig(destination: String, config: String)
+  // --- Config target + merge -------------------------------------------------------------------
+  // mcpClientConfig writes (and merges) into a project-local file rather than just printing, so the
+  // entry survives and lives next to the project. Three on-disk formats: JSON, TOML, YAML. Each
+  // merge inserts-or-replaces ONLY this server's entry and leaves the rest of the file untouched —
+  // done with a small format-aware scanner rather than a JSON/TOML/YAML library, because the plugin
+  // cross-builds to Scala 2.12 / sbt 1.x where pulling such a dep onto the plugin classpath is
+  // fragile.
 
-  private def renderClientConfig(
-      client: String,
-      serverName: String,
-      argv: Seq[String]
-  ): RenderedConfig = {
+  private sealed trait Fmt
+  private case object JsonFmt extends Fmt
+  private case object TomlFmt extends Fmt
+  private case object YamlFmt extends Fmt
+
+  /** Where this client's config lives (project-local), its on-disk format, and the client-specific
+    * extra JSON fields to emit alongside command/args.
+    */
+  private final case class Target(relPath: String, fmt: Fmt, extraJson: Seq[(String, String)])
+
+  private def targetFor(client: String): Target = {
     val normalized = client.trim.toLowerCase.replace('_', '-')
     normalized match {
       case "codex" | "openai" | "openai-codex" =>
-        RenderedConfig(
-          "Codex config.toml (for example ~/.codex/config.toml or .codex/config.toml)",
-          renderCodexToml(serverName, argv)
-        )
+        Target(".codex/config.toml", TomlFmt, Nil)
       case "claude" | "claude-code" | "anthropic" =>
-        RenderedConfig("Claude Code .mcp.json", renderMcpJson(serverName, argv, Nil))
+        Target(".mcp.json", JsonFmt, Nil)
       case "gemini" | "google" | "google-gemini" | "gemini-cli" =>
-        RenderedConfig(
-          "Gemini CLI settings.json (for example ~/.gemini/settings.json or .gemini/settings.json)",
-          renderMcpJson(serverName, argv, Seq("timeout" -> "60000"))
-        )
+        Target(".gemini/settings.json", JsonFmt, Seq("timeout" -> "60000"))
       case "cline" =>
-        RenderedConfig(
-          "Cline MCP JSON (for example ~/.cline/mcp.json or the IDE MCP settings JSON)",
-          renderMcpJson(serverName, argv, Seq("disabled" -> "false", "autoApprove" -> "[]"))
-        )
+        Target(".cline/mcp.json", JsonFmt, Seq("disabled" -> "false", "autoApprove" -> "[]"))
       case "roo" | "roo-code" =>
-        RenderedConfig(
-          "Roo Code MCP JSON (for example .roo/mcp.json or global mcp_settings.json)",
-          renderMcpJson(
-            serverName,
-            argv,
-            Seq("disabled" -> "false", "alwaysAllow" -> "[]", "timeout" -> "60")
-          )
+        Target(
+          ".roo/mcp.json",
+          JsonFmt,
+          Seq("disabled" -> "false", "alwaysAllow" -> "[]", "timeout" -> "60")
         )
       case "continue" | "continue-dev" =>
-        RenderedConfig("Continue config.yaml", renderContinueYaml(serverName, argv))
+        Target(".continue/config.yaml", YamlFmt, Nil)
       case "generic" | "generic-json" | "json" | "oss" | "open-source" | "free" =>
-        RenderedConfig("a generic MCP client JSON config", renderMcpJson(serverName, argv, Nil))
+        Target(".mcp.json", JsonFmt, Nil)
       case other =>
         sys.error(
           s"Unsupported mcpClient '$other'. Use one of: " +
@@ -267,23 +285,162 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
     }
   }
 
-  private def renderMcpJson(
-      serverName: String,
-      argv: Seq[String],
-      extraFields: Seq[(String, String)]
-  ): String = {
+  // --- JSON -------------------------------------------------------------------------------------
+
+  /** The value object for one server key, e.g. `{ "command": ..., "args": [...]<extra> }`, with
+    * fields indented 6 spaces and the closing brace at 4 — matching [[renderMcpJson]].
+    */
+  private def jsonEntry(argv: Seq[String], extraFields: Seq[(String, String)]): String = {
     val argsJson = argv.tail.map(jsonString).mkString("[", ", ", "]")
     val extra =
       extraFields.map { case (name, value) => s",\n      ${jsonString(name)}: $value" }.mkString
     s"""|{
-        |  "mcpServers": {
-        |    ${jsonString(serverName)}: {
         |      "command": ${jsonString(argv.head)},
         |      "args": $argsJson$extra
-        |    }
+        |    }""".stripMargin
+  }
+
+  /** A standalone `.mcp.json`-style document (used when the target file does not yet exist). */
+  private def renderMcpJson(
+      serverName: String,
+      argv: Seq[String],
+      extraFields: Seq[(String, String)]
+  ): String =
+    s"""|{
+        |  "mcpServers": {
+        |    ${jsonString(serverName)}: ${jsonEntry(argv, extraFields)}
         |  }
         |}""".stripMargin
+
+  /** Insert-or-replace this server under the top-level `mcpServers` object, preserving everything
+    * else. Falls back to a fresh document if the file is absent/blank or not a JSON object.
+    */
+  private def mergeJson(
+      existing: Option[String],
+      serverName: String,
+      argv: Seq[String],
+      extraFields: Seq[(String, String)]
+  ): String = {
+    val fresh = renderMcpJson(serverName, argv, extraFields)
+    val src = existing.getOrElse("")
+    val rootOpen = if (src.trim.isEmpty) -1 else src.indexOf('{')
+    val rootClose = if (rootOpen < 0) -1 else matchBracket(src, rootOpen)
+    if (rootClose < 0) fresh // absent/blank/not a JSON object — write a fresh document
+    else {
+      val entry = jsonEntry(argv, extraFields)
+      val msKey = findJsonKey(src, rootOpen + 1, rootClose, "mcpServers")
+      if (msKey < 0) {
+        // No mcpServers object yet — add one to the root object.
+        val hadEntries = src.substring(rootOpen + 1, rootClose).trim.nonEmpty
+        val block = s"""\n  "mcpServers": {\n    ${jsonString(serverName)}: $entry\n  }"""
+        val comma = if (hadEntries) "," else ""
+        src.substring(0, rootOpen + 1) + block + comma + src.substring(rootOpen + 1)
+      } else {
+        val objOpen = src.indexOf('{', src.indexOf(':', msKey))
+        val objClose = matchBracket(src, objOpen)
+        val snKey = findJsonKey(src, objOpen + 1, objClose, serverName)
+        if (snKey >= 0) {
+          // Replace just this server's value.
+          val vs = skipWs(src, src.indexOf(':', snKey) + 1, objClose)
+          val ve = jsonValueEnd(src, vs, objClose)
+          src.substring(0, vs) + entry + src.substring(ve)
+        } else {
+          // Insert this server as the first entry of the existing mcpServers object.
+          val hadEntries = src.substring(objOpen + 1, objClose).trim.nonEmpty
+          val ins = s"""\n    ${jsonString(serverName)}: $entry${if (hadEntries) "," else ""}"""
+          src.substring(0, objOpen + 1) + ins + src.substring(objOpen + 1)
+        }
+      }
+    }
   }
+
+  /** First index >= `i` (and < `limit`) whose char is not whitespace. */
+  @tailrec private def skipWs(s: String, i: Int, limit: Int): Int =
+    if (i < limit && s.charAt(i).isWhitespace) skipWs(s, i + 1, limit) else i
+
+  /** Index just past the value (object/array/string/primitive) that starts at `vs`. */
+  private def jsonValueEnd(s: String, vs: Int, limit: Int): Int =
+    s.charAt(vs) match {
+      case '{' | '[' => matchBracket(s, vs) + 1
+      case '"' =>
+        @tailrec def str(i: Int, esc: Boolean): Int =
+          if (i >= limit) limit
+          else {
+            val c = s.charAt(i)
+            if (esc) str(i + 1, esc = false)
+            else if (c == '\\') str(i + 1, esc = true)
+            else if (c == '"') i + 1
+            else str(i + 1, esc = false)
+          }
+        str(vs + 1, esc = false)
+      case _ =>
+        @tailrec def scan(i: Int): Int =
+          if (i < limit && s.charAt(i) != ',' && s.charAt(i) != '}') scan(i + 1) else i
+        @tailrec def back(i: Int): Int =
+          if (i > vs && s.charAt(i - 1).isWhitespace) back(i - 1) else i
+        back(scan(vs))
+    }
+
+  /** Index of the closing bracket matching the `{`/`[` at `openIdx`, honoring strings/escapes. */
+  private def matchBracket(s: String, openIdx: Int): Int = {
+    @tailrec def loop(i: Int, depth: Int, inStr: Boolean, esc: Boolean): Int =
+      if (i >= s.length) -1
+      else {
+        val c = s.charAt(i)
+        if (inStr) {
+          if (esc) loop(i + 1, depth, inStr = true, esc = false)
+          else if (c == '\\') loop(i + 1, depth, inStr = true, esc = true)
+          else if (c == '"') loop(i + 1, depth, inStr = false, esc = false)
+          else loop(i + 1, depth, inStr = true, esc = false)
+        } else
+          c match {
+            case '"'       => loop(i + 1, depth, inStr = true, esc = false)
+            case '{' | '[' => loop(i + 1, depth + 1, inStr = false, esc = false)
+            case '}' | ']' =>
+              if (depth - 1 == 0) i else loop(i + 1, depth - 1, inStr = false, esc = false)
+            case _ => loop(i + 1, depth, inStr = false, esc = false)
+          }
+      }
+    loop(openIdx, 0, inStr = false, esc = false)
+  }
+
+  /** True if the first non-whitespace char at or after `from` (and before `end`) is a colon. */
+  private def colonFollows(s: String, from: Int, end: Int): Boolean = {
+    val j = skipWs(s, from, end)
+    j < end && s.charAt(j) == ':'
+  }
+
+  /** Index of the key string `"key"` that appears at depth 0 within `[start, end)` and is followed
+    * by a colon, or -1. Assumes `key` needs no JSON escaping (true for our server names).
+    */
+  private def findJsonKey(s: String, start: Int, end: Int, key: String): Int = {
+    val target = "\"" + key + "\""
+    @tailrec def loop(i: Int, depth: Int, inStr: Boolean, esc: Boolean): Int =
+      if (i >= end) -1
+      else {
+        val c = s.charAt(i)
+        if (inStr) {
+          if (esc) loop(i + 1, depth, inStr = true, esc = false)
+          else if (c == '\\') loop(i + 1, depth, inStr = true, esc = true)
+          else if (c == '"') loop(i + 1, depth, inStr = false, esc = false)
+          else loop(i + 1, depth, inStr = true, esc = false)
+        } else
+          c match {
+            case '"' =>
+              if (
+                depth == 0 && s.regionMatches(i, target, 0, target.length) &&
+                colonFollows(s, i + target.length, end)
+              ) i
+              else loop(i + 1, depth, inStr = true, esc = false)
+            case '{' | '[' => loop(i + 1, depth + 1, inStr = false, esc = false)
+            case '}' | ']' => loop(i + 1, depth - 1, inStr = false, esc = false)
+            case _         => loop(i + 1, depth, inStr = false, esc = false)
+          }
+      }
+    loop(start, 0, inStr = false, esc = false)
+  }
+
+  // --- TOML -------------------------------------------------------------------------------------
 
   private def renderCodexToml(serverName: String, argv: Seq[String]): String = {
     val argsToml = argv.tail.map(tomlString).mkString("[", ", ", "]")
@@ -294,17 +451,82 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
         |tool_timeout_sec = 60""".stripMargin
   }
 
-  private def renderContinueYaml(serverName: String, argv: Seq[String]): String = {
+  /** Replace the `[mcp_servers.<name>]` table (header through the line before the next `[...]`
+    * table, or EOF) if present, else append it. Other tables stay put.
+    */
+  private def mergeToml(existing: Option[String], serverName: String, argv: Seq[String]): String = {
+    val fresh = renderCodexToml(serverName, argv)
+    val src = existing.getOrElse("")
+    if (src.trim.isEmpty) fresh
+    else {
+      val header = s"[mcp_servers.${tomlKey(serverName)}]"
+      val lines = src.split("\n", -1).toVector
+      val idx = lines.indexWhere(_.trim == header)
+      if (idx < 0) {
+        val sep = if (src.endsWith("\n")) "" else "\n"
+        src + sep + "\n" + fresh + "\n"
+      } else {
+        // The table runs until the next `[...]` table header, or EOF.
+        val end = lines.indexWhere(_.trim.startsWith("["), idx + 1) match {
+          case -1 => lines.length
+          case e  => e
+        }
+        (lines.take(idx) ++ fresh.split("\n", -1) ++ lines.drop(end)).mkString("\n")
+      }
+    }
+  }
+
+  // --- YAML (Continue) --------------------------------------------------------------------------
+
+  /** One `mcpServers` list item (indented for a 2-space list). */
+  private def continueItem(serverName: String, argv: Seq[String]): String = {
     val args =
       if (argv.tail.isEmpty) ""
       else argv.tail.map(a => s"\n      - ${yamlString(a)}").mkString("\n    args:", "", "")
+    s"""|  - name: ${yamlString(serverName)}
+        |    command: ${yamlString(argv.head)}$args
+        |    connectionTimeout: 60000""".stripMargin
+  }
+
+  private def renderContinueYaml(serverName: String, argv: Seq[String]): String =
     s"""|name: ScalaSemantic MCP
         |version: 1.0.0
         |schema: v1
         |mcpServers:
-        |  - name: ${yamlString(serverName)}
-        |    command: ${yamlString(argv.head)}$args
-        |    connectionTimeout: 60000""".stripMargin
+        |${continueItem(serverName, argv)}""".stripMargin
+
+  /** Insert-or-replace this server's list item under `mcpServers:`, else append the block. */
+  private def mergeYaml(existing: Option[String], serverName: String, argv: Seq[String]): String = {
+    val fresh = renderContinueYaml(serverName, argv)
+    val src = existing.getOrElse("")
+    if (src.trim.isEmpty) fresh
+    else {
+      val item = continueItem(serverName, argv)
+      val lines = src.split("\n", -1).toVector
+      val msIdx = lines.indexWhere(_.matches("""mcpServers:\s*"""))
+      if (msIdx < 0) {
+        val sep = if (src.endsWith("\n")) "" else "\n"
+        src + sep + "mcpServers:\n" + item + "\n"
+      } else {
+        // The list block runs while lines stay indented (or blank).
+        val blockEnd =
+          lines.indexWhere(l => !l.startsWith(" ") && l.trim.nonEmpty, msIdx + 1) match {
+            case -1 => lines.length
+            case e  => e
+          }
+        val nameLine = s"- name: ${yamlString(serverName)}"
+        val itemIdx = (msIdx + 1 until blockEnd).find(i => lines(i).trim == nameLine)
+        itemIdx match {
+          case Some(s0) =>
+            // This item ends at the next list item (`- ...`) or the block end.
+            val e =
+              (s0 + 1 until blockEnd).find(i => lines(i).trim.startsWith("- ")).getOrElse(blockEnd)
+            (lines.take(s0) ++ item.split("\n", -1) ++ lines.drop(e)).mkString("\n")
+          case None =>
+            (lines.take(msIdx + 1) ++ item.split("\n", -1) ++ lines.drop(msIdx + 1)).mkString("\n")
+        }
+      }
+    }
   }
 
   private def tomlKey(value: String): String =

--- a/sbt-plugin/src/test/scala/com/github/mercurievv/scalasemantic/sbtplugin/ConfigMergeSuite.scala
+++ b/sbt-plugin/src/test/scala/com/github/mercurievv/scalasemantic/sbtplugin/ConfigMergeSuite.scala
@@ -1,0 +1,193 @@
+package com.github.mercurievv.scalasemantic.sbtplugin
+
+import ScalaSemanticMcpPlugin.{mergeJson, mergeToml, mergeYaml}
+
+/** Unit tests for the dependency-free config mergers in [[ScalaSemanticMcpPlugin]]. They exercise
+  * the three on-disk formats (JSON / TOML / YAML) for: a fresh file, adding alongside an existing
+  * third-party MCP server, replacing our own entry, preserving unrelated content, and — crucially —
+  * idempotency (re-running the merge on its own output must be a fixpoint).
+  */
+class ConfigMergeSuite extends munit.FunSuite {
+
+  private val name = "scala-semantic"
+  private val argv =
+    Seq("/bin/launch.sh", "/proj", "/cp.txt", "--log", "--log-output")
+
+  /** Assert that applying `merge` to its own output twice more changes nothing. */
+  private def assertIdempotent(
+      label: String,
+      merge: Option[String] => String,
+      seed: Option[String]
+  )(implicit
+      loc: munit.Location
+  ): Unit = {
+    val once = merge(seed)
+    val twice = merge(Some(once))
+    val thrice = merge(Some(twice))
+    assertEquals(twice, once, s"$label: 2nd merge differs from 1st")
+    assertEquals(thrice, twice, s"$label: 3rd merge differs from 2nd")
+  }
+
+  // --- JSON -------------------------------------------------------------------------------------
+
+  test("json: fresh file gets a well-formed mcpServers entry") {
+    val out = mergeJson(None, name, argv, Nil)
+    assert(out.contains("\"mcpServers\""))
+    assert(out.contains("\"scala-semantic\""))
+    assert(out.contains("\"/bin/launch.sh\""))
+    assert(out.contains("\"--log-output\""))
+  }
+
+  test("json: adds alongside an existing server and keeps unrelated root keys") {
+    val existing =
+      """{
+        |  "someOtherKey": true,
+        |  "mcpServers": {
+        |    "other": { "command": "x", "args": ["a"] }
+        |  }
+        |}""".stripMargin
+    val out = mergeJson(Some(existing), name, argv, Seq("timeout" -> "60000"))
+    assert(out.contains("\"other\""), "kept other server")
+    assert(out.contains("\"someOtherKey\""), "kept unrelated root key")
+    assert(out.contains("\"scala-semantic\""), "added our server")
+    assert(out.contains("\"timeout\": 60000"), "emitted extra field")
+  }
+
+  test("json: replaces our own entry without touching siblings") {
+    val existing =
+      """{
+        |  "mcpServers": {
+        |    "scala-semantic": { "command": "OLD", "args": [] },
+        |    "keep": { "command": "k", "args": [] }
+        |  }
+        |}""".stripMargin
+    val out = mergeJson(Some(existing), name, argv, Nil)
+    assert(!out.contains("OLD"), "old value replaced")
+    assert(out.contains("\"keep\""), "kept sibling")
+    assert(out.contains("\"/bin/launch.sh\""), "new command present")
+  }
+
+  test("json: adds mcpServers to a root object that lacks it") {
+    val out = mergeJson(Some("""{ "foo": 1 }"""), name, argv, Nil)
+    assert(out.contains("\"foo\""), "kept foo")
+    assert(out.contains("\"mcpServers\""), "added mcpServers")
+  }
+
+  test("json: not-an-object content falls back to a fresh document") {
+    val out = mergeJson(Some("garbage"), name, argv, Nil)
+    assertEquals(out, mergeJson(None, name, argv, Nil))
+  }
+
+  test("json: idempotent (fresh, with-extra, and with-other-server)") {
+    assertIdempotent("json/fresh", e => mergeJson(e, name, argv, Nil), None)
+    assertIdempotent("json/extra", e => mergeJson(e, name, argv, Seq("timeout" -> "60000")), None)
+    val withOther =
+      """{
+        |  "someOtherKey": true,
+        |  "mcpServers": { "other": { "command": "x", "args": ["a"] } }
+        |}""".stripMargin
+    assertIdempotent("json/other", e => mergeJson(e, name, argv, Nil), Some(withOther))
+    val out = mergeJson(Some(withOther), name, argv, Nil)
+    assert(out.contains("\"other\"") && out.contains("\"someOtherKey\""))
+  }
+
+  // --- TOML -------------------------------------------------------------------------------------
+
+  test("toml: replaces our table and keeps other tables") {
+    val existing =
+      """[mcp_servers.other]
+        |command = "x"
+        |args = ["a"]
+        |
+        |[mcp_servers.scala-semantic]
+        |command = "OLD"
+        |args = []
+        |
+        |[other_table]
+        |foo = 1""".stripMargin
+    val out = mergeToml(Some(existing), name, argv)
+    assert(out.contains("[mcp_servers.other]"), "kept other server")
+    assert(out.contains("[other_table]") && out.contains("foo = 1"), "kept unrelated table")
+    assert(!out.contains("OLD"), "replaced old value")
+    assert(out.contains("\"/bin/launch.sh\""), "new command present")
+  }
+
+  test("toml: appends our table when absent") {
+    val existing = "[mcp_servers.other]\ncommand = \"x\"\nargs = []\n"
+    val out = mergeToml(Some(existing), name, argv)
+    assert(out.contains("[mcp_servers.other]"))
+    assert(out.contains("[mcp_servers.scala-semantic]"))
+  }
+
+  test("toml: ends with exactly one trailing newline") {
+    val out = mergeToml(None, name, argv)
+    assert(out.endsWith("\n"))
+    assert(!out.endsWith("\n\n"))
+  }
+
+  test("toml: idempotent (fresh and with-other-server)") {
+    assertIdempotent("toml/fresh", e => mergeToml(e, name, argv), None)
+    val withOther =
+      """[mcp_servers.other]
+        |command = "x"
+        |args = ["a"]
+        |
+        |[other_table]
+        |foo = 1""".stripMargin
+    assertIdempotent("toml/other", e => mergeToml(e, name, argv), Some(withOther))
+    val out = mergeToml(Some(withOther), name, argv)
+    assert(out.contains("[mcp_servers.other]") && out.contains("[other_table]"))
+  }
+
+  // --- YAML -------------------------------------------------------------------------------------
+
+  test("yaml: replaces our list item and keeps other items and blocks") {
+    val existing =
+      """name: My
+        |mcpServers:
+        |  - name: "other"
+        |    command: "x"
+        |  - name: "scala-semantic"
+        |    command: "OLD"
+        |    connectionTimeout: 1
+        |models:
+        |  - name: gpt""".stripMargin
+    val out = mergeYaml(Some(existing), name, argv)
+    assert(out.contains("""- name: "other""""), "kept other item")
+    assert(out.contains("models:") && out.contains("- name: gpt"), "kept unrelated block")
+    assert(!out.contains("OLD"), "replaced old value")
+    assert(out.contains("\"/bin/launch.sh\""), "new command present")
+  }
+
+  test("yaml: appends our item when mcpServers exists without it") {
+    val existing = "name: My\nmcpServers:\n  - name: \"other\"\n    command: \"x\"\n"
+    val out = mergeYaml(Some(existing), name, argv)
+    assert(out.contains("""- name: "other""""))
+    assert(out.contains("""- name: "scala-semantic""""))
+  }
+
+  test("yaml: re-merging does not duplicate the item's own args sequence (regression)") {
+    // The args list entries (`- "/proj"`) are deeper `- ` lines; they must NOT be mistaken for the
+    // next server item, which previously duplicated args + connectionTimeout on re-merge.
+    val once = mergeYaml(None, name, argv)
+    val twice = mergeYaml(Some(once), name, argv)
+    assertEquals(twice, once)
+    // exactly one occurrence of the args anchor and the connection timeout
+    assertEquals(twice.sliding("connectionTimeout".length).count(_ == "connectionTimeout"), 1)
+    assertEquals(twice.split("\n").count(_.trim == "- \"/proj\""), 1)
+  }
+
+  test("yaml: idempotent (fresh and with-other-server)") {
+    assertIdempotent("yaml/fresh", e => mergeYaml(e, name, argv), None)
+    val withOther =
+      """name: My
+        |mcpServers:
+        |  - name: "other"
+        |    command: "x"
+        |models:
+        |  - name: gpt""".stripMargin
+    assertIdempotent("yaml/other", e => mergeYaml(e, name, argv), Some(withOther))
+    val out = mergeYaml(Some(withOther), name, argv)
+    assert(out.contains("""- name: "other"""") && out.contains("models:"))
+  }
+}


### PR DESCRIPTION
## What

`mcpClientConfig` previously only **printed** the MCP client config to the log. It now **writes** it into a project-local file chosen by `mcpClient`, merging just this server's entry into any existing file — other servers and unrelated settings are left untouched.

| `mcpClient` | file written |
|---|---|
| `claude`, `generic-json` | `.mcp.json` |
| `codex` | `.codex/config.toml` |
| `gemini` | `.gemini/settings.json` |
| `cline` | `.cline/mcp.json` |
| `roo` | `.roo/mcp.json` |
| `continue` | `.continue/config.yaml` |

## How

Merge is **dependency-free** — the plugin cross-builds to Scala 2.12 / sbt 1.x, where pulling a JSON/TOML/YAML parser onto the plugin classpath is version-fragile. Three format-aware mergers:

- **JSON** — brace/string-aware scanner (`matchBracket`, `findJsonKey`, `jsonValueEnd`): insert-or-replace under `mcpServers`, add `mcpServers` to root if missing, fall back to a fresh document if the file is absent/not an object.
- **TOML** — line-based: replace `[mcp_servers.<name>]` up to the next `[...]` table, else append.
- **YAML** — replace/insert the `- name:` item under `mcpServers:`, else append the block.

All written tail-recursively to satisfy the project's no-`var`/no-`return` wartremover lint.

## Verification

- scala-cli sample runs for all three formats: fresh / add-alongside-other-server / replace-same-name / foreign-root-content — each preserves siblings and produces valid output.
- `sbt prePush` green (91 tests, 0 failures); plugin compiles clean.
- Docs updated (`docs/getting-started/integration.md`).

Note: targeted text merge assumes a simple server name (no JSON escaping in the key) — true for the default `scala-semantic`.