### PR TITLE
feat(mcp): move_plan and extract_method_plan refactoring tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ unforked tests run with cwd = repo root. `mcp` test-depends on `analysis` so fix
 
 ## MCP tools (target surface)
 find-usages, method-signature, class-hierarchy, resolve-implicits, trait-vs-local-members,
-type-at-position, cross-file-refs, find-overloads, trace-implicit-chain, call-graph-path.
+type-at-position, cross-file-refs, find-overloads, trace-implicit-chain, call-graph-path,
+rename-plan, move-plan, extract-method-plan.
 
 ## Conventions
 - Symbol strings follow SemanticDB grammar (descriptors end in `#` type, `.` term, `/` package, `(...)` method disambig).

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -249,10 +249,10 @@ final class Analyzer(
     */
   def renamePlan(symbol: String, newName: String): RenamePlan =
     val oldName = index.displayName(symbol)
-    val edits = index.occurrences
-      .collect {
-        case (uri, occ) if occ.symbol == symbol =>
-          val r = occ.range.getOrElse(s.Range.defaultInstance)
+    val edits = index
+      .occurrencesOf(symbol)
+      .collect { case (uri, occ) =>
+        val r = occ.range.getOrElse(s.Range.defaultInstance)
           RenameEdit(
             uri,
             Range(Position(r.startLine, r.startCharacter), Position(r.endLine, r.endCharacter)),
@@ -282,14 +282,9 @@ final class Analyzer(
     val q = query.toLowerCase
     val wantedKind = kind.map(_.toUpperCase)
     val keepPath = bySymbolPath(pathFilter)
-    val excludedKinds = Set[s.SymbolInformation.Kind](
-      s.SymbolInformation.Kind.PARAMETER,
-      s.SymbolInformation.Kind.TYPE_PARAMETER,
-      s.SymbolInformation.Kind.SELF_PARAMETER
-    )
     index.symbols.values.iterator
       .filter(si => index.isGlobal(si.symbol))
-      .filter(si => !excludedKinds.contains(si.kind))
+      .filter(si => !findSymbolExcludedKinds.contains(si.kind))
       .filter(si => si.displayName.nonEmpty && si.displayName != "<init>")
       .filter { si =>
         val n = si.displayName.toLowerCase
@@ -306,6 +301,12 @@ final class Analyzer(
       .take(limit)
       .map(si => symbolRef(si.symbol))
 
+  private val findSymbolExcludedKinds: Set[s.SymbolInformation.Kind] = Set(
+    s.SymbolInformation.Kind.PARAMETER,
+    s.SymbolInformation.Kind.TYPE_PARAMETER,
+    s.SymbolInformation.Kind.SELF_PARAMETER
+  )
+
   // --- find-usages ----------------------------------------------------------
 
   /** Every occurrence of `symbol` across all indexed documents, split into definitions and
@@ -317,8 +318,8 @@ final class Analyzer(
     */
   def findUsages(symbol: String, pathFilter: Option[String] = None): UsagesResult =
     val keep = globMatcher(pathFilter)
-    val located = index.occurrences.collect {
-      case (uri, occ) if occ.symbol == symbol && keep(uri) =>
+    val located = index.occurrencesOf(symbol).collect {
+      case (uri, occ) if keep(uri) =>
         occ.role -> location(uri, occ.range)
     }
     val defs =
@@ -350,9 +351,8 @@ final class Analyzer(
 
   /** The document uri of a symbol's definition occurrence, if the index has one. */
   private def definitionUri(symbol: String): Option[String] =
-    index.occurrences.collectFirst {
-      case (uri, occ) if occ.symbol == symbol && occ.role == s.SymbolOccurrence.Role.DEFINITION =>
-        uri
+    index.occurrencesOf(symbol).collectFirst {
+      case (uri, occ) if occ.role == s.SymbolOccurrence.Role.DEFINITION => uri
     }
 
   // --- method-signature -----------------------------------------------------
@@ -403,13 +403,14 @@ final class Analyzer(
   /** Depth-first transitive parents (excluding `symbol` itself), de-duplicated by first sight. */
   private def linearize(symbol: String): List[String] =
     def parentsOf(sym: String): List[String] = index.info(sym).map(directParents).getOrElse(Nil)
-    def loop(queue: List[String], seen: List[String]): List[String] =
+    @annotation.tailrec
+    def loop(queue: List[String], seen: Set[String], acc: List[String]): List[String] =
       queue match
-        case Nil => seen
+        case Nil => acc.reverse
         case head :: tail =>
-          if seen.contains(head) then loop(tail, seen)
-          else loop(parentsOf(head) ::: tail, seen :+ head)
-    loop(parentsOf(symbol), Nil)
+          if seen.contains(head) then loop(tail, seen, acc)
+          else loop(parentsOf(head) ::: tail, seen + head, head :: acc)
+    loop(parentsOf(symbol), Set.empty, Nil)
 
   /** All indexed classes/traits that declare `symbol` among their direct parents. */
   private def knownSubtypes(symbol: String): List[String] =
@@ -565,10 +566,11 @@ final class Analyzer(
             val method = index.isMethod(occ.symbol)
             if isDef && method then (Some(occ.symbol), acc)
             else if method && current.exists(_ != occ.symbol) then
-              (current, acc :+ ((current.getOrElse(""), occ.symbol, location(doc.uri, occ.range))))
+              (current, (current.getOrElse(""), occ.symbol, location(doc.uri, occ.range)) :: acc)
             else (current, acc)
         }
         ._2
+        .reverse
     }
     edges.toList.groupMap(_._1)(e => (e._2, e._3))
 

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -253,17 +253,207 @@ final class Analyzer(
       .occurrencesOf(symbol)
       .collect { case (uri, occ) =>
         val r = occ.range.getOrElse(s.Range.defaultInstance)
-          RenameEdit(
-            uri,
-            Range(Position(r.startLine, r.startCharacter), Position(r.endLine, r.endCharacter)),
-            oldName,
-            newName
-          )
+        RenameEdit(
+          uri,
+          Range(Position(r.startLine, r.startCharacter), Position(r.endLine, r.endCharacter)),
+          oldName,
+          newName
+        )
       }
       .distinct
       .toList
       .sortBy(e => (e.uri, e.range.start.line, e.range.start.character))
     RenamePlan(symbol, oldName, newName, edits.size, edits)
+
+  // --- move plan ------------------------------------------------------------
+
+  /** The edits to move `symbol` to the package `newOwner`, keeping every call/usage resolving.
+    *
+    * Beyond relocating the definition, a move changes the symbol's fully-qualified name, so each
+    * file that references it may need its import adjusted. Per referencing file (computed from its
+    * own package, derived from SemanticDB — no text guessing of import lines):
+    *   - already in `newOwner` → no import needed (omitted);
+    *   - in the old package `fromOwner` → previously unqualified, now needs the new FQN imported;
+    *   - elsewhere → swap the old FQN import for the new one.
+    *
+    * `references` carries every resolved use (so the caller sees calls/usages, not just the body).
+    * `newOwner` is a package symbol (`com/foo/bar/`); the symbol's simple name is preserved.
+    */
+  def movePlan(symbol: String, newOwner: String): MovePlan =
+    val name = index.displayName(symbol)
+    val fromOwner = index.owner(symbol)
+    val toOwner = if newOwner.endsWith("/") || newOwner.isEmpty then newOwner else s"$newOwner/"
+    val fromFqn = joinFqn(packageDotted(fromOwner), name)
+    val toFqn = joinFqn(packageDotted(toOwner), name)
+    val occs = index.occurrencesOf(symbol)
+    val defLoc = occs.collectFirst {
+      case (uri, occ) if occ.role == s.SymbolOccurrence.Role.DEFINITION => location(uri, occ.range)
+    }
+    val defUri = defLoc.map(_.uri)
+    val references = occs
+      .collect {
+        case (uri, occ) if occ.role == s.SymbolOccurrence.Role.REFERENCE => location(uri, occ.range)
+      }
+      .distinct
+      .toList
+    // One import edit per referencing file, decided by that file's own package.
+    val imports = references
+      .map(_.uri)
+      .distinct
+      .filterNot(defUri.contains) // the definition's file moves with it
+      .flatMap { uri =>
+        val pkg = documentPackage(uri)
+        if pkg.contains(toOwner) then None // already in the destination package
+        else if pkg.contains(fromOwner) then Some(MoveImport(uri, "", toFqn))
+        else Some(MoveImport(uri, fromFqn, toFqn))
+      }
+    MovePlan(
+      symbol,
+      name,
+      kindName(symbol),
+      fromOwner,
+      toOwner,
+      fromFqn,
+      toFqn,
+      defLoc,
+      references,
+      imports
+    )
+
+  /** A package symbol (`com/foo/bar/`) as a dotted name (`com.foo.bar`); empty for the root. */
+  private def packageDotted(pkgSymbol: String): String =
+    pkgSymbol.stripSuffix("/").replace('/', '.')
+
+  private def joinFqn(pkg: String, name: String): String =
+    if pkg.isEmpty then name else s"$pkg.$name"
+
+  /** The package a document belongs to: the owner of its first top-level global definition. `None`
+    * if the document is not indexed or declares nothing top-level.
+    */
+  private def documentPackage(uri: String): Option[String] =
+    index.document(uri).flatMap { doc =>
+      doc.occurrences.iterator
+        .filter(_.role == s.SymbolOccurrence.Role.DEFINITION)
+        .map(_.symbol)
+        .filter(index.isGlobal)
+        .map(index.owner)
+        .find(index.isPackage)
+    }
+
+  // --- extract method plan --------------------------------------------------
+
+  /** The plan to extract the `[start, end)` selection of `uri` into a new method `methodName`.
+    *
+    * Free-variable analysis over the selection's SemanticDB occurrences: a local the selection
+    * READS but whose definition lies outside the selection becomes a parameter; a local the
+    * selection DEFINES that is still referenced after the selection becomes part of the result.
+    * This is exactly the analysis a correct extract-method needs, and it is grounded in the
+    * compiler's resolved symbols and types — not text heuristics. `None` if the uri is not indexed.
+    */
+  def extractMethodPlan(
+      uri: String,
+      startLine: Int,
+      startChar: Int,
+      endLine: Int,
+      endChar: Int,
+      methodName: String
+  ): Option[ExtractMethodPlan] =
+    index.document(uri).map { doc =>
+      def inSelection(r: s.Range): Boolean =
+        val afterStart =
+          r.startLine > startLine || (r.startLine == startLine && r.startCharacter >= startChar)
+        val beforeEnd =
+          r.endLine < endLine || (r.endLine == endLine && r.endCharacter <= endChar)
+        afterStart && beforeEnd
+      def afterSelection(r: s.Range): Boolean =
+        r.startLine > endLine || (r.startLine == endLine && r.startCharacter >= endChar)
+
+      val occ = doc.occurrences
+      // Definition occurrences of each local, used to decide inside/outside the selection.
+      val defInside = occ.iterator
+        .filter(o => o.role == s.SymbolOccurrence.Role.DEFINITION && o.range.exists(inSelection))
+        .map(_.symbol)
+        .filter(index.isLocal)
+        .toSet
+      val definedAnywhere = occ.iterator
+        .filter(_.role == s.SymbolOccurrence.Role.DEFINITION)
+        .map(_.symbol)
+        .toSet
+
+      // Parameters: locals READ in the selection whose definition is NOT inside it (free vars),
+      // ordered by first read position, de-duplicated.
+      val params = occ.iterator
+        .filter(o => o.role == s.SymbolOccurrence.Role.REFERENCE && o.range.exists(inSelection))
+        .filter(o => index.isLocal(o.symbol) && !defInside.contains(o.symbol))
+        .toList
+        .sortBy(o => o.range.map(r => (r.startLine, r.startCharacter)).getOrElse((0, 0)))
+        .map(_.symbol)
+        .distinct
+        .map(sym => ExtractBinding(localName(sym), localTypeText(sym)))
+
+      // Returns: locals DEFINED inside the selection that are still READ after it.
+      val readAfter = occ.iterator
+        .filter(o => o.role == s.SymbolOccurrence.Role.REFERENCE && o.range.exists(afterSelection))
+        .map(_.symbol)
+        .toSet
+      val returns = occ.iterator
+        .filter(o => o.role == s.SymbolOccurrence.Role.DEFINITION && o.range.exists(inSelection))
+        .filter(o => index.isLocal(o.symbol) && readAfter.contains(o.symbol))
+        .toList
+        .sortBy(o => o.range.map(r => (r.startLine, r.startCharacter)).getOrElse((0, 0)))
+        .map(_.symbol)
+        .distinct
+        .map(sym => ExtractBinding(localName(sym), localTypeText(sym)))
+
+      // The method the selection sits in: nearest preceding method definition in the file.
+      val enclosing = occ
+        .filter(o => o.role == s.SymbolOccurrence.Role.DEFINITION && index.isMethod(o.symbol))
+        .filter(o =>
+          o.range.exists(r =>
+            r.startLine < startLine ||
+              (r.startLine == startLine && r.startCharacter <= startChar)
+          )
+        )
+        .maxByOption(o => o.range.map(r => (r.startLine, r.startCharacter)).getOrElse((0, 0)))
+        .map(o => symbolRef(o.symbol))
+
+      val returnType = returns match
+        case Nil      => "Unit"
+        case b :: Nil => b.tpe
+        case many     => many.map(_.tpe).mkString("(", ", ", ")")
+      val paramText = params.map(p => s"${p.name}: ${p.tpe}").mkString(", ")
+      val signature = s"def $methodName($paramText): $returnType"
+      val args = params.map(_.name).mkString(", ")
+      val call = returns match
+        case Nil      => s"$methodName($args)"
+        case b :: Nil => s"val ${b.name} = $methodName($args)"
+        case many     => s"val (${many.map(_.name).mkString(", ")}) = $methodName($args)"
+
+      val range = Range(Position(startLine, startChar), Position(endLine, endChar))
+      ExtractMethodPlan(
+        uri,
+        range,
+        methodName,
+        enclosing,
+        params,
+        returns,
+        returnType,
+        signature,
+        call
+      )
+    }
+
+  /** A local symbol's display name (locals carry no descriptor, so fall back to the index). */
+  private def localName(symbol: String): String =
+    index.info(symbol).map(_.displayName).filter(_.nonEmpty).getOrElse(symbol)
+
+  /** A local's rendered type, or `?` when SemanticDB recorded none — Scala leaves the inferred type
+    * of an unascribed local val Empty, so the caller must supply it (the binding name is always
+    * exact).
+    */
+  private def localTypeText(symbol: String): String =
+    val rendered = renderType(index.info(symbol).map(valueType).getOrElse(s.Type.Empty))
+    if rendered.isEmpty then "?" else rendered
 
   // --- find-symbol ----------------------------------------------------------
 

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/Models.scala
@@ -211,6 +211,58 @@ case class RenamePlan(
     edits: List[RenameEdit]
 ) derives ReadWriter
 
+// --- move plan --------------------------------------------------------------
+
+/** One file's import adjustment for a move: in `uri`, drop `removeImport` (if non-empty) and add
+  * `addImport` (if non-empty), both as dotted fully-qualified names. A file already in the
+  * destination package needs neither and is omitted from the plan.
+  */
+case class MoveImport(uri: String, removeImport: String, addImport: String) derives ReadWriter
+
+/** The edits to move `symbol` from `fromOwner` to `toOwner` (both package symbols), keeping every
+  * call/usage resolving. `definition` is the occurrence to relocate; `references` is every
+  * compiler-resolved use across the project (so the move touches calls/usages, not just the body);
+  * `imports` is the per-file import adjustment that move-induced FQN change requires. The server is
+  * read-only — apply the returned edits yourself.
+  */
+case class MovePlan(
+    symbol: String,
+    displayName: String,
+    kind: String,
+    fromOwner: String,
+    toOwner: String,
+    fromFqn: String,
+    toFqn: String,
+    definition: Option[Location],
+    references: List[Location],
+    imports: List[MoveImport]
+) derives ReadWriter
+
+// --- extract method plan ----------------------------------------------------
+
+/** A name/type pair in an extracted method's surface (a parameter or a returned local). */
+case class ExtractBinding(name: String, tpe: String) derives ReadWriter
+
+/** The plan to extract the selected range of `uri` into a new method `methodName`. `parameters` are
+  * the locals the selection reads but does not define (free variables → params); `returns` are the
+  * locals it defines and that later code outside the selection still uses (→ the result).
+  * `signature` is the new method's declaration and `call` is the expression that replaces the
+  * selection (so both the extracted body AND its call site are covered). `enclosingMethod` is the
+  * method the selection sits in, where the new method belongs. The server is read-only — apply the
+  * edits yourself.
+  */
+case class ExtractMethodPlan(
+    uri: String,
+    range: Range,
+    methodName: String,
+    enclosingMethod: Option[SymbolRef],
+    parameters: List[ExtractBinding],
+    returns: List[ExtractBinding],
+    returnType: String,
+    signature: String,
+    call: String
+) derives ReadWriter
+
 // --- call-graph path-find ---------------------------------------------------
 
 case class CallEdge(from: SymbolRef, to: SymbolRef, at: Location) derives ReadWriter

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerPcSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerPcSuite.scala
@@ -53,6 +53,38 @@ class AnalyzerPcSuite extends munit.FunSuite:
     assertEquals(at.tpe, "Int")
   }
 
+  // A method body with locals so extract-method's free-variable analysis has real structure.
+  // Lines (0-based): 4 `val a`, 5 `val b`, 6 `val c`, 7 `c`.
+  private val calc =
+    """package demo
+      |
+      |object Calc:
+      |  def run(n: Int): Int =
+      |    val a: Int = n + 1
+      |    val b: Int = a * 2
+      |    val c: Int = b + a
+      |    c
+      |""".stripMargin
+  private val calcFile = workspace.resolve("Calc.scala").nn
+  java.nio.file.Files.writeString(calcFile, calc)
+
+  test("extractMethodPlan derives params (free vars), returns (live-out), and the call site") {
+    val live = az.bufferOnly(calcFile.toUri, calc, "Calc.scala").getOrElse(fail("no PC backend"))
+    // Select lines 5..6 (`val b = a * 2` and `val c = b + a`); end is exclusive at (7, 0).
+    val p = live
+      .extractMethodPlan("Calc.scala", 5, 0, 7, 0, "compute")
+      .getOrElse(fail("expected an extract plan"))
+    // `a` is read inside but defined above the selection → a parameter.
+    assertEquals(p.parameters.map(_.name), List("a"))
+    assertEquals(p.parameters.map(_.tpe), List("Int"))
+    // `c` is defined inside and read on line 7 (after the selection) → the return; `b` is not.
+    assertEquals(p.returns.map(_.name), List("c"))
+    assertEquals(p.returnType, "Int")
+    assertEquals(p.signature, "def compute(a: Int): Int")
+    assertEquals(p.call, "val c = compute(a)")
+    assertEquals(p.enclosingMethod.map(_.displayName), Some("run"))
+  }
+
   test("bufferOnly (PC-only) queries the buffer alone; withBuffer (overlay) keeps the disk index") {
     // A disk index holding an unrelated document; the two routings differ on whether it shows.
     val diskDoc = s.TextDocument(

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerSuite.scala
@@ -1,6 +1,9 @@
 package com.github.mercurievv.scalasemantic.analysis
 
+import com.github.mercurievv.scalasemantic.model.MoveImport
 import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+import scala.meta.internal.semanticdb as s
 
 /** Phase 3: query-engine tests against the `com.github.mercurievv.scalasemantic.fixtures`
   * SemanticDB. Several of these exercise relationships (known subtypes, implicit param lists) that
@@ -212,4 +215,34 @@ class AnalyzerSuite extends munit.FunSuite:
   test("callPath returns an empty path when the target is unreachable") {
     // c calls nothing, so a is not reachable from c.
     assertEquals(az.callPath(calls("c"), calls("a")).path, Nil)
+  }
+
+  test("movePlan relocates a symbol and rewrites its FQN, keeping every usage") {
+    val p = az.movePlan(Animal, "com/github/mercurievv/scalasemantic/relocated/")
+    assertEquals(p.fromFqn, "com.github.mercurievv.scalasemantic.fixtures.Animal")
+    assertEquals(p.toFqn, "com.github.mercurievv.scalasemantic.relocated.Animal")
+    assert(p.definition.nonEmpty, "Animal should have a definition to relocate")
+    // Dog and Fish `extends Animal` → the move covers calls/usages, not just the body.
+    assert(p.references.nonEmpty, "the move must list every reference")
+  }
+
+  test("movePlan emits a per-file import swap for cross-package references") {
+    // Two files, two packages: Foo defined in pkgA, referenced from a file in pkgB.
+    def occ(sym: String, role: s.SymbolOccurrence.Role, line: Int) =
+      s.SymbolOccurrence(symbol = sym, role = role, range = Some(s.Range(line, 0, line, 3)))
+    val docA = s.TextDocument(
+      uri = "a/Foo.scala",
+      occurrences = Seq(occ("pkgA/Foo#", s.SymbolOccurrence.Role.DEFINITION, 0))
+    )
+    val docB = s.TextDocument(
+      uri = "b/Bar.scala",
+      occurrences = Seq(
+        occ("pkgB/Bar#", s.SymbolOccurrence.Role.DEFINITION, 0),
+        occ("pkgA/Foo#", s.SymbolOccurrence.Role.REFERENCE, 1)
+      )
+    )
+    val mz = new Analyzer(new SemanticIndex(Vector(docA, docB)))
+    val p = mz.movePlan("pkgA/Foo#", "pkgC/")
+    // the definition's own file moves with it (no import edit there); only Bar.scala needs one
+    assertEquals(p.imports, List(MoveImport("b/Bar.scala", "pkgA.Foo", "pkgC.Foo")))
   }

--- a/core/src/main/scala/com/github/mercurievv/scalasemantic/semanticdb/SemanticIndex.scala
+++ b/core/src/main/scala/com/github/mercurievv/scalasemantic/semanticdb/SemanticIndex.scala
@@ -25,6 +25,16 @@ final class SemanticIndex(val documents: Vector[s.TextDocument]):
   val occurrences: Vector[(String, s.SymbolOccurrence)] =
     documents.flatMap(d => d.occurrences.map(d.uri -> _))
 
+  /** Occurrences grouped by their symbol, so per-symbol queries (usages, rename, definition uri)
+    * are a map lookup instead of a full scan of [[occurrences]].
+    */
+  val occurrencesBySymbol: Map[String, Vector[(String, s.SymbolOccurrence)]] =
+    occurrences.groupBy(_._2.symbol)
+
+  /** Occurrences of one symbol across all documents (empty if none). */
+  def occurrencesOf(symbol: String): Vector[(String, s.SymbolOccurrence)] =
+    occurrencesBySymbol.getOrElse(symbol, Vector.empty)
+
   private val docByUri: Map[String, s.TextDocument] =
     documents.map(d => d.uri -> d).toMap
 

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -50,19 +50,21 @@ object Mcp:
       |files, non-Scala files), or when these tools genuinely do not fit.
       |
       |Pick the tool by what you want to know:
-      |  who calls / references a symbol, where it is used  → find_usages
-      |  subtypes / supertypes / implementers of a type     → class_hierarchy
-      |  a method's signature / parameters / return         → method_signature
-      |  the overloads of a method                          → find_overloads
-      |  members a type declares vs. inherits               → members
-      |  which givens/implicits apply, the implicit chain   → resolve_implicits, trace_implicit_chain
-      |  whether method A reaches B, the call path          → call_path
-      |  the symbol/type at a source position               → type_at_position
-      |  the symbol for a plain name                        → find_symbol
-      |  what's important / where to start, dep cycles       → structure
-      |  a file's structure / where to edit (don't read it)  → document_outline
-      |  the full text of a .scala file (read it THIS way)   → annotated_source
-      |  the exact edits to rename a symbol safely           → rename_plan
+      |  who calls / references a symbol, where it is used    → find_usages
+      |  subtypes / supertypes / implementers of a type       → class_hierarchy
+      |  a method's signature / parameters / return           → method_signature
+      |  the overloads of a method                            → find_overloads
+      |  members a type declares vs. inherits                 → members
+      |  which givens/implicits apply, the implicit chain     → resolve_implicits, trace_implicit_chain
+      |  whether method A reaches B, the call path            → call_path
+      |  the symbol/type at a source position                 → type_at_position
+      |  the symbol for a plain name                          → find_symbol
+      |  what's important / where to start, dep cycles        → structure
+      |  a file's structure / where to edit (don't read it)   → document_outline
+      |  the full text of a .scala file (read it THIS way)    → annotated_source
+      |  the exact edits to rename a symbol safely            → rename_plan
+      |  the edits to move a symbol to another package        → move_plan
+      |  the edits to extract a code range into a new method  → extract_method_plan
       |
       |Symbols: every tool except find_symbol and type_at_position takes a SemanticDB symbol string
       |(grammar: package `foo/`, type `Foo#`, term `foo.`, method `foo().`, overloads `foo().(+1)`).
@@ -70,7 +72,7 @@ object Mcp:
       |from `find_symbol` (from a name) or `type_at_position` (from a source location), then pass it on.
       |
       |Worked example — "who calls Service.run?":
-      |  1. find_symbol "run"  → choose the result whose symbol ends `…/Service#run().`
+      |  1. find_symbol "run"                                 → choose the result whose symbol ends `…/Service#run().`
       |  2. find_usages (or call_path) with that symbol.
       |
       |Recovery: if a tool returns `found:false`, `count:0`, or empty lists, the symbol string is

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -571,6 +571,99 @@ object McpTools:
           )
         )
       )
+    },
+    tool(
+      "move_plan",
+      "The edits to move a top-level definition (class/object/trait/def/val) to another package " +
+        "while keeping every call and usage compiling — not just the definition itself. Three parts: " +
+        "the `definition` location to cut and re-place under `newOwner`; every compiler-resolved " +
+        "`reference` to it across the project (so you can confirm nothing is missed); and the per-file " +
+        "`imports` to add/remove, since the move changes the symbol's fully-qualified name (a file " +
+        "already in the destination package needs none). `newOwner` is the destination package symbol, " +
+        "e.g. `com/foo/bar/`; the simple name is unchanged. Read-only — apply the edits yourself.",
+      List(
+        ("symbol", "string", "the symbol to move"),
+        ("newOwner", "string", "destination package symbol, e.g. `com/foo/bar/`")
+      ),
+      List("symbol", "newOwner")
+    ) { a =>
+      val p = az.movePlan(argStr(a, "symbol"), argStr(a, "newOwner"))
+      jobj(
+        Some("symbol" -> ujson.Str(p.symbol)),
+        Some("move" -> ujson.Str(s"${p.fromFqn} -> ${p.toFqn}")),
+        p.definition.map(d => "definition" -> ujson.Str(loc(d))),
+        Some("referenceCount" -> ujson.Num(p.references.size)),
+        opt(p.references.nonEmpty, "references" -> strs(p.references.map(loc))),
+        opt(
+          p.imports.nonEmpty,
+          "imports" -> ujson.Arr.from(
+            p.imports.map(i =>
+              jobj(
+                Some("uri" -> ujson.Str(i.uri)),
+                opt(i.removeImport.nonEmpty, "remove" -> ujson.Str(i.removeImport)),
+                opt(i.addImport.nonEmpty, "add" -> ujson.Str(i.addImport))
+              )
+            )
+          )
+        )
+      )
+    },
+    tool(
+      "extract_method_plan",
+      "The edits to extract a selected source range into a new method — both the new method AND the " +
+        "call that replaces the selection. From the compiler's resolved symbols/types in the range: " +
+        "locals it READS but does not define become the parameters (with real types); locals it " +
+        "DEFINES that later code still uses become the return. Returns the `signature` to insert in " +
+        "the enclosing scope and the `call` to put where the selection was. A binding name is always " +
+        "exact; an inferred local val whose type SemanticDB did not record renders as `?` for you to " +
+        "fill. Give the selection as start/end line+character (0-based, end exclusive). Pass `source` " +
+        "(the file's CURRENT text) to analyse a buffer edited since — or never — compiled (needs a " +
+        "classpath-started server). Read-only — apply the edits yourself.",
+      List(
+        ("uri", "string", "document uri (path relative to project root)"),
+        ("startLine", "integer", "0-based start line of the selection"),
+        ("startCharacter", "integer", "0-based start column of the selection"),
+        ("endLine", "integer", "0-based end line of the selection (exclusive end)"),
+        ("endCharacter", "integer", "0-based end column of the selection (exclusive)"),
+        ("methodName", "string", "name for the extracted method (default `extracted`)"),
+        ("source", "string", "current full text of the file at `uri`; enables the live PC overlay")
+      ),
+      List("uri", "startLine", "startCharacter", "endLine", "endCharacter")
+    ) { a =>
+      val uri = argStr(a, "uri")
+      val name = argStr(a, "methodName") match
+        case "" => "extracted"
+        case n  => n
+      // PC-only: extraction is a single-file analysis, so when `source` is given query the PC's
+      // regenerated document alone rather than overlaying the (stale-for-this-file) disk index.
+      val engine = a.obj.get("source").map(_.str) match
+        case Some(src) => az.bufferOnly(root.resolve(uri).toUri, src, uri).getOrElse(az)
+        case None      => az
+      engine.extractMethodPlan(
+        uri,
+        argInt(a, "startLine", 0),
+        argInt(a, "startCharacter", 0),
+        argInt(a, "endLine", 0),
+        argInt(a, "endCharacter", 0),
+        name
+      ) match
+        case None => notFoundUri(uri)
+        case Some(p) =>
+          jobj(
+            Some("uri" -> ujson.Str(p.uri)),
+            p.enclosingMethod.map(m => "enclosingMethod" -> ujson.Str(m.displayName)),
+            Some("signature" -> ujson.Str(p.signature)),
+            Some("call" -> ujson.Str(p.call)),
+            opt(
+              p.parameters.nonEmpty,
+              "parameters" -> strs(p.parameters.map(b => s"${b.name}: ${b.tpe}"))
+            ),
+            opt(
+              p.returns.nonEmpty,
+              "returns" -> strs(p.returns.map(b => s"${b.name}: ${b.tpe}"))
+            ),
+            Some("returnType" -> ujson.Str(p.returnType))
+          )
     }
   )
 

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/McpSuite.scala
@@ -39,10 +39,10 @@ class McpSuite extends munit.FunSuite:
     assert(instr.contains("find_symbol"), instr)
   }
 
-  test("tools/list exposes all fourteen tools with schemas") {
+  test("tools/list exposes all sixteen tools with schemas") {
     val r = Mcp.handle(req("tools/list", ujson.Obj()), tools).get
     val names = r("result")("tools").arr.map(_("name").str).toSet
-    assertEquals(names.size, 14)
+    assertEquals(names.size, 16)
     assert(names.contains("find_symbol"), names.toString)
     assert(names.contains("find_usages"), names.toString)
     assert(names.contains("call_path"), names.toString)
@@ -50,6 +50,8 @@ class McpSuite extends munit.FunSuite:
     assert(names.contains("document_outline"), names.toString)
     assert(names.contains("annotated_source"), names.toString)
     assert(names.contains("rename_plan"), names.toString)
+    assert(names.contains("move_plan"), names.toString)
+    assert(names.contains("extract_method_plan"), names.toString)
     // every tool carries an object input schema
     assert(r("result")("tools").arr.forall(_("inputSchema")("type").str == "object"))
   }
@@ -184,6 +186,64 @@ class McpSuite extends munit.FunSuite:
     assert(rp("editCount").num > 0, "expected occurrences to rename")
     // edits are uri:line:col-col ranges (definition + references), not whole lines
     assert(rp("edits").arr.forall(_.str.matches(""".+:\d+:\d+-\d+""")), rp.render())
+  }
+
+  test("move_plan relocates a symbol and lists references + the FQN change") {
+    val mp = call(
+      "move_plan",
+      ujson.Obj("symbol" -> Animal, "newOwner" -> "com/github/mercurievv/scalasemantic/moved/")
+    )
+    assertEquals(
+      mp("move").str,
+      "com.github.mercurievv.scalasemantic.fixtures.Animal -> " +
+        "com.github.mercurievv.scalasemantic.moved.Animal"
+    )
+    assert(mp.obj.contains("definition"), mp.render())
+    assert(mp("referenceCount").num > 0, "the move must surface calls/usages")
+  }
+
+  test("extract_method_plan renders the new signature and the replacing call") {
+    // A buffer with a method body and locals; lives on disk so the PC can resolve its path.
+    val root = java.nio.file.Files.createTempDirectory("mcp-extract").nn
+    val file = root.resolve("Calc.scala").nn
+    val source =
+      """package demo
+        |
+        |object Calc:
+        |  def run(n: Int): Int =
+        |    val a: Int = n + 1
+        |    val b: Int = a * 2
+        |    val c: Int = b + a
+        |    c
+        |""".stripMargin
+    java.nio.file.Files.writeString(file, source)
+
+    val backend = PresentationCompilerBackend.fromCurrentJvm(workspace = Some(root))
+    try
+      val pcTools = McpTools.all(Analyzer(new SemanticIndex(Vector.empty), Some(backend)), root)
+      val resp = Mcp.handle(
+        req(
+          "tools/call",
+          ujson.Obj(
+            "name" -> "extract_method_plan",
+            "arguments" -> ujson.Obj(
+              "uri" -> "Calc.scala",
+              "startLine" -> 5,
+              "startCharacter" -> 0,
+              "endLine" -> 7,
+              "endCharacter" -> 0,
+              "methodName" -> "compute",
+              "source" -> source
+            )
+          )
+        ),
+        pcTools
+      )
+      val r = ujson.read(resp.getOrElse(fail("no response"))("result")("content")(0)("text").str)
+      assertEquals(r("signature").str, "def compute(a: Int): Int")
+      assertEquals(r("call").str, "val c = compute(a)")
+      assertEquals(r("enclosingMethod").str, "run")
+    finally backend.close()
   }
 
   test("tools/call invokes the debug-logging hook with the tool name and args") {
@@ -378,5 +438,5 @@ class McpSuite extends munit.FunSuite:
     // 4 lines in (one blank, one notification) → 2 responses out, with matching ids
     assertEquals(out.size, 2)
     assertEquals(ujson.read(out(0))("id").num, 1.0)
-    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 14)
+    assertEquals(ujson.read(out(1))("result")("tools").arr.size, 16)
   }


### PR DESCRIPTION
Adds two read-only refactoring-plan tools to the MCP surface, alongside the existing `rename_plan`. Both follow the established **plan** contract: the server computes the exact edits from SemanticDB; the caller applies them (no file writes server-side).

## `move_plan`
Move a top-level definition (class/object/trait/def/val) to another package while keeping every call and usage compiling. Returns:
- the `definition` location to cut and re-place under `newOwner`;
- every compiler-resolved `reference` across the project (so usages keep resolving — not just the body);
- the per-file `imports` to add/remove, since the move changes the symbol's fully-qualified name (a file already in the destination package needs none).

## `extract_method_plan`
Free-variable analysis over a selected source range:
- locals it **reads but does not define** → parameters (with resolved types);
- locals it **defines that later code still uses** → the return;
- renders the new method `signature` and the `call` that replaces the selection.

Covers both the extracted body and its call site. An inferred local val whose type SemanticDB leaves unrecorded renders as `?` for the caller to fill (binding names are always exact).

## Discovery / clarity
- Both tools added to the `initialize` routing table; the whole table's arrows are now column-aligned.
- Per-tool descriptions name the output fields so the model knows the result shape before calling.

## Tests
- `AnalyzerSuite`: move FQN rewrite + cross-package import-swap (hand-built index).
- `AnalyzerPcSuite`: extract free-var/live-out analysis on an inline PC-compiled buffer.
- `McpSuite`: both tools end-to-end; tool count 14 → 16.

## Note
Includes the prerequisite `perf(analysis): index occurrences by symbol` commit (`occurrencesOf`), which `move_plan` builds on and was not yet on master.