### PR TITLE
refactor(analysis): extract SemanticRendering from Analyzer

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -21,6 +21,12 @@ final class Analyzer(
     pc: Option[PresentationCompilerBackend] = None
 ):
 
+  /** Symbol→text printers and pure SemanticDB accessors, imported below so the analyzer can call
+    * them unqualified (`renderType`, `symbolRef`, `location`, …) while their bodies live elsewhere.
+    */
+  private val rendering = SemanticRendering(index)
+  import rendering.*
+
   /** An analyzer whose index has `code` (the live contents of the file at `fileUri`) overlaid via
     * the presentation compiler, the overlaid document keyed by `docUri` so it replaces the matching
     * disk document. `fileUri` must point at a real on-disk path (the PC reads `code`, but needs a
@@ -832,102 +838,3 @@ final class Analyzer(
 
   private def memberInfo(member: String, declaredIn: String): MemberInfo =
     MemberInfo(member, index.displayName(member), kindName(member), symbolRef(declaredIn))
-
-  private def rangeContains(r: s.Range, line: Int, character: Int): Boolean =
-    val afterStart = line > r.startLine || (line == r.startLine && character >= r.startCharacter)
-    val beforeEnd = line < r.endLine || (line == r.endLine && character < r.endCharacter)
-    afterStart && beforeEnd
-
-  private def rangeSpan(r: s.Range): Int =
-    (r.endLine - r.startLine) * 10000 + (r.endCharacter - r.startCharacter)
-
-  /** A symbol's type as text: a method's return, a value's type, else the symbol's own name. */
-  private def typeString(symbol: String): String =
-    index.info(symbol).map(_.signature) match
-      case Some(m: s.MethodSignature) => renderType(m.returnType)
-      case Some(v: s.ValueSignature)  => renderType(v.tpe)
-      case _                          => index.displayName(symbol)
-
-  private def location(uri: String, range: Option[s.Range]): Location =
-    val r = range.getOrElse(s.Range.defaultInstance)
-    Location(
-      uri,
-      Range(Position(r.startLine, r.startCharacter), Position(r.endLine, r.endCharacter))
-    )
-
-  private def symbolRef(symbol: String): SymbolRef =
-    SymbolRef(symbol, index.displayName(symbol), kindName(symbol))
-
-  private def kindName(symbol: String): String =
-    index.info(symbol).map(_.kind.toString).getOrElse("UNKNOWN")
-
-  private def parentSymbol(tpe: s.Type): Option[String] =
-    tpe match
-      case s.TypeRef(_, sym, _) => Some(sym)
-      case s.SingleType(_, sym) => Some(sym)
-      case _                    => None
-
-  private def scopeInfos(scope: Option[s.Scope]): Seq[s.SymbolInformation] =
-    scope.toSeq.flatMap { sc =>
-      if sc.hardlinks.nonEmpty then sc.hardlinks
-      else sc.symlinks.flatMap(index.info)
-    }
-
-  private def valueType(info: s.SymbolInformation): s.Type =
-    info.signature match
-      case v: s.ValueSignature  => v.tpe
-      case m: s.MethodSignature => m.returnType
-      case _                    => s.Type.Empty
-
-  private def isImplicit(info: s.SymbolInformation): Boolean =
-    (info.properties & s.SymbolInformation.Property.IMPLICIT.value) != 0
-
-  private def renderMethod(
-      name: String,
-      tparams: List[String],
-      plists: List[ParameterList],
-      ret: String
-  ): String =
-    val tp = if tparams.isEmpty then "" else tparams.mkString("[", ", ", "]")
-    val ps = plists.map { pl =>
-      val prefix = if pl.isImplicit then "implicit " else ""
-      pl.parameters.map(p => s"${p.name}: ${p.tpe}").mkString(s"($prefix", ", ", ")")
-    }.mkString
-    s"def $name$tp$ps: $ret"
-
-  /** Best-effort rendering of a SemanticDB type to readable Scala-ish text. */
-  private def renderType(tpe: s.Type): String =
-    tpe match
-      case s.TypeRef(_, sym, args) =>
-        val base = index.displayName(sym)
-        if args.isEmpty then base else args.map(renderType).mkString(s"$base[", ", ", "]")
-      case s.SingleType(_, sym)    => s"${index.displayName(sym)}.type"
-      case s.ThisType(sym)         => s"${index.displayName(sym)}.this"
-      case s.SuperType(_, sym)     => index.displayName(sym)
-      case s.ByNameType(t)         => s"=> ${renderType(t)}"
-      case s.RepeatedType(t)       => s"${renderType(t)}*"
-      case s.WithType(ts)          => ts.map(renderType).mkString(" with ")
-      case s.IntersectionType(ts)  => ts.map(renderType).mkString(" & ")
-      case s.UnionType(ts)         => ts.map(renderType).mkString(" | ")
-      case s.AnnotatedType(_, t)   => renderType(t)
-      case s.ExistentialType(t, _) => renderType(t)
-      case s.UniversalType(_, t)   => renderType(t)
-      case s.StructuralType(t, _)  => renderType(t)
-      case s.ConstantType(c)       => renderConstant(c)
-      case _                       => ""
-
-  /** Render a literal/constant type (Scala 3 singleton-literal types, e.g. `42`, `"x"`, `true`). */
-  private def renderConstant(c: s.Constant): String =
-    c match
-      case s.IntConstant(v)     => v.toString
-      case s.LongConstant(v)    => s"${v}L"
-      case s.FloatConstant(v)   => s"${v}f"
-      case s.DoubleConstant(v)  => v.toString
-      case s.BooleanConstant(v) => v.toString
-      case s.CharConstant(v)    => s"'${v.toChar}'"
-      case s.StringConstant(v)  => s"\"$v\""
-      case s.ShortConstant(v)   => v.toString
-      case s.ByteConstant(v)    => v.toString
-      case s.UnitConstant()     => "Unit"
-      case s.NullConstant()     => "null"
-      case _                    => ""

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/SemanticRendering.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/SemanticRendering.scala
@@ -1,0 +1,112 @@
+package com.github.mercurievv.scalasemantic.analysis
+
+import com.github.mercurievv.scalasemantic.model.*
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+import scala.meta.internal.semanticdb as s
+
+/** Stateless rendering/lookup helpers over a [[SemanticIndex]]: the symbol→text printers and the
+  * small pure SemanticDB accessors that [[Analyzer]] leans on across every tool. Extracted so the
+  * analyzer stays focused on query logic and delegates the "how do I say this in text / read this
+  * field" concerns here. Holds no state beyond the index; safe to share.
+  */
+final class SemanticRendering(index: SemanticIndex):
+
+  def rangeContains(r: s.Range, line: Int, character: Int): Boolean =
+    val afterStart = line > r.startLine || (line == r.startLine && character >= r.startCharacter)
+    val beforeEnd = line < r.endLine || (line == r.endLine && character < r.endCharacter)
+    afterStart && beforeEnd
+
+  def rangeSpan(r: s.Range): Int =
+    (r.endLine - r.startLine) * 10000 + (r.endCharacter - r.startCharacter)
+
+  /** A symbol's type as text: a method's return, a value's type, else the symbol's own name. */
+  def typeString(symbol: String): String =
+    index.info(symbol).map(_.signature) match
+      case Some(m: s.MethodSignature) => renderType(m.returnType)
+      case Some(v: s.ValueSignature)  => renderType(v.tpe)
+      case _                          => index.displayName(symbol)
+
+  def location(uri: String, range: Option[s.Range]): Location =
+    val r = range.getOrElse(s.Range.defaultInstance)
+    Location(
+      uri,
+      Range(Position(r.startLine, r.startCharacter), Position(r.endLine, r.endCharacter))
+    )
+
+  def symbolRef(symbol: String): SymbolRef =
+    SymbolRef(symbol, index.displayName(symbol), kindName(symbol))
+
+  def kindName(symbol: String): String =
+    index.info(symbol).map(_.kind.toString).getOrElse("UNKNOWN")
+
+  def parentSymbol(tpe: s.Type): Option[String] =
+    tpe match
+      case s.TypeRef(_, sym, _) => Some(sym)
+      case s.SingleType(_, sym) => Some(sym)
+      case _                    => None
+
+  def scopeInfos(scope: Option[s.Scope]): Seq[s.SymbolInformation] =
+    scope.toSeq.flatMap { sc =>
+      if sc.hardlinks.nonEmpty then sc.hardlinks
+      else sc.symlinks.flatMap(index.info)
+    }
+
+  def valueType(info: s.SymbolInformation): s.Type =
+    info.signature match
+      case v: s.ValueSignature  => v.tpe
+      case m: s.MethodSignature => m.returnType
+      case _                    => s.Type.Empty
+
+  def isImplicit(info: s.SymbolInformation): Boolean =
+    (info.properties & s.SymbolInformation.Property.IMPLICIT.value) != 0
+
+  def renderMethod(
+      name: String,
+      tparams: List[String],
+      plists: List[ParameterList],
+      ret: String
+  ): String =
+    val tp = if tparams.isEmpty then "" else tparams.mkString("[", ", ", "]")
+    val ps = plists.map { pl =>
+      val prefix = if pl.isImplicit then "implicit " else ""
+      pl.parameters.map(p => s"${p.name}: ${p.tpe}").mkString(s"($prefix", ", ", ")")
+    }.mkString
+    s"def $name$tp$ps: $ret"
+
+  /** Best-effort rendering of a SemanticDB type to readable Scala-ish text. */
+  def renderType(tpe: s.Type): String =
+    tpe match
+      case s.TypeRef(_, sym, args) =>
+        val base = index.displayName(sym)
+        if args.isEmpty then base else args.map(renderType).mkString(s"$base[", ", ", "]")
+      case s.SingleType(_, sym)    => s"${index.displayName(sym)}.type"
+      case s.ThisType(sym)         => s"${index.displayName(sym)}.this"
+      case s.SuperType(_, sym)     => index.displayName(sym)
+      case s.ByNameType(t)         => s"=> ${renderType(t)}"
+      case s.RepeatedType(t)       => s"${renderType(t)}*"
+      case s.WithType(ts)          => ts.map(renderType).mkString(" with ")
+      case s.IntersectionType(ts)  => ts.map(renderType).mkString(" & ")
+      case s.UnionType(ts)         => ts.map(renderType).mkString(" | ")
+      case s.AnnotatedType(_, t)   => renderType(t)
+      case s.ExistentialType(t, _) => renderType(t)
+      case s.UniversalType(_, t)   => renderType(t)
+      case s.StructuralType(t, _)  => renderType(t)
+      case s.ConstantType(c)       => renderConstant(c)
+      case _                       => ""
+
+  /** Render a literal/constant type (Scala 3 singleton-literal types, e.g. `42`, `"x"`, `true`). */
+  def renderConstant(c: s.Constant): String =
+    c match
+      case s.IntConstant(v)     => v.toString
+      case s.LongConstant(v)    => s"${v}L"
+      case s.FloatConstant(v)   => s"${v}f"
+      case s.DoubleConstant(v)  => v.toString
+      case s.BooleanConstant(v) => v.toString
+      case s.CharConstant(v)    => s"'${v.toChar}'"
+      case s.StringConstant(v)  => s"\"$v\""
+      case s.ShortConstant(v)   => v.toString
+      case s.ByteConstant(v)    => v.toString
+      case s.UnitConstant()     => "Unit"
+      case s.NullConstant()     => "null"
+      case _                    => ""


### PR DESCRIPTION
## What

Extract a stateless `SemanticRendering(index)` collaborator out of `Analyzer`, holding the symbol→text printers and pure SemanticDB accessors: `renderType`, `renderConstant`, `renderMethod`, `symbolRef`, `kindName`, `location`, `typeString`, `parentSymbol`, `scopeInfos`, `valueType`, `isImplicit`, `rangeContains`, `rangeSpan`.

`Analyzer` holds `private val rendering = SemanticRendering(index)` and `import rendering.*`, so all call sites stay unqualified — a pure mechanical move, no behaviour change.

## Why

`Analyzer` had grown into one large flat-scope class mixing query logic with rendering/lookup helpers. This shrinks it (933 → 840 lines) to focused query logic and isolates the "render to text / read this field" concerns.

Deliberately **not** split into Hierarchy/Implicit/CallGraph classes — they share too many helpers; that would just move coupling into constructor wiring.

## Test

Full `sbt test` green (incl. dogfood + MCP suites); `scalafmtAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)