### PR TITLE
ci: add Scala Steward for automated dependency updates

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,18 @@
+name: Scala Steward
+
+on:
+  workflow_dispatch:                # manual: Actions tab -> Run workflow
+  schedule:
+    - cron: "0 6 * * 1"             # continuous: every Monday 06:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds Scala Steward GitHub Action.

- `workflow_dispatch` — manual run from Actions tab (use for first one-shot bump)
- `schedule` — weekly cron (Mon 06:00 UTC) for continuous updates
- `permissions` set so default `GITHUB_TOKEN` can open PRs

Updates both library deps and sbt plugins. One PR per dependency; Conventional-Commit titles fit the squash-merge flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)