### PR TITLE
build(core): use native Scala 3 scalameta 4.17.0, drop for3Use2_13

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/CompatSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/CompatSuite.scala
@@ -18,13 +18,23 @@ class CompatSuite extends munit.FunSuite:
 
   private val pkg = "com/github/mercurievv/scalasemantic/compat/"
 
+  // Locate the golden root robustly w.r.t. the process cwd. Normal `sbt test` runs unforked from the
+  // repo root, but a forked runner (e.g. Stryker4s mutation testing) starts from the module dir, so a
+  // single cwd-relative path is fragile. Walk up from cwd trying the known relative locations.
+  private val compatRoot: Option[Path] =
+    val rels = List("analysis/src/test/resources/compat", "src/test/resources/compat")
+    val start = Paths.get("").toAbsolutePath
+    val bases = Iterator.iterate(start)(_.getParent).takeWhile(_ != null).take(8).toList
+    (for base <- bases.iterator; rel <- rels.iterator; p = base.resolve(rel) if Files.isDirectory(p)
+    yield p).nextOption()
+
   private val versionDirs: List[Path] =
-    val root = Paths.get("analysis/src/test/resources/compat")
-    if !Files.isDirectory(root) then Nil
-    else
-      val s = Files.list(root)
-      try s.iterator.asScala.filter(Files.isDirectory(_)).toList.sortBy(_.getFileName.toString)
-      finally s.close()
+    compatRoot match
+      case None => Nil
+      case Some(r) =>
+        val s = Files.list(r)
+        try s.iterator.asScala.filter(Files.isDirectory(_)).toList.sortBy(_.getFileName.toString)
+        finally s.close()
 
   test("golden fixtures exist for at least one non-default version"):
     assert(versionDirs.nonEmpty, "no compat golden dirs found — run `sbt compatGoldenAll`")

--- a/build.sbt
+++ b/build.sbt
@@ -58,16 +58,17 @@ lazy val proguard = taskKey[File]("Run ProGuard to shrink the assembly JAR")
 lazy val testShrunk = taskKey[Unit]("Run tests using the shrunk ProGuard JAR")
 
 // core: load + index SemanticDB and expose symbol-grammar primitives. No JSON, no MCP.
-// scalameta + its SemanticDB bindings are JVM-published on the 2.13 line; consume them from
-// Scala 3 via for3Use2_13 (as scalafix does). `semanticdb-shared` carries the
+// scalameta + its SemanticDB bindings are now published natively for Scala 3 (semanticdb-shared_3
+// from 4.16.2), so we depend on the _3 artifacts directly — no more for3Use2_13. This keeps the
+// whole transitive ScalaPB/protobuf stack on the Scala 3 line. `semanticdb-shared` carries the
 // scala.meta.internal.semanticdb.* protobuf classes (not pulled in by `scalameta`).
 lazy val core = (project in file("core"))
   .settings(commonSettings)
   .settings(
     name := "scalasemantic-core",
     libraryDependencies ++= Seq(
-      ("org.scalameta" %% "scalameta" % "4.13.9").cross(CrossVersion.for3Use2_13),
-      ("org.scalameta" %% "semanticdb-shared" % "4.13.9").cross(CrossVersion.for3Use2_13),
+      "org.scalameta" %% "scalameta" % "4.17.0",
+      "org.scalameta" %% "semanticdb-shared" % "4.17.0",
       munit
     )
   )


### PR DESCRIPTION
## What

- Bump scalameta **4.13.9 → 4.17.0** and depend on the **native Scala 3** (`_3`) artifacts of `scalameta` and `semanticdb-shared`, dropping the `.cross(CrossVersion.for3Use2_13)` consumption.
- `CompatSuite`: resolve the golden-SemanticDB root by walking up from cwd instead of a single repo-root-relative path.

## Why

`semanticdb-shared` is now published natively for Scala 3 (the `_3` line starts at 4.16.2), so the `for3Use2_13` workaround — which pulled the entire scalameta + ScalaPB/protobuf stack as `_2.13` — is no longer needed. Depending on the `_3` artifacts keeps the whole transitive dependency tree on the Scala 3 line and removes a latent cross-version-suffix hazard (two stdlib-variant builds of `scalapb-runtime`/`scala-collection-compat` colliding when any other `_3` dependency is added to the classpath).

The `CompatSuite` change makes the golden lookup independent of the process working directory: normal `sbt test` runs unforked from the repo root, but a runner that forks from the module dir would not find `analysis/src/test/resources/compat`. Walking up from cwd handles both.

## Verification

- `sbt Test/compile` — clean, no API drift across all modules (incl. `pc`).
- `sbt test` — all 92 tests pass.
- `CompatSuite` — 19/19 pass (golden lookup unchanged for the normal cwd).