### PR TITLE
test(model): cover InputTypes validation to kill mutants

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/model/InputTypesSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/model/InputTypesSuite.scala
@@ -1,0 +1,132 @@
+package com.github.mercurievv.scalasemantic.model
+
+import com.github.mercurievv.scalasemantic.model.InputTypes.*
+
+/** Unit tests for the boundary-validation smart constructors in [[InputTypes]]. These are pure (no
+  * SemanticDB needed), so they are cheap to exercise exhaustively — both the accept and reject
+  * paths, plus the off-by-one boundaries of the position/range comparisons. They run under
+  * Stryker's test-filter (alongside ModelsSuite) to kill the otherwise-uncovered validation
+  * mutants.
+  */
+class InputTypesSuite extends munit.FunSuite:
+
+  // Assert a Left whose message carries the given substring (kills StringLiteral mutations on the
+  // error text, which survive when only `.isLeft` is checked).
+  private def assertLeft(e: Either[String, ?], substring: String)(using munit.Location): Unit =
+    assert(e.isLeft, s"expected Left, got $e")
+    assert(e.swap.exists(_.contains(substring)), s"message ${e.swap} did not contain '$substring'")
+
+  test("SemanticDbSymbol.from accepts global and local, rejects blank and non-symbol"):
+    assert(SemanticDbSymbol.from("com/example/Foo#").isRight)
+    assert(SemanticDbSymbol.from("local0").isRight)
+    assertLeft(SemanticDbSymbol.from("   "), "non-empty")
+    assertLeft(SemanticDbSymbol.from("foo"), "invalid SemanticDB symbol")
+
+  test("MethodSymbol.from accepts a method, rejects a type and a non-global"):
+    assert(MethodSymbol.from("com/example/Foo#bar().").isRight)
+    assertLeft(MethodSymbol.from("com/example/Foo#"), "expected method symbol")
+    assertLeft(MethodSymbol.from("local0"), "expected method symbol")
+
+  test("TypeSymbol.from accepts a type, rejects a method"):
+    assert(TypeSymbol.from("com/example/Foo#").isRight)
+    assertLeft(TypeSymbol.from("com/example/Foo#bar()."), "expected type symbol")
+
+  test("PackageSymbol.from: blank -> empty, appends slash, rejects non-package"):
+    assertEquals(PackageSymbol.from("").toOption.map(_.value), Some(""))
+    assertEquals(PackageSymbol.from("  ").toOption.map(_.value), Some(""))
+    assertEquals(PackageSymbol.from("com/example/").toOption.map(_.value), Some("com/example/"))
+    assertEquals(PackageSymbol.from("com/example").toOption.map(_.value), Some("com/example/"))
+
+  test("DocumentUri.from: relative ok; rejects blank, absolute, and dot-dot"):
+    assert(DocumentUri.from("src/Main.scala").isRight)
+    assertLeft(DocumentUri.from("   "), "non-empty")
+    assertLeft(DocumentUri.from("/etc/passwd"), "must be relative")
+    assertLeft(DocumentUri.from("a/../b.scala"), "must not contain")
+
+  test("NonNegativeInt.from accepts >= 0, rejects negative"):
+    assert(NonNegativeInt.from(0, "line").isRight)
+    assert(NonNegativeInt.from(7, "line").isRight)
+    assertLeft(NonNegativeInt.from(-1, "line"), "must be >= 0")
+
+  test("PositiveInt.from accepts > 0, rejects 0 and negative; DefaultLimit is 50"):
+    assert(PositiveInt.from(1, "limit").isRight)
+    assertLeft(PositiveInt.from(0, "limit"), "must be > 0")
+    assertLeft(PositiveInt.from(-3, "limit"), "must be > 0")
+    assertEquals(PositiveInt.DefaultLimit.value, 50)
+
+  test("SourcePosition.before respects line then character, strictly"):
+    def pos(l: Int, c: Int) = SourcePosition.from(l, c).toOption.get
+    assert(pos(1, 2).before(pos(1, 3)), "same line, later char")
+    assert(pos(1, 2).before(pos(2, 0)), "earlier line wins")
+    assert(!pos(1, 2).before(pos(1, 2)), "equal is not before")
+    assert(!pos(1, 3).before(pos(1, 2)), "same line, earlier char")
+    assert(!pos(2, 0).before(pos(1, 9)), "later line is not before")
+
+  test("SourcePosition.atOrBefore is inclusive on the boundary"):
+    def pos(l: Int, c: Int) = SourcePosition.from(l, c).toOption.get
+    assert(pos(1, 2).atOrBefore(1, 2), "equal counts")
+    assert(pos(1, 2).atOrBefore(1, 3), "same line, later char")
+    assert(pos(1, 2).atOrBefore(2, 0), "earlier line")
+    assert(!pos(1, 2).atOrBefore(1, 1), "same line, earlier char")
+    assert(!pos(1, 2).atOrBefore(0, 9), "later line")
+
+  test("SourcePosition.atOrAfter is inclusive on the boundary"):
+    def pos(l: Int, c: Int) = SourcePosition.from(l, c).toOption.get
+    assert(pos(1, 2).atOrAfter(1, 2), "equal counts")
+    assert(pos(1, 3).atOrAfter(1, 2), "same line, earlier target char")
+    assert(pos(2, 0).atOrAfter(1, 9), "later line")
+    assert(!pos(1, 2).atOrAfter(1, 3), "same line, later target char")
+    assert(!pos(1, 2).atOrAfter(2, 0), "earlier line")
+
+  test("SourcePosition.from rejects a negative line or character"):
+    assertLeft(SourcePosition.from(-1, 0), "line")
+    assertLeft(SourcePosition.from(0, -1), "character")
+
+  test("SourceRange.from requires end strictly after start; contains/startsAtOrAfterEnd"):
+    val r = SourceRange.from(1, 0, 2, 5).toOption.get
+    assertEquals((r.startLine, r.startCharacter, r.endLine, r.endCharacter), (1, 0, 2, 5))
+    assert(r.contains(1, 0, 2, 5), "the full span is contained")
+    assert(r.contains(1, 2, 2, 1), "an inner span is contained")
+    assert(!r.contains(0, 0, 2, 5), "a span starting before is not contained")
+    assert(!r.contains(1, 0, 3, 0), "a span ending after is not contained")
+    assert(r.startsAtOrAfterEnd(2, 5), "the end position is at-or-after the end")
+    assert(!r.startsAtOrAfterEnd(1, 4), "a mid position is before the end")
+    assertLeft(SourceRange.from(2, 0, 1, 0), "after")
+    assertLeft(SourceRange.from(1, 5, 1, 5), "after") // empty range rejected
+
+  test("ScalaIdentifier.from: plain/symbolic/backticked ok; keyword/garbage/blank rejected"):
+    assert(ScalaIdentifier.from("foo").isRight)
+    assert(ScalaIdentifier.from("foo_$1").isRight)
+    assert(ScalaIdentifier.from("+:").isRight)
+    assert(ScalaIdentifier.from("`weird name`").isRight)
+    assertLeft(ScalaIdentifier.from("class"), "invalid Scala identifier")
+    assertLeft(ScalaIdentifier.from("1abc"), "invalid Scala identifier")
+    assertLeft(ScalaIdentifier.from("   "), "non-empty")
+
+  test("StructureDimension.from maps every keyword and defaults blank to Combined"):
+    import StructureDimension.*
+    assertEquals(StructureDimension.from(""), Right(Combined))
+    assertEquals(StructureDimension.from("combined"), Right(Combined))
+    assertEquals(StructureDimension.from("extends"), Right(Extends))
+    assertEquals(StructureDimension.from("memberType"), Right(MemberType))
+    assertEquals(StructureDimension.from("call"), Right(Call))
+    assertEquals(StructureDimension.from("implicit"), Right(Implicit))
+    assertLeft(StructureDimension.from("nope"), "invalid structure dimension")
+
+  test("StructureSort.from maps every keyword and defaults blank to Afferent"):
+    import StructureSort.*
+    assertEquals(StructureSort.from(""), Right(Afferent))
+    assertEquals(StructureSort.from("afferent"), Right(Afferent))
+    assertEquals(StructureSort.from("efferent"), Right(Efferent))
+    assertEquals(StructureSort.from("instability"), Right(Instability))
+    assertEquals(StructureSort.from("layer"), Right(Layer))
+    assertEquals(StructureSort.from("centrality"), Right(Centrality))
+    assertEquals(StructureSort.from("sccSize"), Right(SccSize))
+    assertLeft(StructureSort.from("nope"), "invalid structure sort")
+
+  test("SourceFormat.from recognises compilable/plain and defaults to Annotated"):
+    import SourceFormat.*
+    assertEquals(SourceFormat.from("compilable"), Compilable)
+    assertEquals(SourceFormat.from("plain"), Plain)
+    assertEquals(SourceFormat.from("annotated"), Annotated)
+    assertEquals(SourceFormat.from("anything else"), Annotated)

--- a/mutation-nocoverage.txt
+++ b/mutation-nocoverage.txt
@@ -1,11 +1,10 @@
-# NoCoverage mutants: 317
-# generated from analysis/target/stryker4s-report/1782671061459/report.json
+# NoCoverage mutants: 275
+# generated from analysis/target/stryker4s-report/1782671913743/report.json
 #
 # by file:
 #    101 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #     83 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
 #     45 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/DependencyGraphs.scala
-#     42 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
 #     24 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetrics.scala
 #     22 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala
 #
@@ -284,45 +283,3 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetri
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala:115:90  [EqualityOperator] -> <
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala:115:90  [EqualityOperator] -> ==
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala:115:90  [EqualityOperator] -> >=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:21:49  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:62:20  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:92:46  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:103:17  [EqualityOperator] -> <=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:103:17  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:103:17  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:103:24  [LogicalOperator] -> &&
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:104:20  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:104:28  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:104:46  [EqualityOperator] -> <
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:104:46  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:104:46  [EqualityOperator] -> >=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:107:17  [EqualityOperator] -> <
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:107:17  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:107:17  [EqualityOperator] -> >=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:107:24  [LogicalOperator] -> &&
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:108:20  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:108:28  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:108:46  [EqualityOperator] -> <
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:108:46  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:108:46  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:129:51  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:210:34  [BooleanLiteral] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:211:34  [BooleanLiteral] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:212:34  [BooleanLiteral] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:228:14  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:229:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:230:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:231:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:232:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:233:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:234:35  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:247:14  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:248:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:249:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:250:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:251:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:252:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:253:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:254:36  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:264:14  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:265:14  [StringLiteral] -> ""

--- a/mutation-survivors.txt
+++ b/mutation-survivors.txt
@@ -1,10 +1,10 @@
-# Survived mutants: 80
-# generated from analysis/target/stryker4s-report/1782671061459/report.json
+# Survived mutants: 52
+# generated from analysis/target/stryker4s-report/1782671913743/report.json
 #
 # by file:
-#     34 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
 #     32 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #     14 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+#      6 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
 #
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:430:31  [MethodExpression] -> params.isEmpty
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:430:47  [LogicalOperator] -> ||
@@ -53,36 +53,8 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scal
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:368:67  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:369:67  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:28:23  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:31:19  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:42:19  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:52:12  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:52:25  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:53:19  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:62:14  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:63:23  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:64:10  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:64:10  [MethodExpression] -> normalized.nonEmpty
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:64:53  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:65:17  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:72:23  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:74:12  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:74:12  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:74:28  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:74:43  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:75:17  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:76:16  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:85:49  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:99:17  [EqualityOperator] -> <=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:99:17  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:99:35  [LogicalOperator] -> &&
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:100:20  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:100:39  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:100:57  [EqualityOperator] -> <=
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:100:57  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:100:57  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:113:40  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:114:45  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:146:14  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:147:21  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:205:23  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:213:48  [StringLiteral] -> ""

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,5 +16,13 @@ libraryDependencies += "com.guardsquare" % "proguard-base" % "7.9.1"
 // Mutation testing. The published sbt-stryker4s (0.21.0) is built against sbt 2.0.0-RC2 and its ABI
 // fails to load on sbt 2.0.0 final. Stryker4s MASTER already pins the plugin to sbt 2.0.0 final, so
 // we consume a locally-published build of master (`sbtPlugin3/publishLocal` in a stryker4s clone)
-// until a release ships. Run with `sbt "analysis/stryker"`; config in stryker4s.conf.
-addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.0.0+1-2c0f5bd7-SNAPSHOT")
+// until a release ships.
+//
+// That snapshot lives ONLY in the local ivy cache — it is on no remote repo, so loading it
+// unconditionally breaks every environment that lacks the publishLocal (notably CI: the meta-build
+// can't resolve it and the whole build fails before any task runs). So gate it behind a flag and
+// enable it only when actually mutation-testing:
+//   sbt -Dstryker=true "analysis/stryker"      (config in stryker4s.conf)
+if (sys.props.get("stryker").contains("true") || sys.env.contains("STRYKER"))
+  Seq(addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.0.0+1-2c0f5bd7-SNAPSHOT"))
+else Seq.empty[Setting[?]]

--- a/scripts/mutation-summary.sh
+++ b/scripts/mutation-summary.sh
@@ -23,7 +23,7 @@ if [[ -z "$report" ]]; then
 fi
 if [[ -z "$report" || ! -f "$report" ]]; then
   echo "error: no report.json found (looked under analysis/target/stryker4s-report/*/)" >&2
-  echo "       run 'sbt \"analysis/stryker\"' first, or pass the report path explicitly." >&2
+  echo "       run 'sbt -Dstryker=true \"analysis/stryker\"' first, or pass the report path explicitly." >&2
   exit 1
 fi
 

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -1,6 +1,7 @@
 stryker4s {
   # --- Mutation testing (sbt plugin) --------------------------------------------------------------
-  # Run from the repo root: sbt "analysis/stryker"
+  # Run from the repo root: sbt -Dstryker=true "analysis/stryker"
+  # (the -Dstryker flag loads the local-only sbt-stryker4s snapshot; see project/plugins.sbt)
   # The plugin auto-derives the Scala dialect from the build, instruments coverage, and honours
   # test-filter (unlike the command-runner). See docs/project/development.md ("Mutation testing").
 

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -23,7 +23,8 @@ stryker4s {
   # presentation compiler (too slow under mutation).
   test-filter = [
     "com.github.mercurievv.scalasemantic.analysis.CompatSuite",
-    "com.github.mercurievv.scalasemantic.model.ModelsSuite"
+    "com.github.mercurievv.scalasemantic.model.ModelsSuite",
+    "com.github.mercurievv.scalasemantic.model.InputTypesSuite"
   ]
 
   # html → browsable report (stryker4s-report/<ts>/index.html); json → machine-readable


### PR DESCRIPTION
## What
Adds `InputTypesSuite` covering every `InputTypes` smart constructor (symbol/package/uri parsing, NonNegative/Positive ints, `SourcePosition`/`SourceRange` boundary comparisons, `ScalaIdentifier`, and the `StructureDimension`/`StructureSort`/`SourceFormat` enums) on both accept and reject paths, asserting error-message text. Registers it in `stryker4s.conf`'s `test-filter`.

## Why
Picked the highest-ROI cluster from the committed mutation baseline: `InputTypes.scala` had 34 Survived + 43 NoCoverage mutants, all pure validation logic — cheap to cover with one focused suite and no production changes.

## Result (re-ran `sbt "analysis/stryker"`)
| status | before | after |
|---|---|---|
| Killed | 44 | 114 |
| Survived | 80 | 52 |
| NoCoverage | 317 | 275 |

Regenerated `mutation-survivors.txt` / `mutation-nocoverage.txt` via `scripts/mutation-summary.sh` so the gain shows as a plain diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)