### PR TITLE
test(analysis): cover AnalyzerHelpers to kill mutants

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersSuite.scala
@@ -1,0 +1,191 @@
+package com.github.mercurievv.scalasemantic.analysis
+
+import com.github.mercurievv.scalasemantic.model.*
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+import scala.meta.internal.semanticdb as s
+
+/** Unit tests for the stateless rendering/lookup helpers in [[AnalyzerHelpers]]. Most are pure
+  * functions of hand-built SemanticDB protobufs (no on-disk index needed); `displayName` falls back
+  * to a global symbol's last descriptor name, so fabricated symbols like `scala/Int#` render as
+  * `Int`. A small in-memory index covers the few helpers that read symbol info. Registered in
+  * stryker4s.conf so the printer/range/glob mutants are killed.
+  */
+class AnalyzerHelpersSuite extends munit.FunSuite:
+
+  private val emptyIndex = SemanticIndex.fromRoots(Nil)
+  private val h = AnalyzerHelpers(emptyIndex)
+
+  private def ref(symbol: String, args: s.Type*): s.Type =
+    s.TypeRef(s.Type.Empty, symbol, args.toList)
+  private val IntT = ref("scala/Int#")
+  private val StringT = ref("scala/Predef.String#")
+
+  test("renderType: TypeRef with and without type arguments"):
+    assertEquals(h.renderType(IntT), "Int")
+    assertEquals(h.renderType(ref("scala/collection/immutable/List#", IntT)), "List[Int]")
+    assertEquals(h.renderType(ref("scala/Predef.Map#", IntT, StringT)), "Map[Int, String]")
+
+  test("renderType: every non-TypeRef shape and the empty default"):
+    assertEquals(h.renderType(s.SingleType(s.Type.Empty, "a/B.")), "B.type")
+    assertEquals(h.renderType(s.ThisType("a/B#")), "B.this")
+    assertEquals(h.renderType(s.SuperType(s.Type.Empty, "a/B#")), "B")
+    assertEquals(h.renderType(s.ByNameType(IntT)), "=> Int")
+    assertEquals(h.renderType(s.RepeatedType(IntT)), "Int*")
+    assertEquals(h.renderType(s.WithType(List(IntT, StringT))), "Int with String")
+    assertEquals(h.renderType(s.IntersectionType(List(IntT, StringT))), "Int & String")
+    assertEquals(h.renderType(s.UnionType(List(IntT, StringT))), "Int | String")
+    assertEquals(h.renderType(s.AnnotatedType(Nil, IntT)), "Int")
+    assertEquals(h.renderType(s.ExistentialType(IntT, None)), "Int")
+    assertEquals(h.renderType(s.UniversalType(None, IntT)), "Int")
+    assertEquals(h.renderType(s.StructuralType(IntT, None)), "Int")
+    assertEquals(h.renderType(s.Type.Empty), "")
+
+  test("renderType: ConstantType delegates to renderConstant"):
+    assertEquals(h.renderType(s.ConstantType(s.IntConstant(42))), "42")
+
+  test("renderConstant: every constant kind"):
+    assertEquals(h.renderConstant(s.IntConstant(42)), "42")
+    assertEquals(h.renderConstant(s.LongConstant(7L)), "7L")
+    assertEquals(h.renderConstant(s.FloatConstant(1.5f)), "1.5f")
+    assertEquals(h.renderConstant(s.DoubleConstant(2.5)), "2.5")
+    assertEquals(h.renderConstant(s.BooleanConstant(true)), "true")
+    assertEquals(h.renderConstant(s.CharConstant('a'.toInt)), "'a'")
+    assertEquals(h.renderConstant(s.StringConstant("x")), "\"x\"")
+    assertEquals(h.renderConstant(s.ShortConstant(3)), "3")
+    assertEquals(h.renderConstant(s.ByteConstant(4)), "4")
+    assertEquals(h.renderConstant(s.UnitConstant()), "Unit")
+    assertEquals(h.renderConstant(s.NullConstant()), "null")
+
+  test("renderMethod: type params, implicit lists, separators"):
+    def p(name: String, tpe: String) = Parameter(name, tpe, isImplicit = false)
+    assertEquals(
+      h.renderMethod("f", Nil, List(ParameterList(List(p("x", "Int")), isImplicit = false)), "Int"),
+      "def f(x: Int): Int"
+    )
+    assertEquals(
+      h.renderMethod(
+        "g",
+        List("A", "B"),
+        List(ParameterList(List(p("x", "A"), p("y", "B")), isImplicit = false)),
+        "B"
+      ),
+      "def g[A, B](x: A, y: B): B"
+    )
+    assertEquals(
+      h.renderMethod("e", Nil, List(ParameterList(List(p("c", "C")), isImplicit = true)), "Unit"),
+      "def e(implicit c: C): Unit"
+    )
+
+  test("rangeContains is inclusive at start, exclusive at end"):
+    val r = s.Range(1, 2, 3, 4)
+    assert(h.rangeContains(r, 1, 2), "start boundary is contained")
+    assert(h.rangeContains(r, 2, 9), "an interior line is contained")
+    assert(h.rangeContains(r, 3, 3), "just before the end is contained")
+    assert(!h.rangeContains(r, 1, 1), "before the start char is excluded")
+    assert(!h.rangeContains(r, 0, 9), "an earlier line is excluded")
+    assert(!h.rangeContains(r, 3, 4), "the end position itself is excluded")
+    assert(!h.rangeContains(r, 4, 0), "a later line is excluded")
+
+  test("rangeSpan weights lines over characters"):
+    assertEquals(h.rangeSpan(s.Range(1, 0, 3, 5)), 20005)
+    assertEquals(h.rangeSpan(s.Range(2, 4, 2, 9)), 5)
+
+  test("alreadyAscribed finds a top-level colon before the body's ="):
+    assert(h.alreadyAscribed("val x: Int = 1", 4), "explicit ascription")
+    assert(!h.alreadyAscribed("val x = 1", 4), "no ascription")
+    assert(!h.alreadyAscribed("def f(a: Int) = a", 4), "colon nested in () does not count")
+    assert(h.alreadyAscribed("def f[T]: T = x", 4), "colon after [] group counts")
+    assert(!h.alreadyAscribed("val x = 1", -1), "negative start")
+    assert(!h.alreadyAscribed("val x = 1", 99), "start past end")
+
+  test("packageDotted and joinFqn"):
+    assertEquals(h.packageDotted("com/foo/bar/"), "com.foo.bar")
+    assertEquals(h.packageDotted(""), "")
+    assertEquals(h.joinFqn("", "X"), "X")
+    assertEquals(h.joinFqn("com.foo", "X"), "com.foo.X")
+
+  test("globMatcher: None keeps all; literal is substring; * is wildcard"):
+    assert(h.globMatcher(None)("anything"))
+    val foo = h.globMatcher(Some("Foo"))
+    assert(foo("xFooy"))
+    assert(!foo("bar"))
+    val ab = h.globMatcher(Some("a*b"))
+    assert(ab("axxb"))
+    assert(ab("ab"))
+    assert(!ab("ba"))
+
+  test("parentSymbol and notObject"):
+    assertEquals(h.parentSymbol(IntT), Some("scala/Int#"))
+    assertEquals(h.parentSymbol(s.SingleType(s.Type.Empty, "a/B.")), Some("a/B."))
+    assertEquals(h.parentSymbol(s.Type.Empty), None)
+    assert(h.notObject(IntT), "Int is not Object")
+    assert(!h.notObject(ref("java/lang/Object#")), "Object is Object")
+
+  test("isImplicit reads the IMPLICIT property bit"):
+    def info(props: Int) =
+      s.SymbolInformation(symbol = "a/x.", properties = props)
+    assert(h.isImplicit(info(s.SymbolInformation.Property.IMPLICIT.value)))
+    assert(!h.isImplicit(info(0)))
+    assert(
+      h.isImplicit(info(s.SymbolInformation.Property.IMPLICIT.value | 1)),
+      "bit set among others"
+    )
+
+  test("directParents reads a ClassSignature's parents; non-class is empty"):
+    val cls = s.SymbolInformation(
+      symbol = "a/Dog#",
+      kind = s.SymbolInformation.Kind.CLASS,
+      signature =
+        s.ClassSignature(None, List(ref("a/Animal#"), ref("java/lang/Object#")), s.Type.Empty, None)
+    )
+    assertEquals(h.directParents(cls), List("a/Animal#", "java/lang/Object#"))
+    val notClass = s.SymbolInformation(symbol = "a/x.", signature = s.NoSignature)
+    assertEquals(h.directParents(notClass), Nil)
+
+  // --- helpers that read a small in-memory index ---------------------------
+
+  private def sigInfo(
+      symbol: String,
+      kind: s.SymbolInformation.Kind,
+      displayName: String,
+      signature: s.Signature = s.NoSignature
+  ): s.SymbolInformation =
+    s.SymbolInformation(
+      symbol = symbol,
+      kind = kind,
+      displayName = displayName,
+      signature = signature
+    )
+
+  private val dog = sigInfo(
+    "a/Dog#",
+    s.SymbolInformation.Kind.CLASS,
+    "Dog",
+    s.ClassSignature(None, List(ref("a/Animal#")), s.Type.Empty, None)
+  )
+  private val animal = sigInfo("a/Animal#", s.SymbolInformation.Kind.CLASS, "Animal")
+  private val initSym = sigInfo("a/Dog#`<init>`().", s.SymbolInformation.Kind.METHOD, "<init>")
+  private val field = sigInfo("a/Dog#x.", s.SymbolInformation.Kind.FIELD, "x")
+  private val hidden = sigInfo("a/Dog#h.", s.SymbolInformation.Kind.PARAMETER, "h")
+  private val idx =
+    new SemanticIndex(
+      Vector(s.TextDocument(uri = "a.scala", symbols = Vector(dog, animal, initSym, field, hidden)))
+    )
+  private val hi = AnalyzerHelpers(idx)
+
+  test("includeInOutline keeps named class/field, drops <init> and non-outline kinds"):
+    assert(hi.includeInOutline("a/Dog#"), "class")
+    assert(hi.includeInOutline("a/Dog#x."), "field")
+    assert(!hi.includeInOutline("a/Dog#`<init>`()."), "constructor excluded by name")
+    assert(!hi.includeInOutline("a/Dog#h."), "parameter kind excluded")
+    assert(!hi.includeInOutline("a/Missing#"), "unknown symbol excluded")
+
+  test("kindName returns the kind or UNKNOWN"):
+    assertEquals(hi.kindName("a/Dog#"), "CLASS")
+    assertEquals(hi.kindName("a/Missing#"), "UNKNOWN")
+
+  test("linearize and knownSubtypes walk the parent relation"):
+    assertEquals(hi.linearize("a/Dog#"), List("a/Animal#"))
+    assertEquals(hi.knownSubtypes("a/Animal#"), List("a/Dog#"))
+    assertEquals(hi.directParents(dog), List("a/Animal#"))

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersSuite.scala
@@ -107,13 +107,13 @@ class AnalyzerHelpersSuite extends munit.FunSuite:
 
   test("globMatcher: None keeps all; literal is substring; * is wildcard"):
     assert(h.globMatcher(None)("anything"))
-    val foo = h.globMatcher(Some("Foo"))
-    assert(foo("xFooy"))
-    assert(!foo("bar"))
-    val ab = h.globMatcher(Some("a*b"))
-    assert(ab("axxb"))
-    assert(ab("ab"))
-    assert(!ab("ba"))
+    val fooGlob = h.globMatcher(Some("Foo"))
+    assert(fooGlob("xFooy"))
+    assert(!fooGlob("bar"))
+    val abGlob = h.globMatcher(Some("a*b"))
+    assert(abGlob("axxb"))
+    assert(abGlob("ab"))
+    assert(!abGlob("ba"))
 
   test("parentSymbol and notObject"):
     assertEquals(h.parentSymbol(IntT), Some("scala/Int#"))
@@ -158,19 +158,24 @@ class AnalyzerHelpersSuite extends munit.FunSuite:
       signature = signature
     )
 
-  private val dog = sigInfo(
+  private val dogInfo = sigInfo(
     "a/Dog#",
     s.SymbolInformation.Kind.CLASS,
     "Dog",
     s.ClassSignature(None, List(ref("a/Animal#")), s.Type.Empty, None)
   )
-  private val animal = sigInfo("a/Animal#", s.SymbolInformation.Kind.CLASS, "Animal")
-  private val initSym = sigInfo("a/Dog#`<init>`().", s.SymbolInformation.Kind.METHOD, "<init>")
-  private val field = sigInfo("a/Dog#x.", s.SymbolInformation.Kind.FIELD, "x")
-  private val hidden = sigInfo("a/Dog#h.", s.SymbolInformation.Kind.PARAMETER, "h")
+  private val animalInfo = sigInfo("a/Animal#", s.SymbolInformation.Kind.CLASS, "Animal")
+  private val initInfo = sigInfo("a/Dog#`<init>`().", s.SymbolInformation.Kind.METHOD, "<init>")
+  private val fieldInfo = sigInfo("a/Dog#x.", s.SymbolInformation.Kind.FIELD, "x")
+  private val hiddenInfo = sigInfo("a/Dog#h.", s.SymbolInformation.Kind.PARAMETER, "h")
   private val idx =
     new SemanticIndex(
-      Vector(s.TextDocument(uri = "a.scala", symbols = Vector(dog, animal, initSym, field, hidden)))
+      Vector(
+        s.TextDocument(
+          uri = "a.scala",
+          symbols = Vector(dogInfo, animalInfo, initInfo, fieldInfo, hiddenInfo)
+        )
+      )
     )
   private val hi = AnalyzerHelpers(idx)
 
@@ -188,4 +193,4 @@ class AnalyzerHelpersSuite extends munit.FunSuite:
   test("linearize and knownSubtypes walk the parent relation"):
     assertEquals(hi.linearize("a/Dog#"), List("a/Animal#"))
     assertEquals(hi.knownSubtypes("a/Animal#"), List("a/Dog#"))
-    assertEquals(hi.directParents(dog), List("a/Animal#"))
+    assertEquals(hi.directParents(dogInfo), List("a/Animal#"))

--- a/mutation-nocoverage.txt
+++ b/mutation-nocoverage.txt
@@ -1,10 +1,10 @@
-# NoCoverage mutants: 275
-# generated from analysis/target/stryker4s-report/1782671913743/report.json
+# NoCoverage mutants: 213
+# generated from analysis/target/stryker4s-report/1782674938914/report.json
 #
 # by file:
-#    101 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #     83 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
 #     45 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/DependencyGraphs.scala
+#     39 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #     24 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetrics.scala
 #     22 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala
 #
@@ -91,12 +91,6 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:518:5
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:523:9  [MethodExpression] -> occ.range.forall(h.rangeContains(_, position.lineValue, position.characterValue))
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:570:14  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:570:14  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:30:5  [MethodExpression] -> index.info(symbol).forall { si => outlineKinds.contains(si.kind) && si.displayName.nonEmpty && si.displayName != "<init>" }
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:31:38  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:31:41  [MethodExpression] -> si.displayName.isEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:31:65  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:31:83  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:31:86  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:45:34  [MethodExpression] -> t.typeArguments.isEmpty
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:50:13  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:51:54  [StringLiteral] -> ""
@@ -123,29 +117,6 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scal
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:108:31  [LogicalOperator] -> &&
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:110:66  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:110:83  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:10  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:10  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:12  [EqualityOperator] -> <
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:12  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:12  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:32  [BooleanLiteral] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:122:29  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:122:37  [BooleanLiteral] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:123:29  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:123:37  [BooleanLiteral] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:15  [EqualityOperator] -> <
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:15  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:15  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:20  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:33  [EqualityOperator] -> <=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:33  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:33  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:47  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:133:27  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:136:8  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:136:8  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:136:8  [MethodExpression] -> pkg.nonEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:136:35  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:143:7  [MethodExpression] -> doc.occurrences.iterator.filter(_.role == s.SymbolOccurrence.Role.DEFINITION).map(_.symbol).filterNot(index.isGlobal)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:143:7  [MethodExpression] -> doc.occurrences.iterator.filterNot(_.role == s.SymbolOccurrence.Role.DEFINITION)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:144:24  [EqualityOperator] -> !=
@@ -155,42 +126,9 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scal
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:8  [ConditionalExpression] -> true
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:8  [MethodExpression] -> rendered.nonEmpty
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:30  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:174:32  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:174:87  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:186:16  [MethodExpression] -> definitionUri(sym).forall(keepUri)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:191:35  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:275:9  [MethodExpression] -> m.parameterLists.toList.flatMap(scope => scopeInfos(Some(scope))).filterNot(isImplicit)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:27  [EqualityOperator] -> <
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:27  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:27  [EqualityOperator] -> >=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:41  [LogicalOperator] -> &&
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:50  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:65  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:78  [EqualityOperator] -> <
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:78  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:78  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:26  [EqualityOperator] -> <=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:26  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:26  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:38  [LogicalOperator] -> &&
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:47  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:60  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:73  [EqualityOperator] -> <=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:73  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:296:73  [EqualityOperator] -> >
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:297:16  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:362:39  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:363:39  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:365:39  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:366:39  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:367:67  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:375:39  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:381:36  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:382:36  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:385:36  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:386:36  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:389:36  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:390:36  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:391:36  [StringLiteral] -> "Stryker was here!"
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/DependencyGraphs.scala:20:33  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/DependencyGraphs.scala:23:46  [LogicalOperator] -> ||

--- a/mutation-survivors.txt
+++ b/mutation-survivors.txt
@@ -1,8 +1,8 @@
-# Survived mutants: 52
-# generated from analysis/target/stryker4s-report/1782671913743/report.json
+# Survived mutants: 38
+# generated from analysis/target/stryker4s-report/1782674938914/report.json
 #
 # by file:
-#     32 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+#     18 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #     14 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
 #      6 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
 #
@@ -20,6 +20,13 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:599:2
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:601:12  [MethodExpression] -> nodes.take(1)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:603:47  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:622:74  [LogicalOperator] -> ||
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:10  [ConditionalExpression] -> false
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:12  [EqualityOperator] -> ==
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:12  [EqualityOperator] -> >
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:32  [BooleanLiteral] -> true
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:122:29  [EqualityOperator] -> !=
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:15  [EqualityOperator] -> >
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:33  [EqualityOperator] -> <=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:210:14  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:232:42  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:240:22  [LogicalOperator] -> ||
@@ -29,29 +36,8 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scal
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:242:6  [MethodExpression] -> index.info(index.owner(info.symbol)).forall(isImplicit)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:258:23  [MethodExpression] -> parentSymbol(tpe).forall(sym => index.displayName(sym) == givenName)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:259:8  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:320:55  [StringLiteral] -> ""
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:78  [EqualityOperator] -> ==
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:330:10  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:349:17  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:349:17  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:349:17  [MethodExpression] -> tparams.nonEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:349:38  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:349:63  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:349:68  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:349:74  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:351:23  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:351:23  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:351:42  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:351:59  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:352:30  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:352:63  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:352:76  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:352:82  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:361:12  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:361:70  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:361:81  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:361:87  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:368:67  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:369:67  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:28:23  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:64:10  [ConditionalExpression] -> true
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:64:53  [LogicalOperator] -> ||

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -25,7 +25,8 @@ stryker4s {
   test-filter = [
     "com.github.mercurievv.scalasemantic.analysis.CompatSuite",
     "com.github.mercurievv.scalasemantic.model.ModelsSuite",
-    "com.github.mercurievv.scalasemantic.model.InputTypesSuite"
+    "com.github.mercurievv.scalasemantic.model.InputTypesSuite",
+    "com.github.mercurievv.scalasemantic.analysis.AnalyzerHelpersSuite"
   ]
 
   # html → browsable report (stryker4s-report/<ts>/index.html); json → machine-readable


### PR DESCRIPTION
## What
Adds `AnalyzerHelpersSuite`, unit-testing the stateless `AnalyzerHelpers` directly with hand-built SemanticDB protobufs (no on-disk index): `renderType` (every `Type` shape), `renderConstant` (every constant kind), `renderMethod`, `rangeContains`/`rangeSpan`, `alreadyAscribed`, `packageDotted`/`joinFqn`, `globMatcher`, `parentSymbol`/`notObject`, `isImplicit`, `directParents`, plus a small in-memory index for `includeInOutline`, `kindName`, `linearize`, `knownSubtypes`. Registers it in `stryker4s.conf`.

## Why
Next-highest-ROI cluster after `InputTypes`: `AnalyzerHelpers.scala` carried ~135 live mutants (33 Survived + 102 NoCoverage), nearly all pure rendering/lookup logic reachable without fixtures. `displayName` falls back to a global symbol's descriptor name, so fabricated symbols like `scala/Int#` render deterministically.

## Result (re-ran `sbt -Dstryker=true "analysis/stryker"`)
| status | before | after |
|---|---|---|
| Killed | 114 | 190 |
| Survived | 52 | 38 |
| NoCoverage | 275 | 213 |

`AnalyzerHelpers` live mutants: 135 → 57. No production changes.

Note: the suite's helper vals are suffixed (`animalInfo`, `dogInfo`, …) so the symbols they emit don't perturb the dogfood `findSymbol`/structure suites that load `fromProject(".")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)