### PR TITLE
test(analysis): cover Analyzer query orchestration to kill mutants

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerCoreSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerCoreSuite.scala
@@ -1,0 +1,196 @@
+package com.github.mercurievv.scalasemantic.analysis
+
+import com.github.mercurievv.scalasemantic.model.InputTypes.*
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+import scala.meta.internal.semanticdb as s
+
+/** Deterministic unit tests for [[Analyzer]] driven against small hand-built in-memory indexes (no
+  * on-disk dogfooding, so they are stable under mutation and belong in stryker4s.conf's filter —
+  * unlike AnalyzerSuite, which loads the live `fromProject(".")` index). Each builds exactly the
+  * symbols/occurrences a query needs and asserts the orchestration branches (hierarchy
+  * linearization, overload grouping, implicit-list detection, given resolution, call-path BFS).
+  */
+class AnalyzerCoreSuite extends munit.FunSuite:
+
+  private val P = "com/x/"
+
+  private def tref(sym: String): s.Type = s.TypeRef(s.Type.Empty, sym, Nil)
+  private val ObjectT = tref("java/lang/Object#")
+  private val IntT = tref("scala/Int#")
+
+  private def info(
+      symbol: String,
+      kind: s.SymbolInformation.Kind,
+      displayName: String,
+      signature: s.Signature = s.NoSignature,
+      properties: Int = 0
+  ): s.SymbolInformation =
+    s.SymbolInformation(
+      symbol = symbol,
+      kind = kind,
+      displayName = displayName,
+      signature = signature,
+      properties = properties
+    )
+
+  private def cls(symbol: String, display: String, parents: List[s.Type], decls: List[String]) =
+    info(
+      symbol,
+      s.SymbolInformation.Kind.CLASS,
+      display,
+      s.ClassSignature(None, parents, s.Type.Empty, Some(s.Scope(symlinks = decls)))
+    )
+
+  private def meth(symbol: String, display: String, sig: s.Signature = s.NoSignature) =
+    info(symbol, s.SymbolInformation.Kind.METHOD, display, sig)
+
+  private def param(symbol: String, display: String, implicitly: Boolean) =
+    info(
+      symbol,
+      s.SymbolInformation.Kind.PARAMETER,
+      display,
+      s.ValueSignature(IntT),
+      if implicitly then s.SymbolInformation.Property.IMPLICIT.value else 0
+    )
+
+  private def occ(symbol: String, role: s.SymbolOccurrence.Role, line: Int) =
+    s.SymbolOccurrence(Some(s.Range(line, 0, line, 1)), symbol, role)
+
+  import s.SymbolOccurrence.Role.{DEFINITION, REFERENCE}
+
+  // --- hierarchy fixture: Puppy <: Dog <: Animal ----------------------------
+
+  private val animalCls =
+    cls(s"${P}Animal#", "Animal", List(ObjectT), List(s"${P}Animal#greetM()."))
+  private val dogCls =
+    cls(s"${P}Dog#", "Dog", List(tref(s"${P}Animal#")), List(s"${P}Dog#barkM()."))
+  private val puppyCls = cls(s"${P}Puppy#", "Puppy", List(tref(s"${P}Dog#")), Nil)
+  private val greetM = meth(s"${P}Animal#greetM().", "greetM")
+  private val barkM = meth(s"${P}Dog#barkM().", "barkM")
+
+  private def analyzer(symbols: s.SymbolInformation*)(occs: s.SymbolOccurrence*): Analyzer =
+    Analyzer(
+      SemanticIndex(
+        Vector(
+          s.TextDocument(uri = "x.scala", symbols = symbols.toVector, occurrences = occs.toVector)
+        )
+      )
+    )
+
+  private def tpe(v: String) = TypeSymbol.from(v).fold(fail(_), identity)
+  private def method(v: String) = MethodSymbol.from(v).fold(fail(_), identity)
+
+  test("classHierarchy: parents, full linearization, known subtypes"):
+    val az = analyzer(animalCls, dogCls, puppyCls, greetM, barkM)()
+    val h = az.classHierarchy(tpe(s"${P}Puppy#")).getOrElse(fail("no hierarchy"))
+    assertEquals(h.parents.map(_.displayName), List("Dog"))
+    assertEquals(h.linearization.map(_.displayName), List("Dog", "Animal", "Object"))
+    assertEquals(
+      az.classHierarchy(tpe(s"${P}Animal#")).get.knownSubtypes.map(_.displayName),
+      List("Dog")
+    )
+
+  test("members: declared on the type, inherited from the linearization"):
+    val az = analyzer(animalCls, dogCls, puppyCls, greetM, barkM)()
+    val m = az.members(tpe(s"${P}Dog#")).getOrElse(fail("no members"))
+    assertEquals(m.declared.map(_.displayName), List("barkM"))
+    assertEquals(m.inherited.map(_.displayName), List("greetM"))
+
+  // --- method-signature implicit-list detection -----------------------------
+
+  private def plist(params: s.SymbolInformation*) = s.Scope(hardlinks = params.toVector)
+  private def methodSig(symbol: String, display: String, lists: Seq[s.Scope]) =
+    meth(symbol, display, s.MethodSignature(None, lists, IntT))
+
+  test("methodSignature flags a list implicit only when non-empty and all-implicit"):
+    val all =
+      methodSig(s"${P}C#a().", "a", Seq(plist(param(s"${P}C#a().(e)", "e", implicitly = true))))
+    val none =
+      methodSig(s"${P}C#b().", "b", Seq(plist(param(s"${P}C#b().(x)", "x", implicitly = false))))
+    val mixed = methodSig(
+      s"${P}C#c().",
+      "c",
+      Seq(
+        plist(
+          param(s"${P}C#c().(a)", "a", implicitly = true),
+          param(s"${P}C#c().(b)", "b", implicitly = false)
+        )
+      )
+    )
+    val az = analyzer(all, none, mixed)()
+    assertEquals(
+      az.methodSignature(method(s"${P}C#a().")).get.parameterLists.map(_.isImplicit),
+      List(true)
+    )
+    assertEquals(
+      az.methodSignature(method(s"${P}C#b().")).get.parameterLists.map(_.isImplicit),
+      List(false)
+    )
+    assertEquals(
+      az.methodSignature(method(s"${P}C#c().")).get.parameterLists.map(_.isImplicit),
+      List(false)
+    )
+
+  // --- find-overloads -------------------------------------------------------
+
+  test("findOverloads groups by owner AND name (not same-owner/-name alone)"):
+    val put0 = methodSig(s"${P}Box#put().", "put", Nil)
+    val put1 = methodSig(s"${P}Box#put(+1).", "put", Nil)
+    val get0 = methodSig(s"${P}Box#get().", "get", Nil) // same owner, different name
+    val otherPut = methodSig("com/y/Other#put().", "put", Nil) // same name, different owner
+    val az = analyzer(put0, put1, get0, otherPut)()
+    val o = az.findOverloads(method(s"${P}Box#put()."))
+    assertEquals(o.name, "put")
+    assertEquals(o.overloads.map(_.symbol), List(s"${P}Box#put().", s"${P}Box#put(+1)."))
+    assert(o.overloads.forall(_.displayName == "put"))
+
+  // --- resolve-implicits ----------------------------------------------------
+
+  private val showCls = cls(s"${P}Show#", "Show", List(ObjectT), Nil)
+  private def givenObj(symbol: String, display: String) =
+    info(
+      symbol,
+      s.SymbolInformation.Kind.OBJECT,
+      display,
+      s.ClassSignature(None, List(tref(s"${P}Show#"), ObjectT), s.Type.Empty, None),
+      s.SymbolInformation.Property.IMPLICIT.value
+    )
+
+  test("resolveImplicits: candidate is not from an explicit import; chosen iff unique"):
+    val one = analyzer(showCls, givenObj(s"${P}intShow.", "intShow"))()
+    val r = one.resolveImplicits(tpe(s"${P}Show#"))
+    assertEquals(r.candidates.map(_.target.displayName), List("intShow"))
+    assert(!r.candidates.head.fromExplicitImport, "synthesized, not an explicit import")
+    assertEquals(r.chosen.map(_.displayName), Some("intShow"))
+    val two = analyzer(
+      showCls,
+      givenObj(s"${P}intShow.", "intShow"),
+      givenObj(s"${P}listShow.", "listShow")
+    )()
+    assertEquals(two.resolveImplicits(tpe(s"${P}Show#")).chosen, None)
+
+  // --- call-path BFS --------------------------------------------------------
+
+  test("callPath walks definition->reference edges; self path is the single node"):
+    // a (def) -> references b; b (def) -> references c; c (def)
+    val a = meth(s"${P}M#a().", "a")
+    val b = meth(s"${P}M#b().", "b")
+    val c = meth(s"${P}M#c().", "c")
+    val az = analyzer(a, b, c)(
+      occ(s"${P}M#a().", DEFINITION, 0),
+      occ(s"${P}M#b().", REFERENCE, 1),
+      occ(s"${P}M#b().", DEFINITION, 2),
+      occ(s"${P}M#c().", REFERENCE, 3),
+      occ(s"${P}M#c().", DEFINITION, 4)
+    )
+    val p = az.callPath(method(s"${P}M#a()."), method(s"${P}M#c()."))
+    assertEquals(p.path.map(_.displayName), List("a", "b", "c"))
+    assertEquals(
+      p.edges.map(e => e.from.displayName -> e.to.displayName),
+      List("a" -> "b", "b" -> "c")
+    )
+    val self = az.callPath(method(s"${P}M#a()."), method(s"${P}M#a()."))
+    assertEquals(self.path.map(_.displayName), List("a"))
+    val unreachable = az.callPath(method(s"${P}M#c()."), method(s"${P}M#a()."))
+    assertEquals(unreachable.path, Nil)

--- a/mutation-nocoverage.txt
+++ b/mutation-nocoverage.txt
@@ -1,5 +1,5 @@
 # NoCoverage mutants: 213
-# generated from analysis/target/stryker4s-report/1782678647242/report.json
+# generated from analysis/target/stryker4s-report/1782678825860/report.json
 #
 # by file:
 #     83 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala

--- a/mutation-nocoverage.txt
+++ b/mutation-nocoverage.txt
@@ -1,5 +1,5 @@
 # NoCoverage mutants: 213
-# generated from analysis/target/stryker4s-report/1782674938914/report.json
+# generated from analysis/target/stryker4s-report/1782678647242/report.json
 #
 # by file:
 #     83 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala

--- a/mutation-survivors.txt
+++ b/mutation-survivors.txt
@@ -1,24 +1,13 @@
-# Survived mutants: 38
-# generated from analysis/target/stryker4s-report/1782674938914/report.json
+# Survived mutants: 24
+# generated from analysis/target/stryker4s-report/1782678647242/report.json
 #
 # by file:
-#     18 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
-#     14 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+#     15 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #      6 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
+#      3 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
 #
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:430:31  [MethodExpression] -> params.isEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:430:47  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:430:50  [MethodExpression] -> params.exists(_.isImplicit)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:464:9  [MethodExpression] -> h.linearize(sym).filterNot(keep)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:482:36  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:547:30  [BooleanLiteral] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:595:14  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:595:19  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:599:20  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:599:20  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:599:28  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:601:12  [MethodExpression] -> nodes.take(1)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:603:47  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:622:74  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:10  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:12  [EqualityOperator] -> ==
@@ -30,14 +19,11 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scal
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:210:14  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:232:42  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:240:22  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:241:8  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:241:48  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:241:84  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:242:6  [MethodExpression] -> index.info(index.owner(info.symbol)).forall(isImplicit)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:258:23  [MethodExpression] -> parentSymbol(tpe).forall(sym => index.displayName(sym) == givenName)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:259:8  [ConditionalExpression] -> true
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:295:78  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:330:10  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:28:23  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:64:10  [ConditionalExpression] -> true
 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala:64:53  [LogicalOperator] -> ||

--- a/mutation-survivors.txt
+++ b/mutation-survivors.txt
@@ -1,12 +1,11 @@
-# Survived mutants: 24
-# generated from analysis/target/stryker4s-report/1782678647242/report.json
+# Survived mutants: 23
+# generated from analysis/target/stryker4s-report/1782678825860/report.json
 #
 # by file:
 #     15 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #      6 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
-#      3 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+#      2 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
 #
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:482:36  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:599:20  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:622:74  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:10  [ConditionalExpression] -> false

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -26,7 +26,8 @@ stryker4s {
     "com.github.mercurievv.scalasemantic.analysis.CompatSuite",
     "com.github.mercurievv.scalasemantic.model.ModelsSuite",
     "com.github.mercurievv.scalasemantic.model.InputTypesSuite",
-    "com.github.mercurievv.scalasemantic.analysis.AnalyzerHelpersSuite"
+    "com.github.mercurievv.scalasemantic.analysis.AnalyzerHelpersSuite",
+    "com.github.mercurievv.scalasemantic.analysis.AnalyzerCoreSuite"
   ]
 
   # html → browsable report (stryker4s-report/<ts>/index.html); json → machine-readable


### PR DESCRIPTION
Follows #55 (AnalyzerHelpers).

## What
Adds `AnalyzerCoreSuite`, driving `Analyzer` against small hand-built in-memory indexes (deterministic, so it's filter-safe — unlike `AnalyzerSuite`, which dogfoods the live `fromProject(".")` index and is deliberately excluded from mutation). Covers: `classHierarchy` linearization/known-subtypes, `members` declared-vs-inherited, `methodSignature` implicit-list detection (all/none/mixed params), `findOverloads` owner+name grouping, `resolveImplicits` candidate/`chosen`, and `callPath` BFS over definition→reference edges. Registered in `stryker4s.conf`.

## Result (re-ran `sbt -Dstryker=true "analysis/stryker"`)
| status | before | after |
|---|---|---|
| Killed | 190 | 205 |
| Survived | 38 | 23 |
| NoCoverage | 213 | 213 |

`Analyzer.scala` survivors: 14 → 2. The two left are **equivalent mutants** — the `fromSym == toSym` fast-path that BFS already satisfies, and a `callGraph` fold guard whose effect never reaches a `callPath`-observable result.

Note: helper vals are suffixed (`animalCls`, `dogCls`, …) so the symbols they emit don't perturb the dogfood `findSymbol`/structure suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)