### PR TITLE
test(analysis): cover the remaining Analyzer tools to kill mutants

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerToolsSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerToolsSuite.scala
@@ -1,0 +1,278 @@
+package com.github.mercurievv.scalasemantic.analysis
+
+import com.github.mercurievv.scalasemantic.model.*
+import com.github.mercurievv.scalasemantic.model.InputTypes.*
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+
+import scala.meta.internal.semanticdb as s
+
+/** Deterministic unit tests for the remaining `Analyzer` tools (outline, find-symbol, move-plan,
+  * extract-method-plan, ranked structure, type-at-position, trace-implicit-chain), driven against
+  * hand-built in-memory indexes. Filter-safe (no live dogfooding), so they belong in stryker4s.conf
+  * and cover the tool methods that only AnalyzerSuite/AnalyzerPcSuite reached.
+  */
+class AnalyzerToolsSuite extends munit.FunSuite:
+
+  private def tref(sym: String): s.Type = s.TypeRef(s.Type.Empty, sym, Nil)
+  private val IntT = tref("scala/Int#")
+  private val IMPL = s.SymbolInformation.Property.IMPLICIT.value
+
+  private def si(
+      sym: String,
+      kind: s.SymbolInformation.Kind,
+      display: String,
+      signature: s.Signature = s.NoSignature,
+      props: Int = 0
+  ) =
+    s.SymbolInformation(
+      symbol = sym,
+      kind = kind,
+      displayName = display,
+      signature = signature,
+      properties = props
+    )
+
+  private def occ(sym: String, role: s.SymbolOccurrence.Role, l1: Int, c1: Int, l2: Int, c2: Int) =
+    s.SymbolOccurrence(Some(s.Range(l1, c1, l2, c2)), sym, role)
+  private val DEF = s.SymbolOccurrence.Role.DEFINITION
+  private val REF = s.SymbolOccurrence.Role.REFERENCE
+
+  private def index(docs: s.TextDocument*) = SemanticIndex(docs.toVector)
+  private def doc(uri: String, symbols: Seq[s.SymbolInformation], occs: Seq[s.SymbolOccurrence]) =
+    s.TextDocument(uri = uri, symbols = symbols.toVector, occurrences = occs.toVector)
+
+  private def docUri(v: String) = DocumentUri.from(v).fold(fail(_), identity)
+
+  // ============================== outline =====================================
+
+  test("outline nests members under their type with per-entry signatures"):
+    val symbols = Seq(
+      si("o/C#", s.SymbolInformation.Kind.CLASS, "C"),
+      si("o/C#m().", s.SymbolInformation.Kind.METHOD, "m", s.MethodSignature(None, Nil, IntT)),
+      si("o/C#v.", s.SymbolInformation.Kind.FIELD, "v", s.ValueSignature(IntT)),
+      si(
+        "o/C#`<init>`().",
+        s.SymbolInformation.Kind.METHOD,
+        "<init>",
+        s.MethodSignature(None, Nil, IntT)
+      )
+    )
+    val occs = Seq(
+      occ("o/C#", DEF, 0, 0, 0, 1),
+      occ("o/C#m().", DEF, 1, 2, 1, 3),
+      occ("o/C#v.", DEF, 2, 2, 2, 3),
+      occ("o/C#`<init>`().", DEF, 0, 0, 0, 1) // excluded by name
+    )
+    val az = Analyzer(index(doc("o.scala", symbols, occs)))
+    val top = az.outline(docUri("o.scala")).getOrElse(fail("not indexed"))
+    assertEquals(top.map(_.symbol), List("o/C#"), "one top-level type, <init> excluded")
+    val kids = top.head.children
+    assertEquals(kids.map(_.name), List("m", "v"), "members nested and ordered by line")
+    assert(kids.find(_.name == "m").get.signature.startsWith("def m"), "method signature")
+    assertEquals(kids.find(_.name == "v").get.signature, ": Int", "value type")
+    assertEquals(top.head.signature, "", "a type needs no signature line")
+
+  // ============================ find-symbol ===================================
+
+  private val findIdx = index(
+    doc(
+      "f.scala",
+      Seq(
+        si("f/Animal#", s.SymbolInformation.Kind.CLASS, "Animal"),
+        si("f/AnimalKind#", s.SymbolInformation.Kind.CLASS, "AnimalKind"),
+        si("f/Zoo#animal().", s.SymbolInformation.Kind.METHOD, "animal"),
+        si("f/Zoo#`<init>`().", s.SymbolInformation.Kind.METHOD, "<init>"),
+        si("f/Zoo#animal().(p)", s.SymbolInformation.Kind.PARAMETER, "animal") // excluded by kind
+      ),
+      Nil
+    )
+  )
+
+  test("findSymbol: exact vs substring, excludes <init>/params, ranks exact>prefix>substring"):
+    val az = Analyzer(findIdx)
+    assertEquals(
+      az.findSymbol("animal", exact = true).map(_.displayName),
+      List("Animal", "animal"),
+      "exact (case-insensitive); AnimalKind/<init>/param excluded"
+    )
+    assertEquals(
+      az.findSymbol("anim").map(_.displayName),
+      List("Animal", "animal", "AnimalKind"),
+      "substring, ranked exact/prefix then by length"
+    )
+    assertEquals(
+      az.findSymbol("animal", kind = Some("CLASS")).map(_.displayName).toSet,
+      Set("Animal", "AnimalKind"),
+      "kind filter keeps only classes"
+    )
+    assertEquals(az.findSymbol("animal", limit = lim(1)).size, 1, "limit applies")
+    assert(az.findSymbol("nomatch").isEmpty)
+
+  private def lim(n: Int) = PositiveInt.from(n, "limit").fold(fail(_), identity)
+
+  // ============================== move-plan ===================================
+
+  test("movePlan: per-file import edits decided by each referrer's own package"):
+    val foo = doc(
+      "pkg/a.scala",
+      Seq(si("m/pkg/Foo#", s.SymbolInformation.Kind.CLASS, "Foo")),
+      Seq(occ("m/pkg/Foo#", DEF, 0, 0, 0, 3))
+    )
+    // a referrer already in the destination package -> no import
+    val inDest = doc(
+      "dest/b.scala",
+      Seq(si("m/dest/B#", s.SymbolInformation.Kind.CLASS, "B")),
+      Seq(occ("m/dest/B#", DEF, 0, 0, 0, 1), occ("m/pkg/Foo#", REF, 1, 4, 1, 7))
+    )
+    // a referrer in the source package -> add the new FQN (nothing to remove)
+    val inSource = doc(
+      "pkg/c.scala",
+      Seq(si("m/pkg/C#", s.SymbolInformation.Kind.CLASS, "C")),
+      Seq(occ("m/pkg/C#", DEF, 0, 0, 0, 1), occ("m/pkg/Foo#", REF, 1, 4, 1, 7))
+    )
+    // a referrer elsewhere -> swap old FQN for new
+    val elsewhere = doc(
+      "other/d.scala",
+      Seq(si("m/other/D#", s.SymbolInformation.Kind.CLASS, "D")),
+      Seq(occ("m/other/D#", DEF, 0, 0, 0, 1), occ("m/pkg/Foo#", REF, 1, 4, 1, 7))
+    )
+    val az = Analyzer(index(foo, inDest, inSource, elsewhere))
+    val sym = SemanticDbSymbol.from("m/pkg/Foo#").fold(fail(_), identity)
+    val dest = PackageSymbol.from("m/dest/").fold(fail(_), identity)
+    val plan = az.movePlan(sym, dest)
+    assertEquals(plan.fromFqn, "m.pkg.Foo")
+    assertEquals(plan.toFqn, "m.dest.Foo")
+    assertEquals(plan.references.size, 3, "every cross-file use")
+    assertEquals(
+      plan.imports.toSet,
+      Set(
+        MoveImport("pkg/c.scala", "", "m.dest.Foo"),
+        MoveImport("other/d.scala", "m.pkg.Foo", "m.dest.Foo")
+      ),
+      "dest-package referrer needs no import"
+    )
+
+  // ========================== extract-method-plan =============================
+
+  test("extractMethodPlan: free-var params, escaping returns, rendered signature/call"):
+    def local(n: String, display: String) =
+      si(n, s.SymbolInformation.Kind.LOCAL, display, s.ValueSignature(IntT))
+    val symbols = Seq(
+      si("ex/M#run().", s.SymbolInformation.Kind.METHOD, "run", s.MethodSignature(None, Nil, IntT)),
+      local("local0", "a"), // defined before, read inside  -> param
+      local("local1", "b"), // defined inside, read after   -> return
+      local("local2", "c") // defined and read inside only  -> neither
+    )
+    val occs = Seq(
+      occ("ex/M#run().", DEF, 0, 2, 0, 5),
+      occ("local0", DEF, 1, 8, 1, 9), // outside selection (before)
+      occ("local0", REF, 3, 10, 3, 11), // inside  -> a is a free read
+      occ("local1", DEF, 3, 4, 3, 5), // inside
+      occ("local2", DEF, 4, 4, 4, 5), // inside
+      occ("local2", REF, 4, 8, 4, 9), // inside (not escaping)
+      occ("local1", REF, 6, 4, 6, 5) // after selection -> b escapes
+    )
+    val az = Analyzer(index(doc("ex.scala", symbols, occs)))
+    val range = SourceRange.from(2, 0, 5, 0).fold(fail(_), identity)
+    val name = ScalaIdentifier.from("extracted").fold(fail(_), identity)
+    val plan = az.extractMethodPlan(docUri("ex.scala"), range, name).getOrElse(fail("not indexed"))
+    assertEquals(plan.parameters.map(_.name), List("a"), "free var read inside")
+    assertEquals(plan.returns.map(_.name), List("b"), "defined inside, read after")
+    assertEquals(plan.returnType, "Int")
+    assertEquals(plan.signature, "def extracted(a: Int): Int")
+    assertEquals(plan.call, "val b = extracted(a)")
+    assertEquals(plan.enclosingMethod.map(_.displayName), Some("run"))
+
+  // ======================== ranked structure symbols ==========================
+
+  test("rankedStructureSymbols sorts by the chosen metric and honours the limit"):
+    // B -> A (B extends A): A has afferent 1, B has efferent 1.
+    val symbols = Seq(
+      si(
+        "s/A#",
+        s.SymbolInformation.Kind.CLASS,
+        "A",
+        s.ClassSignature(None, List(tref("java/lang/Object#")), s.Type.Empty, Some(s.Scope()))
+      ),
+      si(
+        "s/B#",
+        s.SymbolInformation.Kind.CLASS,
+        "B",
+        s.ClassSignature(None, List(tref("s/A#")), s.Type.Empty, Some(s.Scope()))
+      )
+    )
+    val occs = Seq(occ("s/A#", DEF, 0, 0, 0, 1), occ("s/B#", DEF, 1, 0, 1, 1))
+    val az = Analyzer(index(doc("s/lib.scala", symbols, occs)))
+    val byAfferent = az
+      .rankedStructureSymbols(StructureDimension.Combined, StructureSort.Afferent, lim(1))
+      .map((sym, _) => sym.displayName)
+    assertEquals(byAfferent, List("A"), "A (depended on) ranks highest by afferent, limit 1")
+    val byEfferent = az
+      .rankedStructureSymbols(StructureDimension.Combined, StructureSort.Efferent, lim(1))
+      .map((sym, _) => sym.displayName)
+    assertEquals(byEfferent, List("B"), "B (depends on A) ranks highest by efferent")
+
+  // =========================== type-at-position ===============================
+
+  test("typeAtPosition picks the smallest occurrence covering the point"):
+    val symbols = Seq(
+      si("t/T#", s.SymbolInformation.Kind.CLASS, "T"),
+      si("t/T#m().", s.SymbolInformation.Kind.METHOD, "m", s.MethodSignature(None, Nil, IntT))
+    )
+    val occs = Seq(
+      occ("t/T#", REF, 1, 0, 1, 9), // wide span
+      occ("t/T#m().", REF, 1, 2, 1, 3) // narrow span over the same point
+    )
+    val az = Analyzer(index(doc("t.scala", symbols, occs)))
+    val pos = SourcePosition.from(1, 2).fold(fail(_), identity)
+    val at = az.typeAtPosition(docUri("t.scala"), pos).getOrElse(fail("nothing at position"))
+    assertEquals(at.symbol, "t/T#m().", "the tighter range wins")
+    assertEquals(at.displayName, "m")
+
+  // ========================= trace-implicit-chain =============================
+
+  test("traceImplicitChain walks given dependencies transitively"):
+    def givenObj(sym: String, display: String, produces: String) =
+      si(
+        sym,
+        s.SymbolInformation.Kind.OBJECT,
+        display,
+        s.ClassSignature(None, List(tref(produces), tref("java/lang/Object#")), s.Type.Empty, None),
+        IMPL
+      )
+    def givenDef(sym: String, display: String, produces: String, dep: String) =
+      si(
+        sym,
+        s.SymbolInformation.Kind.METHOD,
+        display,
+        s.MethodSignature(
+          None,
+          Seq(
+            s.Scope(hardlinks =
+              Vector(
+                si(
+                  sym + "(p)",
+                  s.SymbolInformation.Kind.PARAMETER,
+                  "p",
+                  s.ValueSignature(tref(dep)),
+                  IMPL
+                )
+              )
+            )
+          ),
+          tref(produces)
+        ),
+        IMPL
+      )
+    val symbols = Seq(
+      si("ic/Show#", s.SymbolInformation.Kind.CLASS, "Show"),
+      si("ic/Eq#", s.SymbolInformation.Kind.CLASS, "Eq"),
+      givenDef("ic/showFromEq().", "showFromEq", "ic/Show#", "ic/Eq#"), // Show needs Eq
+      givenObj("ic/eqInst.", "eqInst", "ic/Eq#") // Eq provided
+    )
+    val az = Analyzer(index(doc("ic.scala", symbols, Nil)))
+    val sym = TypeSymbol.from("ic/Show#").fold(fail(_), identity)
+    val chain = az.traceImplicitChain(sym)
+    assertEquals(chain.queryType, "ic/Show#")
+    assert(chain.steps.exists(_.target.displayName == "showFromEq"), chain.steps.toString)
+    assert(chain.steps.exists(_.target.displayName == "eqInst"), "transitive Eq given reached")

--- a/mutation-nocoverage.txt
+++ b/mutation-nocoverage.txt
@@ -1,93 +1,17 @@
-# NoCoverage mutants: 122
-# generated from analysis/target/stryker4s-report/1782680877459/report.json
+# NoCoverage mutants: 36
+# generated from analysis/target/stryker4s-report/1782683008384/report.json
 #
 # by file:
-#     83 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
-#     39 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+#     29 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+#      7 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
 #
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:75:36  [MethodExpression] -> pathFilter.filterNot(_.nonEmpty)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:75:54  [MethodExpression] -> _.isEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:76:5  [MethodExpression] -> structureResult.symbols.filter(s => keepModule(s.module)).map(s => s -> selectedMetrics(s, dimension)).sortBy((_, metrics) => -rankStructureMetrics(metrics, sort)).drop(limit.value)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:76:5  [MethodExpression] -> structureResult.symbols.filterNot(s => keepModule(s.module))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:120:27  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:120:65  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:127:12  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:127:12  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:138:31  [MethodExpression] -> parentOf(sym).nonEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:147:61  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:148:41  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:149:41  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:222:35  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:228:37  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:234:19  [MethodExpression] -> references.map(_.uri).distinct.filter(defUri.contains)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:240:12  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:240:12  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:241:17  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:241:17  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:241:67  [StringLiteral] -> "Stryker was here!"
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:282:23  [MethodExpression] -> occ.iterator.filter(o => o.role == s.SymbolOccurrence.Role.DEFINITION && o.range.exists(inSelection)).map(_.symbol).filterNot(index.isLocal)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:282:23  [MethodExpression] -> occ.iterator.filterNot(o => o.role == s.SymbolOccurrence.Role.DEFINITION && o.range.exists(inSelection))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:283:29  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:283:67  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:283:70  [MethodExpression] -> o.range.forall(inSelection)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:290:20  [MethodExpression] -> occ.iterator.filter(o => o.role == s.SymbolOccurrence.Role.REFERENCE && o.range.exists(inSelection)).filterNot(o => index.isLocal(o.symbol) && !defInside.contains(o.symbol))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:290:20  [MethodExpression] -> occ.iterator.filterNot(o => o.role == s.SymbolOccurrence.Role.REFERENCE && o.range.exists(inSelection))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:291:29  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:291:66  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:291:69  [MethodExpression] -> o.range.forall(inSelection)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:292:46  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:300:23  [MethodExpression] -> occ.iterator.filterNot(o => o.role == s.SymbolOccurrence.Role.REFERENCE && o.range.exists(afterSelection))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:301:29  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:301:66  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:301:69  [MethodExpression] -> o.range.forall(afterSelection)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:304:21  [MethodExpression] -> occ.iterator.filter(o => o.role == s.SymbolOccurrence.Role.DEFINITION && o.range.exists(inSelection)).filterNot(o => index.isLocal(o.symbol) && readAfter.contains(o.symbol))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:304:21  [MethodExpression] -> occ.iterator.filterNot(o => o.role == s.SymbolOccurrence.Role.DEFINITION && o.range.exists(inSelection))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:305:29  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:305:67  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:305:70  [MethodExpression] -> o.range.forall(inSelection)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:306:46  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:314:23  [MethodExpression] -> occ.filter(o => o.role == s.SymbolOccurrence.Role.DEFINITION && index.isMethod(o.symbol)).filterNot(o => o.range.exists(r => range.start.atOrAfter(r.startLine, r.startCharacter)))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:314:23  [MethodExpression] -> occ.filterNot(o => o.role == s.SymbolOccurrence.Role.DEFINITION && index.isMethod(o.symbol))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:315:29  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:315:67  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:316:22  [MethodExpression] -> o.range.forall(r => range.start.atOrAfter(r.startLine, r.startCharacter))
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:321:26  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:323:51  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:323:56  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:323:62  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:324:39  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:324:72  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:325:23  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:326:46  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:328:26  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:329:26  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:330:26  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:330:61  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:366:5  [MethodExpression] -> index.symbols.values.iterator.filter(si => index.isGlobal(si.symbol)).filter(si => !findSymbolExcludedKinds.contains(si.kind)).filter(si => si.displayName.nonEmpty && si.displayName != "<init>").filter { si => val n = si.displayName.toLowerCase if (exact) n == q else n.contains(q) }.filter(si => wantedKind.forall(k => si.kind.toString.toUpperCase == k)).filter(si => keepPath(si.symbol)).toList.sortBy { si => val n = si.displayName.toLowerCase val rank = if (n == q) 0 else if (n.startsWith(q)) 1 else 2 (rank, si.displayName.length, si.symbol) }.drop(limit.value)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:366:5  [MethodExpression] -> index.symbols.values.iterator.filter(si => index.isGlobal(si.symbol)).filter(si => !findSymbolExcludedKinds.contains(si.kind)).filter(si => si.displayName.nonEmpty && si.displayName != "<init>").filter { si => val n = si.displayName.toLowerCase if (exact) n == q else n.contains(q) }.filter(si => wantedKind.forall(k => si.kind.toString.toUpperCase == k)).filterNot(si => keepPath(si.symbol))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:366:5  [MethodExpression] -> index.symbols.values.iterator.filter(si => index.isGlobal(si.symbol)).filter(si => !findSymbolExcludedKinds.contains(si.kind)).filter(si => si.displayName.nonEmpty && si.displayName != "<init>").filter { si => val n = si.displayName.toLowerCase if (exact) n == q else n.contains(q) }.filterNot(si => wantedKind.forall(k => si.kind.toString.toUpperCase == k))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:366:5  [MethodExpression] -> index.symbols.values.iterator.filter(si => index.isGlobal(si.symbol)).filter(si => !findSymbolExcludedKinds.contains(si.kind)).filter(si => si.displayName.nonEmpty && si.displayName != "<init>").filterNot { si => val n = si.displayName.toLowerCase if (exact) n == q else n.contains(q) }
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:366:5  [MethodExpression] -> index.symbols.values.iterator.filter(si => index.isGlobal(si.symbol)).filter(si => !findSymbolExcludedKinds.contains(si.kind)).filterNot(si => si.displayName.nonEmpty && si.displayName != "<init>")
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:366:5  [MethodExpression] -> index.symbols.values.iterator.filter(si => index.isGlobal(si.symbol)).filterNot(si => !findSymbolExcludedKinds.contains(si.kind))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:366:5  [MethodExpression] -> index.symbols.values.iterator.filterNot(si => index.isGlobal(si.symbol))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:369:21  [MethodExpression] -> si.displayName.isEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:369:45  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:369:63  [EqualityOperator] -> ==
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:369:66  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:372:12  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:372:12  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:372:25  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:374:21  [MethodExpression] -> wantedKind.exists(k => si.kind.toString.toUpperCase == k)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:374:73  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:23  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:23  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:25  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:45  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:45  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:518:5  [MethodExpression] -> index.document(docUri).toSeq.flatMap(_.occurrences).filterNot(occ => occ.range.exists(h.rangeContains(_, position.lineValue, position.characterValue)))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:523:9  [MethodExpression] -> occ.range.forall(h.rangeContains(_, position.lineValue, position.characterValue))
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:570:14  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:570:14  [ConditionalExpression] -> true
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:45:34  [MethodExpression] -> t.typeArguments.isEmpty
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:50:13  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:51:54  [StringLiteral] -> ""
@@ -114,16 +38,6 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scal
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:108:31  [LogicalOperator] -> &&
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:110:66  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:110:83  [StringLiteral] -> ""
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:143:7  [MethodExpression] -> doc.occurrences.iterator.filter(_.role == s.SymbolOccurrence.Role.DEFINITION).map(_.symbol).filterNot(index.isGlobal)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:143:7  [MethodExpression] -> doc.occurrences.iterator.filterNot(_.role == s.SymbolOccurrence.Role.DEFINITION)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:144:24  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:155:5  [MethodExpression] -> index.info(symbol).map(_.displayName).filterNot(_.nonEmpty)
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:155:50  [MethodExpression] -> _.isEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:8  [ConditionalExpression] -> false
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:8  [ConditionalExpression] -> true
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:8  [MethodExpression] -> rendered.nonEmpty
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:30  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:186:16  [MethodExpression] -> definitionUri(sym).forall(keepUri)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:191:35  [EqualityOperator] -> !=
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:275:9  [MethodExpression] -> m.parameterLists.toList.flatMap(scope => scopeInfos(Some(scope))).filterNot(isImplicit)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:391:36  [StringLiteral] -> "Stryker was here!"

--- a/mutation-survivors.txt
+++ b/mutation-survivors.txt
@@ -1,14 +1,38 @@
-# Survived mutants: 46
-# generated from analysis/target/stryker4s-report/1782680877459/report.json
+# Survived mutants: 71
+# generated from analysis/target/stryker4s-report/1782683008384/report.json
 #
 # by file:
-#     15 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+#     26 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+#     16 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
 #     10 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/StructureMetrics.scala
 #      8 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetrics.scala
 #      6 src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
 #      5 src/main/scala/com/github/mercurievv/scalasemantic/analysis/graph/DependencyGraphs.scala
-#      2 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
 #
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:75:36  [MethodExpression] -> pathFilter.filterNot(_.nonEmpty)
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:75:54  [MethodExpression] -> _.isEmpty
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:147:61  [StringLiteral] -> "Stryker was here!"
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:222:35  [EqualityOperator] -> !=
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:283:70  [MethodExpression] -> o.range.forall(inSelection)
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:290:20  [MethodExpression] -> occ.iterator.filterNot(o => o.role == s.SymbolOccurrence.Role.REFERENCE && o.range.exists(inSelection))
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:291:66  [LogicalOperator] -> ||
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:291:69  [MethodExpression] -> o.range.forall(inSelection)
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:301:69  [MethodExpression] -> o.range.forall(afterSelection)
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:304:21  [MethodExpression] -> occ.iterator.filterNot(o => o.role == s.SymbolOccurrence.Role.DEFINITION && o.range.exists(inSelection))
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:305:67  [LogicalOperator] -> ||
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:305:70  [MethodExpression] -> o.range.forall(inSelection)
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:316:22  [MethodExpression] -> o.range.forall(r => range.start.atOrAfter(r.startLine, r.startCharacter))
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:324:72  [StringLiteral] -> ""
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:326:46  [StringLiteral] -> ""
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:369:45  [LogicalOperator] -> ||
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:369:66  [StringLiteral] -> ""
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:23  [ConditionalExpression] -> false
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:23  [ConditionalExpression] -> true
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:25  [EqualityOperator] -> !=
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:45  [ConditionalExpression] -> false
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:379:45  [ConditionalExpression] -> true
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:523:9  [MethodExpression] -> occ.range.forall(h.rangeContains(_, position.lineValue, position.characterValue))
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:570:14  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:599:20  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala:622:74  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:119:10  [ConditionalExpression] -> false
@@ -18,10 +42,11 @@ src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scal
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:122:29  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:15  [EqualityOperator] -> >
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:127:33  [EqualityOperator] -> <=
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:8  [ConditionalExpression] -> false
+src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:163:30  [StringLiteral] -> ""
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:210:14  [ConditionalExpression] -> false
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:232:42  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:240:22  [LogicalOperator] -> ||
-src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:241:48  [EqualityOperator] -> !=
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:241:84  [LogicalOperator] -> ||
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:258:23  [MethodExpression] -> parentSymbol(tpe).forall(sym => index.displayName(sym) == givenName)
 src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala:259:8  [ConditionalExpression] -> true

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -28,7 +28,8 @@ stryker4s {
     "com.github.mercurievv.scalasemantic.model.InputTypesSuite",
     "com.github.mercurievv.scalasemantic.analysis.AnalyzerHelpersSuite",
     "com.github.mercurievv.scalasemantic.analysis.AnalyzerCoreSuite",
-    "com.github.mercurievv.scalasemantic.analysis.graph.StructureMetricsSuite"
+    "com.github.mercurievv.scalasemantic.analysis.graph.StructureMetricsSuite",
+    "com.github.mercurievv.scalasemantic.analysis.AnalyzerToolsSuite"
   ]
 
   # html → browsable report (stryker4s-report/<ts>/index.html); json → machine-readable


### PR DESCRIPTION
Follows #57 / #59. Completes the Analyzer.scala coverage investigation.

## What
Adds `AnalyzerToolsSuite` driving the seven `Analyzer` tool methods that no filtered suite reached — `outline`, `findSymbol`, `movePlan`, `extractMethodPlan`, `rankedStructureSymbols`, `typeAtPosition`, `traceImplicitChain` — against hand-built in-memory indexes (locals as `localN` for extract-method free-variable analysis, multi-package docs for move-plan import edits, nested defs for outline). Deterministic and filter-safe, unlike `AnalyzerSuite`/`AnalyzerPcSuite`. Registered in `stryker4s.conf`.

## Why
These tools were the bulk of the remaining NoCoverage — `extractMethodPlan` (38) + `findSymbol` (21) alone were 71% of `Analyzer.scala`'s uncovered mutants.

## Result (re-ran `sbt -Dstryker=true "analysis/stryker"`)
| status | before | after |
|---|---|---|
| Killed | 273 | 334 |
| Survived | 46 | 71 |
| NoCoverage | 122 | 36 |

`Analyzer.scala` NoCoverage: 83 → 7. Project-wide NoCoverage is now **36** (down from 317 at the start of this effort). The new survivors are loose-assertion gaps in the same tools — a follow-up tightening pass, not missing coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)