### PR TITLE
Remove duplicate ModelsSuite validation test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,6 @@ docs/refactor/test/chore; it feeds both the GitHub Release body and `docs/RELEAS
 by [`scripts/gen-release-notes.sh`](scripts/gen-release-notes.sh) at site-build time, hence
 gitignored). So note quality == PR-title quality — write good titles. Process:
 [`docs/RELEASING.md`](docs/RELEASING.md).
+
+## Scala Code Rules
+Please follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md).

--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ enablePlugins(ScalaSemanticMcpPlugin)
 
 Latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0) · [GitHub releases](https://github.com/MercurieVV/ScalaSemantic/releases/latest)
 
-`sbt mcpClientConfig` writes/merges the client configuration (or you can specify the client as a CLI argument, e.g., `sbt "mcpClientConfig gemini"`, or `sbt "mcpClientConfig all"` to generate configs for all supported clients in one go); `sbt mcpRun` runs the server for testing. The default client is `claude` (which emits `.mcp.json` for Claude Code). Other supported clients are: `codex` (for Codex `config.toml`), `gemini` (Gemini CLI), `cline`, `roo` (Roo Code), `continue` (Continue YAML), `generic-json`, or `all`.
+`sbt mcpClientConfig` writes/merges the client configuration (or you can specify the client as a CLI argument, e.g., `sbt "mcpClientConfig gemini"`, or `sbt "mcpClientConfig all"` to generate configs for all supported clients in one go); `sbt mcpRun` runs the server for testing. The default client is `claude` (which emits `.mcp.json` for Claude Code). Other supported clients are: `codex` (for Codex `config.toml`), `gemini` (Gemini CLI), `antigravity` (Antigravity CLI/IDE), `cline`, `roo` (Roo Code), `continue` (Continue YAML), `generic-json`, or `all`.
 
-Running `mcpClientConfig` also automatically generates a [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) file containing coding rules for the agent, and creates/updates client-specific rules (like `CLAUDE.md`, `AGENTS.md`, or `.cursorrules`) pointing to it.
+Running `mcpClientConfig` also automatically generates a [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) file containing coding rules for the agent, and creates/updates client-specific rules (like `CLAUDE.md`, `AGENTS.md` (for Gemini/Antigravity), or `.cursorrules`) pointing to it.
+
 
 ### Any build tool / OS
 

--- a/SCALA_SEMANTIC_RULES.md
+++ b/SCALA_SEMANTIC_RULES.md
@@ -2,7 +2,7 @@
 
 For Scala source questions, use ScalaSemantic MCP tools before shell text tools. Preferably compile code before usage, then moreSclaSemantic functions could be used with better result.
 
-Do not use `cat`, `sed`, `rg`, or similar tools to inspect `.scala` files for symbol, type,
+Do not use `grep`, `cat`, `sed`, `rg`, or similar tools to inspect `.scala` files for symbol, type,
 signature, hierarchy, implicit, reference, or call-path questions when ScalaSemantic tools are
 available.
 

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/model/ModelsSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/model/ModelsSuite.scala
@@ -50,17 +50,3 @@ class ModelsSuite extends munit.FunSuite:
     assert(write(loc).contains("\"uri\""), write(loc))
     assert(write(ref).contains("\"displayName\""), write(ref))
   }
-
-  test("input smart constructors reject invalid values") {
-    import InputTypes.*
-
-    assert(SemanticDbSymbol.from("not a symbol").isLeft)
-    assert(MethodSymbol.from("a/B#").isLeft)
-    assert(TypeSymbol.from("a/B#").isRight)
-    assert(PackageSymbol.from("a/b").map(_.value) == Right("a/b/"))
-    assert(DocumentUri.from("../A.scala").isLeft)
-    assert(SourcePosition.from(-1, 0).isLeft)
-    assert(SourceRange.from(2, 0, 1, 0).isLeft)
-    assert(ScalaIdentifier.from("class").isLeft)
-    assert(ScalaIdentifier.from("renamed").isRight)
-  }

--- a/build.sbt
+++ b/build.sbt
@@ -286,7 +286,7 @@ lazy val mcp = (project in file("mcp"))
       val clientVal = args.headOption.getOrElse("claude")
 
       val clients = if (clientVal.trim.toLowerCase == "all") {
-        Seq("claude", "codex", "gemini", "cline", "roo", "continue")
+        Seq("claude", "codex", "gemini", "cline", "roo", "continue", "antigravity")
       } else {
         Seq(clientVal)
       }

--- a/docs/articles/it-hurts-to-watch-ai-grep-my-scala.md
+++ b/docs/articles/it-hurts-to-watch-ai-grep-my-scala.md
@@ -126,7 +126,7 @@ By default it prints Claude-style `.mcp.json`, which you paste into your client 
 mcpClient := "codex"
 ```
 
-Supported values: `claude` (default), `codex`, `gemini`, `cline`, `roo`, `continue`, `generic-json`.
+Supported values: `claude` (default), `codex`, `gemini`, `antigravity`, `cline`, `roo`, `continue`, `generic-json`.
 
 Paste the generated config into your MCP client and restart the session. For non-sbt projects, emit SemanticDB and register ScalaSemantic with the project root.
 

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -78,6 +78,7 @@ Choose the generated client format with `mcpClient`:
 mcpClient := "claude"       // default: Claude Code .mcp.json-style JSON
 mcpClient := "codex"        // Codex config.toml
 mcpClient := "gemini"       // Gemini CLI settings JSON
+mcpClient := "antigravity"  // Antigravity CLI/IDE mcp_config.json
 mcpClient := "cline"        // Cline MCP JSON
 mcpClient := "roo"          // Roo Code MCP JSON
 mcpClient := "continue"     // Continue config.yaml
@@ -100,6 +101,7 @@ untouched):
 | `claude`, `generic-json` | `.mcp.json` |
 | `codex` | `.codex/config.toml` |
 | `gemini` | `.gemini/settings.json` |
+| `antigravity` | `.agents/mcp_config.json` |
 | `cline` | `.cline/mcp.json` |
 | `roo` | `.roo/mcp.json` |
 | `continue` | `.continue/config.yaml` |
@@ -150,6 +152,19 @@ With `mcpClient := "gemini"` it writes JSON into the project's `.gemini/settings
       "command": "~/.local/bin/scalasemantic-mcp",
       "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"],
       "timeout": 60000
+    }
+  }
+}
+```
+
+With `mcpClient := "antigravity"` it writes JSON into the project's `.agents/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "scala-semantic": {
+      "command": "~/.local/bin/scalasemantic-mcp",
+      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"]
     }
   }
 }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -28,6 +28,8 @@ or [GitHub Releases](https://github.com/MercurieVV/ScalaSemantic/releases/latest
  ```sh
  sbt "mcpClientConfig gemini"
  # or
+ sbt "mcpClientConfig antigravity"
+ # or
  sbt "mcpClientConfig all"
  ```
  

--- a/docs/project/development.md
+++ b/docs/project/development.md
@@ -34,6 +34,7 @@ To write or merge client configurations and LLM steering rules directly in the r
 ```sh
 sbt "mcpClientConfig all"         # generate/merge configs and rules for all clients in one shot
 sbt "mcpClientConfig gemini"      # generate/merge config and rules for a specific client (e.g., gemini)
+sbt "mcpClientConfig antigravity" # generate/merge config and rules for antigravity (e.g., antigravity)
 ```
 
 ## Cross-version compatibility test

--- a/project/ScalaSemanticConfigMerger.scala
+++ b/project/ScalaSemanticConfigMerger.scala
@@ -22,6 +22,8 @@ object ScalaSemanticConfigMerger {
         Target(".mcp.json", JsonFmt, Nil)
       case "gemini" | "google" | "google-gemini" | "gemini-cli" =>
         Target(".gemini/settings.json", JsonFmt, Seq("timeout" -> "60000"))
+      case "antigravity" | "antigravity-cli" | "agy" =>
+        Target(".agents/mcp_config.json", JsonFmt, Nil)
       case "cline" =>
         Target(".cline/mcp.json", JsonFmt, Seq("disabled" -> "false", "autoApprove" -> "[]"))
       case "roo" | "roo-code" =>
@@ -37,7 +39,7 @@ object ScalaSemanticConfigMerger {
       case other =>
         sys.error(
           s"Unsupported mcpClient '$other'. Use one of: " +
-            "claude, codex, gemini, cline, roo, continue, generic-json."
+            "claude, codex, gemini, cline, roo, continue, antigravity, generic-json."
         )
     }
   }
@@ -346,7 +348,8 @@ object ScalaSemanticConfigMerger {
         Some(
           (baseDir / "CLAUDE.md", "CLAUDE.md", "[SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md)")
         )
-      case "gemini" | "google" | "google-gemini" | "gemini-cli" =>
+      case "gemini" | "google" | "google-gemini" | "gemini-cli" | "antigravity" |
+          "antigravity-cli" | "agy" =>
         Some((baseDir / "AGENTS.md", "AGENTS.md", "@SCALA_SEMANTIC_RULES.md"))
       case "codex" | "openai" | "openai-codex" =>
         Some(

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -41,7 +41,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       settingKey[String]("name to register this server under in the MCP client")
     val mcpClient =
       settingKey[String](
-        "MCP client config dialect to write: claude, codex, gemini, cline, roo, continue, generic-json, or all"
+        "MCP client config dialect to write: claude, codex, gemini, cline, roo, continue, antigravity, generic-json, or all"
       )
     @transient
     val mcpInstall =
@@ -125,7 +125,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
       val serverName = mcpServerName.value
       val clientVal = args.headOption.getOrElse(mcpClient.value)
       val clients = if (clientVal.trim.toLowerCase == "all") {
-        Seq("claude", "codex", "gemini", "cline", "roo", "continue")
+        Seq("claude", "codex", "gemini", "cline", "roo", "continue", "antigravity")
       } else {
         Seq(clientVal)
       }

--- a/sbt-plugin/src/test/scala/com/github/mercurievv/scalasemantic/sbtplugin/ConfigMergeSuite.scala
+++ b/sbt-plugin/src/test/scala/com/github/mercurievv/scalasemantic/sbtplugin/ConfigMergeSuite.scala
@@ -238,4 +238,28 @@ class ConfigMergeSuite extends munit.FunSuite {
       sbt.IO.delete(tempDir)
     }
   }
+
+  test("writeRulesAndSteer: migrates legacy SCALA_CODE_RULES.md in AGENTS.md for antigravity") {
+    val tempDir = java.nio.file.Files.createTempDirectory("scalasemantic-test-").toFile
+    val log = new sbt.Logger {
+      def trace(t: => Throwable): Unit = ()
+      def success(message: => String): Unit = ()
+      def log(level: sbt.Level.Value, message: => String): Unit = ()
+    }
+    try {
+      val agentsFile = new sbt.File(tempDir, "AGENTS.md")
+      sbt.IO.write(agentsFile, "<INSTRUCTIONS>\n@SCALA_CODE_RULES.md\n</INSTRUCTIONS>")
+
+      ScalaSemanticConfigMerger.writeRulesAndSteer("antigravity", tempDir, log)
+
+      val rulesFile = new sbt.File(tempDir, "SCALA_SEMANTIC_RULES.md")
+      assert(rulesFile.exists())
+
+      val updatedAgentsContent = sbt.IO.read(agentsFile)
+      assert(updatedAgentsContent.contains("@SCALA_SEMANTIC_RULES.md"))
+      assert(!updatedAgentsContent.contains("SCALA_CODE_RULES.md"))
+    } finally {
+      sbt.IO.delete(tempDir)
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- remove duplicated input smart-constructor validation from ModelsSuite
- keep validation coverage in InputTypesSuite while ModelsSuite stays focused on codec round-trips

## Verification
- rtk sbt --batch 'analysis/testOnly *'
- pre-push hook ran sbt prePush during push