### PR TITLE
chore: expose CLAUDE.md project context to LLM agents on startup

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,9 +1,6 @@
-# AGENTS.md instructions
+# Project Rules & Context
 
-<INSTRUCTIONS>
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/SCALA_SEMANTIC_RULES.md
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/CLAUDE.md
-</INSTRUCTIONS>
+Please follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code.
 
 ## Project Description & Startup Context
 
@@ -24,5 +21,4 @@ For detailed instructions, architecture, build/test commands, and conventions, p
 - **Conventions**:
   - Follow Scala Code Rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md).
   - Use Conventional Commit titles for squash merging PRs (`feat:`, `fix:`, `perf:`).
-
 

--- a/.continue/rules.txt
+++ b/.continue/rules.txt
@@ -1,9 +1,6 @@
-# AGENTS.md instructions
+# Project Rules & Context
 
-<INSTRUCTIONS>
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/SCALA_SEMANTIC_RULES.md
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/CLAUDE.md
-</INSTRUCTIONS>
+Please follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code.
 
 ## Project Description & Startup Context
 
@@ -24,5 +21,4 @@ For detailed instructions, architecture, build/test commands, and conventions, p
 - **Conventions**:
   - Follow Scala Code Rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md).
   - Use Conventional Commit titles for squash merging PRs (`feat:`, `fix:`, `perf:`).
-
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,9 +1,6 @@
-# AGENTS.md instructions
+# Project Rules & Context
 
-<INSTRUCTIONS>
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/SCALA_SEMANTIC_RULES.md
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/CLAUDE.md
-</INSTRUCTIONS>
+Please follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code.
 
 ## Project Description & Startup Context
 
@@ -24,5 +21,4 @@ For detailed instructions, architecture, build/test commands, and conventions, p
 - **Conventions**:
   - Follow Scala Code Rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md).
   - Use Conventional Commit titles for squash merging PRs (`feat:`, `fix:`, `perf:`).
-
 


### PR DESCRIPTION
This PR exposes the project context and conventions defined in CLAUDE.md to all LLM agents (Cursor, Roo/Cline, Continue, Codex, Gemini/Antigravity) on startup by adding it to their respective rules files.