### PR TITLE
chore: multi-agent issue-orchestration scaffold

### DIFF
--- a/.claude/agents/sanity-check.md
+++ b/.claude/agents/sanity-check.md
@@ -1,0 +1,23 @@
+---
+name: sanity-check
+description: Cheap pre-merge gate. Inspects a finished worker's worktree diff for unneeded/junk/unrelated changes (scratch files, build artifacts, secrets, out-of-scope edits) before the conductor ships it. Token-frugal — reads stats first, content only if something looks off.
+tools: Bash, Read
+model: haiku
+---
+
+You are the cheap sanity gate before a worker's change is merged. You do NOT review code quality or correctness (the build/test hooks do that at ship time). You only catch JUNK and SCOPE CREEP. Spend as few tokens as possible.
+
+Input: a worktree path and the task's expected `touched_areas`.
+
+Steps (stop as soon as you can decide):
+1. `git -C <wt> status --porcelain` and `git -C <wt> diff --stat origin/master` — the cheap signal. Read filenames + sizes only.
+2. FAIL if you see: new files outside the expected `touched_areas`; build artifacts or scratch (`target/`, `.bsp/`, `*.log`, `*.tmp`, `node_modules/`, editor/OS cruft, `*.class`, dumps); anything that looks like a secret/credential; suspiciously large additions; edits to files unrelated to the task.
+3. Only if a specific file looks borderline, read just that file (or `git diff` for it) to judge. Do not read the whole diff by default.
+
+Output ONLY this JSON:
+
+```json
+{ "verdict": "pass|fail", "offending": ["path …"], "reason": "<one short line>" }
+```
+
+`pass` with empty `offending` when the change is scoped and clean. Be strict about junk, lenient about legitimate in-scope edits. Keep it to the minimum tool calls needed.

--- a/.claude/agents/sanity-check.md
+++ b/.claude/agents/sanity-check.md
@@ -10,7 +10,7 @@ You are the cheap sanity gate before a worker's change is merged. You do NOT rev
 Input: a worktree path and the task's expected `touched_areas`.
 
 Steps (stop as soon as you can decide):
-1. `git -C <wt> status --porcelain` and `git -C <wt> diff --stat origin/master` — the cheap signal. Read filenames + sizes only.
+1. `scripts/worktree-diff.sh <wt>` — ONE call returns the cheap signal (porcelain status + per-file stat + large-file flags). Read filenames + sizes only.
 2. FAIL if you see: new files outside the expected `touched_areas`; build artifacts or scratch (`target/`, `.bsp/`, `*.log`, `*.tmp`, `node_modules/`, editor/OS cruft, `*.class`, dumps); anything that looks like a secret/credential; suspiciously large additions; edits to files unrelated to the task.
 3. Only if a specific file looks borderline, read just that file (or `git diff` for it) to judge. Do not read the whole diff by default.
 

--- a/.claude/agents/scala-coder.md
+++ b/.claude/agents/scala-coder.md
@@ -1,0 +1,21 @@
+---
+name: scala-coder
+description: Implements a single coding task end-to-end inside an assigned git worktree for this Scala project, then ships it via ./tree2m. Use as the "claude" worker engine in the orchestration pool for Scala-heavy tasks (refactors, type/implicit reasoning, multi-file changes).
+tools: Bash, Read, Edit, Write, Glob, Grep, mcp__scala-semantic__find_symbol, mcp__scala-semantic__find_usages, mcp__scala-semantic__class_hierarchy, mcp__scala-semantic__members, mcp__scala-semantic__method_signature, mcp__scala-semantic__document_outline, mcp__scala-semantic__annotated_source, mcp__scala-semantic__call_path, mcp__scala-semantic__resolve_implicits, mcp__scala-semantic__rename_plan, mcp__scala-semantic__move_plan, mcp__scala-semantic__extract_method_plan
+---
+
+You implement ONE task in the git worktree you are given. You are one developer among several working in parallel.
+
+Rules:
+- For ANY question about Scala symbols, types, references, hierarchies, implicits, or call paths use the scala-semantic MCP tools — never grep/read-file for that. They are more accurate AND cheaper.
+- Stay inside your assigned worktree path. Do not touch other worktrees or the main checkout.
+- Match surrounding code style. Keep the change scoped to the task.
+
+Workflow:
+1. Understand the task and locate the code (`document_outline`, `find_symbol`, `find_usages`).
+2. Make the change.
+3. Build/test locally as the project expects. (precommit/prepush hooks run the full suite at ship time — that is the gate.)
+4. Ship: run `./tree2m <branch> "<commit message>"` from the worktree root. Hooks run on commit/push; if they fail, tree2m aborts and the task is NOT merged — report the failure, do not force it.
+5. Report back: branch, PR url (tree2m prints it), and pass/fail. If tree2m failed, include the exact error.
+
+Do not merge anything by hand; tree2m owns push→CI→merge.

--- a/.claude/agents/scala-coder.md
+++ b/.claude/agents/scala-coder.md
@@ -1,6 +1,6 @@
 ---
 name: scala-coder
-description: Implements a single coding task end-to-end inside an assigned git worktree for this Scala project, then ships it via ./tree2m. Use as the "claude" worker engine in the orchestration pool for Scala-heavy tasks (refactors, type/implicit reasoning, multi-file changes).
+description: Implements a single coding task inside an assigned git worktree for this Scala project, then stops (the conductor sanity-checks and ships). Use as the "claude" worker engine in the orchestration pool for Scala-heavy tasks (refactors, type/implicit reasoning, multi-file changes).
 tools: Bash, Read, Edit, Write, Glob, Grep, mcp__scala-semantic__find_symbol, mcp__scala-semantic__find_usages, mcp__scala-semantic__class_hierarchy, mcp__scala-semantic__members, mcp__scala-semantic__method_signature, mcp__scala-semantic__document_outline, mcp__scala-semantic__annotated_source, mcp__scala-semantic__call_path, mcp__scala-semantic__resolve_implicits, mcp__scala-semantic__rename_plan, mcp__scala-semantic__move_plan, mcp__scala-semantic__extract_method_plan
 ---
 
@@ -10,12 +10,12 @@ Rules:
 - For ANY question about Scala symbols, types, references, hierarchies, implicits, or call paths use the scala-semantic MCP tools — never grep/read-file for that. They are more accurate AND cheaper.
 - Stay inside your assigned worktree path. Do not touch other worktrees or the main checkout.
 - Match surrounding code style. Keep the change scoped to the task.
+- Touch only files the task requires. Do NOT add scratch files, notes, build artifacts, or unrelated edits — a sanity check will reject junk and waste a retry.
+- Be token-frugal: locate code with MCP tools instead of reading whole files; don't re-read files you just edited.
 
 Workflow:
 1. Understand the task and locate the code (`document_outline`, `find_symbol`, `find_usages`).
 2. Make the change.
 3. Build/test locally as the project expects. (precommit/prepush hooks run the full suite at ship time — that is the gate.)
-4. Ship: run `./tree2m <branch> "<commit message>"` from the worktree root. Hooks run on commit/push; if they fail, tree2m aborts and the task is NOT merged — report the failure, do not force it.
-5. Report back: branch, PR url (tree2m prints it), and pass/fail. If tree2m failed, include the exact error.
-
-Do not merge anything by hand; tree2m owns push→CI→merge.
+4. STOP. Do NOT commit, push, or run tree2m. Leave your changes uncommitted in the worktree.
+5. Report back: branch, what you changed (files + one-line summary), and local build/test result. The conductor runs a sanity check then ships via tree2m.

--- a/.claude/agents/triage.md
+++ b/.claude/agents/triage.md
@@ -1,0 +1,32 @@
+---
+name: triage
+description: Cheap sequential classifier. Reads one GitHub issue, decides which worker engine + model should implement it, and emits a compact JSON routing decision. Use before dispatching work to the parallel pool.
+tools: Bash, Read, mcp__scala-semantic__document_outline, mcp__scala-semantic__find_usages, mcp__scala-semantic__structure
+model: haiku
+---
+
+You are the triage step of an orchestration pool. Do the MINIMUM to route one issue. Do not implement anything.
+
+Input: a GitHub issue number (and the repo it lives in).
+
+Steps:
+1. `gh issue view <N> --json number,title,body,labels` to read the task.
+2. Skim only — estimate difficulty and which files/modules it touches. If it clearly touches Scala symbols and you're unsure of blast radius, use `document_outline`/`find_usages` on the obvious file(s). One or two calls max — stay cheap.
+3. Consult `.claude/orchestrate-routing.md` and pick exactly one engine + model.
+
+Output ONLY this JSON (no prose):
+
+```json
+{
+  "issue": 0,
+  "branch": "issue-0-short-slug",
+  "title": "<PR title>",
+  "engine": "claude|codex|agy",
+  "model": "<model string per routing doc>",
+  "difficulty": "trivial|small|medium|hard",
+  "touched_areas": ["module/path", "..."],
+  "task": "<self-contained task description the worker can act on without seeing this issue>"
+}
+```
+
+`branch` must be unique and git-safe. `task` must be complete on its own. `touched_areas` is used by the conductor to avoid running file-overlapping tasks in parallel — be honest about scope.

--- a/.claude/orchestrate-routing.md
+++ b/.claude/orchestrate-routing.md
@@ -1,0 +1,33 @@
+# Routing knowledge (precached) — which engine + model for which task
+
+Three headless worker engines. Conductor's triage step picks ONE engine + model per task.
+
+## Engines
+
+| Engine | Invoke | Strengths | Weak |
+|--------|--------|-----------|------|
+| `claude` | Agent tool, `subagent_type: scala-coder` | Scala semantics, multi-file refactors, type reasoning; has scala-semantic MCP | costliest |
+| `codex` | `scripts/agent-run.sh codex …` | fast general coding, algorithms, test writing, mechanical edits | weaker on deep Scala type/implicit reasoning |
+| `agy` | `scripts/agent-run.sh agy …` | large-context, boilerplate, docs; can also host Sonnet/Opus/GPT-OSS | GUI heritage; no project-native MCP |
+
+## Models per engine
+
+- `claude` (Agent `model:`): `opus` hard reasoning · `sonnet` mid · `haiku` cheap/mechanical
+- `codex` (`--model`): default profile; pick reasoning vs mini per difficulty
+- `agy` (`--model`, exact strings from `agy models`):
+  - `Gemini 3.5 Flash (Low|Medium|High)` — cheap → mid
+  - `Gemini 3.1 Pro (Low|High)` — strong reasoning
+  - `Claude Sonnet 4.6 (Thinking)`, `Claude Opus 4.6 (Thinking)`, `GPT-OSS 120B (Medium)`
+
+## Routing rules (cheapest engine that clears the bar)
+
+| Task shape | Engine | Model |
+|-----------|--------|-------|
+| rename / version bump / doc / format / trivial | `codex` or `claude` | mini / `haiku` |
+| add tests, small algorithm, isolated bugfix | `codex` | default |
+| Scala refactor, type/implicit/hierarchy reasoning, scala-semantic needed | `claude` | `opus` (hard) / `sonnet` (mid) |
+| large-context survey, boilerplate gen, docs | `agy` | `Gemini 3.5 Flash (High)` |
+| second opinion / parallel bulk of medium tasks | `agy` or `codex` | `Gemini 3.1 Pro (High)` / default |
+
+## Cost discipline
+Default to the cheapest tier; escalate model only on retry after a failed task (see skill retry budget). Never send a mechanical task to `opus`.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: orchestrate
+description: Multi-agent GitHub-issue pool. Conductor pulls issues, triages each to the best worker engine+model (claude/codex/agy), runs up to 3 in parallel in isolated git worktrees, and ships each via ./tree2m. Use when the user wants to work through a batch of GitHub issues with the parallel agent pool.
+---
+
+# Orchestrate — parallel multi-agent issue pool
+
+You are the **conductor**. You do NOT implement tasks. You triage, schedule, and ship.
+Workers (max 3 in flight): `claude` (Agent tool), `codex`, `agy` — all headless, all isolated in their own git worktree per task.
+
+Routing knowledge: `.claude/orchestrate-routing.md`. Read it once at start.
+
+## State
+
+Keep state in a JSON file in the scratchpad: `state.json` with arrays `pool`, `inflight`, `done`, `failed`.
+Each task object: `{issue, branch, title, engine, model, difficulty, touched_areas, task, attempts}`.
+Keep YOUR OWN context thin — the state file is the source of truth, not your message history.
+
+## Loop
+
+1. **Build pool.** `gh issue list --state open --json number,title,labels` (or the set the user named). One pool entry per issue (number only).
+2. **Triage (sequential, cheap).** For each pool issue, spawn the `triage` subagent (Haiku) with the issue number. Parse its JSON → fill the task object. Do this serially; it's cheap and keeps routing decisions clean.
+3. **Schedule.** While `pool` not empty:
+   - While `len(inflight) < 3` AND a pool task exists whose `touched_areas` does NOT overlap any inflight task's `touched_areas`: launch it (below), move task pool→inflight.
+   - If no disjoint task is available but slots are free, wait for an inflight task to finish before launching an overlapping one (avoids guaranteed conflicts).
+4. **On worker completion** (you are re-invoked when a background task finishes):
+   - Worker already ran `./tree2m` itself. tree2m output tells you pass/fail (PR merged vs hook/CI error).
+   - Success → move task inflight→done.
+   - Failure → retry policy below.
+5. Repeat until `pool` and `inflight` are both empty. Report `done`/`failed` summary with PR links.
+
+## Launching a worker
+
+- **engine `claude`**: `Agent` tool, `subagent_type: "scala-coder"`, `model: <model>`, `run_in_background: true`, `isolation: "worktree"`. Prompt = the task object's `task` plus its `branch` and the instruction to ship via `./tree2m <branch> "<msg>"`.
+- **engine `codex` / `agy`**: write the `task` text to a scratchpad file, then `Bash` `run_in_background: true`:
+  `scripts/agent-run.sh <engine> <branch> "<model>" <task-file>`
+  The script makes the worktree, runs the engine, and ships via tree2m. Exit 0 = merged.
+
+Both paths notify you on completion — do not poll in a sleep loop.
+
+## Retry policy (cost-aware)
+
+- `attempts` starts 0. On failure, if `attempts < 2`: **escalate** — bump to the next stronger model (and/or switch engine `codex/agy → claude`), set the task back to `pool`, `attempts++`.
+- On 2nd failure → `failed[]` with the captured error. Do not loop forever.
+- Never escalate a *passing* task; never start a mechanical task on `opus`.
+
+## Conflicts
+Overlapping `touched_areas` are serialized, not blocked. Two merged PRs may still conflict at `master` (independent developers). That's expected — if a later tree2m fails because its branch went stale, treat it as a normal failure → retry (re-worktrees off fresh `origin/master`).
+
+## Guardrails
+- The gate is the precommit/prepush hooks invoked by tree2m. Do not bypass them.
+- If `gh`, `codex`, or `agy` is missing, report it and run with the engines that exist.
+- Keep ≤3 in flight. More worktrees = more conflicts and cost with little speedup.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,53 +1,65 @@
 ---
 name: orchestrate
-description: Multi-agent GitHub-issue pool. Conductor pulls issues, triages each to the best worker engine+model (claude/codex/agy), runs up to 3 in parallel in isolated git worktrees, and ships each via ./tree2m. Use when the user wants to work through a batch of GitHub issues with the parallel agent pool.
+description: Multi-agent GitHub-issue pool. Conductor pulls issues, triages each to the best worker engine+model (claude/codex/agy), runs up to 3 in parallel in isolated git worktrees, sanity-checks each diff, and ships via ./tree2m. Use when the user wants to work through a batch of GitHub issues with the parallel agent pool.
 ---
 
 # Orchestrate — parallel multi-agent issue pool
 
-You are the **conductor**. You do NOT implement tasks. You triage, schedule, and ship.
-Workers (max 3 in flight): `claude` (Agent tool), `codex`, `agy` — all headless, all isolated in their own git worktree per task.
+You are the **conductor**. You do NOT implement tasks. You triage, schedule, sanity-check, and ship.
+Workers (max 3 in flight): `claude` (Agent tool), `codex`, `agy` — all headless, each isolated in its own git worktree per task. Workers implement and STOP; the conductor reviews and ships.
 
 Routing knowledge: `.claude/orchestrate-routing.md`. Read it once at start.
 
+## Token discipline (applies to the whole flow)
+
+Tokens are a budget — spend them where they change the outcome.
+- Stay thin: state lives in `state.json`, not your message history. Don't echo full diffs/issue bodies back into your context.
+- Cheapest capable model per step: triage = Haiku, sanity = Haiku, workers per routing table (escalate only on retry).
+- Feed sub-agents the minimum: a branch, a path, the self-contained `task`, expected `touched_areas` — not the whole repo or prior conversation.
+- Don't re-read files you just wrote; don't re-triage a task you already routed.
+
 ## State
 
-Keep state in a JSON file in the scratchpad: `state.json` with arrays `pool`, `inflight`, `done`, `failed`.
-Each task object: `{issue, branch, title, engine, model, difficulty, touched_areas, task, attempts}`.
-Keep YOUR OWN context thin — the state file is the source of truth, not your message history.
+`state.json` (scratchpad) with arrays `pool`, `inflight`, `done`, `failed`.
+Each task: `{issue, branch, title, engine, model, difficulty, touched_areas, task, worktree, attempts}`.
 
 ## Loop
 
-1. **Build pool.** `gh issue list --state open --json number,title,labels` (or the set the user named). One pool entry per issue (number only).
-2. **Triage (sequential, cheap).** For each pool issue, spawn the `triage` subagent (Haiku) with the issue number. Parse its JSON → fill the task object. Do this serially; it's cheap and keeps routing decisions clean.
+1. **Build pool.** `gh issue list --state open --json number,title,labels` (or the set the user named). One entry per issue (number only).
+2. **Triage (sequential, cheap).** Spawn the `triage` subagent (Haiku) per issue → parse JSON → fill the task object. Serial; cheap; keeps routing clean.
 3. **Schedule.** While `pool` not empty:
-   - While `len(inflight) < 3` AND a pool task exists whose `touched_areas` does NOT overlap any inflight task's `touched_areas`: launch it (below), move task pool→inflight.
-   - If no disjoint task is available but slots are free, wait for an inflight task to finish before launching an overlapping one (avoids guaranteed conflicts).
+   - While `len(inflight) < 3` AND a pool task whose `touched_areas` does NOT overlap any inflight task exists: launch it, move pool→inflight.
+   - If only overlapping tasks remain, wait for an inflight one to finish first (avoids guaranteed conflicts).
 4. **On worker completion** (you are re-invoked when a background task finishes):
-   - Worker already ran `./tree2m` itself. tree2m output tells you pass/fail (PR merged vs hook/CI error).
-   - Success → move task inflight→done.
-   - Failure → retry policy below.
-5. Repeat until `pool` and `inflight` are both empty. Report `done`/`failed` summary with PR links.
+   a. **Sanity check** — spawn `sanity-check` (Haiku) with the task's `worktree` + `touched_areas`. Cheap pre-merge gate for junk/scope-creep (NOT correctness — hooks own that).
+      - `fail` → don't ship. Treat as a failed attempt; retry policy below (feed the offending paths back so the next attempt avoids them).
+   b. **Ship** — on `pass`, run `scripts/agent-ship.sh <branch> "<msg>"`. It runs `./tree2m` (commit→push→hooks gate→CI→squash-merge) then removes the worktree.
+      - success → inflight→done. failure (hooks/CI) → retry policy.
+5. Repeat until `pool` and `inflight` empty. Report `done`/`failed` with PR links.
 
 ## Launching a worker
 
-- **engine `claude`**: `Agent` tool, `subagent_type: "scala-coder"`, `model: <model>`, `run_in_background: true`, `isolation: "worktree"`. Prompt = the task object's `task` plus its `branch` and the instruction to ship via `./tree2m <branch> "<msg>"`.
-- **engine `codex` / `agy`**: write the `task` text to a scratchpad file, then `Bash` `run_in_background: true`:
-  `scripts/agent-run.sh <engine> <branch> "<model>" <task-file>`
-  The script makes the worktree, runs the engine, and ships via tree2m. Exit 0 = merged.
+All engines work in a dedicated worktree off fresh `origin/master` and leave it **uncommitted** for the sanity gate.
 
-Both paths notify you on completion — do not poll in a sleep loop.
+- **engine `claude`**: create the worktree first —
+  `git worktree add -b <branch> .claude/worktrees/<branch> origin/master` (record path in `state.json` `worktree`).
+  Then `Agent` tool, `subagent_type: "scala-coder"`, `model: <model>`, `run_in_background: true`. Prompt = the `task`, the worktree path, and "work only in that path; do not commit/push/tree2m; stop and report changed files."
+- **engine `codex` / `agy`**: write `task` to a scratchpad file, then `Bash` `run_in_background: true`:
+  `scripts/agent-run.sh <engine> <branch> "<model>" <task-file>`
+  The script makes the worktree, runs the engine, leaves it dirty, and prints the worktree path (record it).
+
+Both notify you on completion — do not poll in a sleep loop.
 
 ## Retry policy (cost-aware)
 
-- `attempts` starts 0. On failure, if `attempts < 2`: **escalate** — bump to the next stronger model (and/or switch engine `codex/agy → claude`), set the task back to `pool`, `attempts++`.
-- On 2nd failure → `failed[]` with the captured error. Do not loop forever.
+- `attempts` starts 0. On failure (sanity OR hooks/CI), if `attempts < 2`: **escalate** — stronger model (and/or `codex/agy → claude`), set task back to `pool`, `attempts++`. For sanity failures, include the offending paths in the retry task so the worker doesn't repeat them. Remove the stale worktree before retrying.
+- 2nd failure → `failed[]` with the captured reason. Don't loop forever.
 - Never escalate a *passing* task; never start a mechanical task on `opus`.
 
 ## Conflicts
-Overlapping `touched_areas` are serialized, not blocked. Two merged PRs may still conflict at `master` (independent developers). That's expected — if a later tree2m fails because its branch went stale, treat it as a normal failure → retry (re-worktrees off fresh `origin/master`).
+Overlapping `touched_areas` are serialized, not blocked. Two merged PRs may still conflict at `master` (independent developers) — expected. If a later ship fails because its branch went stale, treat as normal failure → retry off fresh `origin/master`.
 
 ## Guardrails
-- The gate is the precommit/prepush hooks invoked by tree2m. Do not bypass them.
+- Gates: (1) cheap `sanity-check` for junk/scope before merge, (2) precommit/prepush hooks via tree2m for correctness. Do not bypass either.
 - If `gh`, `codex`, or `agy` is missing, report it and run with the engines that exist.
 - Keep ≤3 in flight. More worktrees = more conflicts and cost with little speedup.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -12,8 +12,9 @@ Routing knowledge: `.claude/orchestrate-routing.md`. Read it once at start.
 
 ## Token discipline (applies to the whole flow)
 
-Tokens are a budget — spend them where they change the outcome.
-- Stay thin: state lives in `state.json`, not your message history. Don't echo full diffs/issue bodies back into your context.
+ Tokens are a budget — spend them where they change the outcome. You (the conductor) run on an expensive model; your context is the costliest tokens in the system. Protect it.
+- **Delegate down whenever it's safe.** Any sub-step that is mechanical or low-judgment — parsing an issue, summarizing a diff, generating a branch slug or commit message, wrangling JSON, classifying difficulty — should be handed to a cheap helper agent (Haiku), not done inline in your context. Spend your own reasoning only on scheduling, routing decisions, and handling failures. If a cheaper model would do it without harming the result, use the cheaper model.
+- Stay thin: state lives in `state.json`, not your message history. Don't echo full diffs/issue bodies back into your context — let a Haiku helper read them and return only the verdict/summary you need.
 - Cheapest capable model per step: triage = Haiku, sanity = Haiku, workers per routing table (escalate only on retry).
 - Feed sub-agents the minimum: a branch, a path, the self-contained `task`, expected `touched_areas` — not the whole repo or prior conversation.
 - Don't re-read files you just wrote; don't re-triage a task you already routed.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -19,6 +19,18 @@ Routing knowledge: `.claude/orchestrate-routing.md`. Read it once at start.
 - Feed sub-agents the minimum: a branch, a path, the self-contained `task`, expected `touched_areas` — not the whole repo or prior conversation.
 - Don't re-read files you just wrote; don't re-triage a task you already routed.
 
+## Reusable scripts — one call per phase
+
+Every recurring git chain in this flow is a script. Call the script; never re-issue the steps one-by-one as separate Bash calls (each round-trip costs tokens). If you find yourself repeating a new multi-step chain across tasks, add a script for it under `scripts/` (mirror `tree2m`: `rtk`, quiet output) instead of paying the round-trips again.
+
+| Phase | Script (one call) |
+|-------|-------------------|
+| new isolated workspace | `scripts/worktree-new.sh <branch>` → prints worktree path |
+| run codex/agy worker | `scripts/agent-run.sh <engine> <branch> "<model>" <task-file>` |
+| sanity signal for the gate | `scripts/worktree-diff.sh <wt>` |
+| ship after sanity pass | `scripts/agent-ship.sh <branch> "<msg>"` (tree2m + cleanup) |
+| scoped commit+push (no merge) | `scripts/commit-push.sh <branch> "<msg>" <paths…>` |
+
 ## State
 
 `state.json` (scratchpad) with arrays `pool`, `inflight`, `done`, `failed`.
@@ -42,8 +54,7 @@ Each task: `{issue, branch, title, engine, model, difficulty, touched_areas, tas
 
 All engines work in a dedicated worktree off fresh `origin/master` and leave it **uncommitted** for the sanity gate.
 
-- **engine `claude`**: create the worktree first —
-  `git worktree add -b <branch> .claude/worktrees/<branch> origin/master` (record path in `state.json` `worktree`).
+- **engine `claude`**: create the worktree with `scripts/worktree-new.sh <branch>` (prints the path; record in `state.json` `worktree`).
   Then `Agent` tool, `subagent_type: "scala-coder"`, `model: <model>`, `run_in_background: true`. Prompt = the `task`, the worktree path, and "work only in that path; do not commit/push/tree2m; stop and report changed files."
 - **engine `codex` / `agy`**: write `task` to a scratchpad file, then `Bash` `run_in_background: true`:
   `scripts/agent-run.sh <engine> <branch> "<model>" <task-file>`

--- a/scripts/agent-run.sh
+++ b/scripts/agent-run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Run one external worker engine (codex|agy) on one task inside a fresh git worktree,
+# then ship via ./tree2m. Used by the /orchestrate conductor for non-Claude engines.
+# (The "claude" engine is driven directly by the conductor via the Agent tool, not this script.)
+#
+# Usage:
+#   scripts/agent-run.sh <engine> <branch> <model> <task-file>
+#     engine     codex | agy
+#     branch     git-safe branch name (also the worktree dir name)
+#     model      engine-specific model string ("" = engine default)
+#     task-file  path to a file containing the self-contained task description
+#
+# Exit 0 = shipped (PR merged by tree2m). Non-zero = failed (hooks/CI/engine error); not merged.
+
+set -euo pipefail
+
+engine="${1:?engine required: codex|agy}"
+branch="${2:?branch required}"
+model="${3-}"
+task_file="${4:?task-file required}"
+
+[[ -f "$task_file" ]] || { echo "task-file not found: $task_file" >&2; exit 1; }
+task="$(cat "$task_file")"
+
+repo_root="$(git rev-parse --show-toplevel)"
+base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+[[ -n "$base" ]] || base="master"
+wt="${repo_root}/.claude/worktrees/${branch}"
+
+cleanup() { git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Fresh worktree off the latest base.
+git -C "$repo_root" fetch origin "$base" --quiet || true
+git -C "$repo_root" worktree add -b "$branch" "$wt" "origin/${base}"
+
+prompt="You are one developer working in this checkout: ${wt}
+Implement ONLY this task, scoped and matching existing style:
+
+${task}
+
+When done, build/test as the project expects. Do NOT commit or push — the orchestrator ships it."
+
+case "$engine" in
+  codex)
+    ( cd "$wt" && codex exec ${model:+--model "$model"} --dangerously-bypass-approvals-and-sandbox "$prompt" )
+    ;;
+  agy)
+    agy --print --add-dir "$wt" ${model:+--model "$model"} --dangerously-skip-permissions "$prompt"
+    ;;
+  *)
+    echo "unknown engine: $engine" >&2; exit 2 ;;
+esac
+
+# Ship from inside the worktree: hooks gate, push, CI, squash-merge.
+( cd "$wt" && ./tree2m "$branch" "${branch}: automated implementation" )

--- a/scripts/agent-run.sh
+++ b/scripts/agent-run.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Run one external worker engine (codex|agy) on one task inside a fresh git worktree,
-# then ship via ./tree2m. Used by the /orchestrate conductor for non-Claude engines.
+# Run one external worker engine (codex|agy) on one task inside a fresh git worktree.
+# Does NOT commit, push, or merge — the conductor runs a sanity check on the worktree diff
+# first, then ships via scripts/agent-ship.sh. Used by /orchestrate for non-Claude engines.
 # (The "claude" engine is driven directly by the conductor via the Agent tool, not this script.)
 #
 # Usage:
@@ -11,7 +12,8 @@
 #     model      engine-specific model string ("" = engine default)
 #     task-file  path to a file containing the self-contained task description
 #
-# Exit 0 = shipped (PR merged by tree2m). Non-zero = failed (hooks/CI/engine error); not merged.
+# On success, prints the worktree path on the last line and leaves it in place (uncommitted
+# changes). Exit 0 = engine ran; non-zero = setup/engine error.
 
 set -euo pipefail
 
@@ -28,9 +30,6 @@ base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | 
 [[ -n "$base" ]] || base="master"
 wt="${repo_root}/.claude/worktrees/${branch}"
 
-cleanup() { git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null || true; }
-trap cleanup EXIT
-
 # Fresh worktree off the latest base.
 git -C "$repo_root" fetch origin "$base" --quiet || true
 git -C "$repo_root" worktree add -b "$branch" "$wt" "origin/${base}"
@@ -40,7 +39,9 @@ Implement ONLY this task, scoped and matching existing style:
 
 ${task}
 
-When done, build/test as the project expects. Do NOT commit or push — the orchestrator ships it."
+Touch only files this task requires. Do NOT add scratch files, build artifacts, notes,
+or unrelated edits. When done, build/test as the project expects. Do NOT commit or push —
+the orchestrator reviews and ships it."
 
 case "$engine" in
   codex)
@@ -53,5 +54,5 @@ case "$engine" in
     echo "unknown engine: $engine" >&2; exit 2 ;;
 esac
 
-# Ship from inside the worktree: hooks gate, push, CI, squash-merge.
-( cd "$wt" && ./tree2m "$branch" "${branch}: automated implementation" )
+# Leave the worktree dirty for the conductor's sanity check + ship step.
+echo "$wt"

--- a/scripts/agent-run.sh
+++ b/scripts/agent-run.sh
@@ -25,14 +25,10 @@ task_file="${4:?task-file required}"
 [[ -f "$task_file" ]] || { echo "task-file not found: $task_file" >&2; exit 1; }
 task="$(cat "$task_file")"
 
-repo_root="$(git rev-parse --show-toplevel)"
-base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
-[[ -n "$base" ]] || base="master"
-wt="${repo_root}/.claude/worktrees/${branch}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-# Fresh worktree off the latest base.
-git -C "$repo_root" fetch origin "$base" --quiet || true
-git -C "$repo_root" worktree add -b "$branch" "$wt" "origin/${base}"
+# Fresh worktree off the latest base (shared with the claude engine via the same script).
+wt="$("$script_dir/worktree-new.sh" "$branch")"
 
 prompt="You are one developer working in this checkout: ${wt}
 Implement ONLY this task, scoped and matching existing style:

--- a/scripts/agent-ship.sh
+++ b/scripts/agent-ship.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Ship a worker's worktree AFTER the conductor's sanity check passed.
+# Runs ./tree2m (commit -> push -> hooks gate -> CI -> squash-merge), then removes the worktree.
+#
+# Usage:
+#   scripts/agent-ship.sh <branch> [commit-message]
+#
+# Exit 0 = merged. Non-zero = hooks/CI/push failed; NOT merged (worktree left for inspection).
+
+set -euo pipefail
+
+branch="${1:?branch required}"
+message="${2:-${branch}: automated implementation}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+wt="${repo_root}/.claude/worktrees/${branch}"
+[[ -d "$wt" ]] || { echo "worktree not found: $wt" >&2; exit 1; }
+
+if ( cd "$wt" && ./tree2m "$branch" "$message" ); then
+  git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null || true
+else
+  echo "ship failed for $branch; worktree kept at $wt for inspection" >&2
+  exit 1
+fi

--- a/scripts/commit-push.sh
+++ b/scripts/commit-push.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Stage an EXPLICIT set of paths (never `add -A`), commit, push the current/target branch,
+# and print the resulting PR file list if a PR exists. For iterating on a feature branch
+# without sweeping unrelated working-tree changes and without auto-merging (unlike tree2m).
+#
+# Usage:
+#   scripts/commit-push.sh <branch> "<commit message>" <path> [<path> ...]
+#
+# Uses rtk to keep output (and token cost) small. Exits nonzero on hook/push failure.
+
+set -euo pipefail
+
+branch="${1:?branch required}"
+message="${2:?commit message required}"
+shift 2
+[[ $# -gt 0 ]] || { echo "at least one path required" >&2; exit 1; }
+paths=("$@")
+
+command -v rtk >/dev/null 2>&1 || { echo "Missing required command: rtk" >&2; exit 1; }
+remote="origin"
+
+# Switch to / create the branch without disturbing unrelated changes.
+current="$(rtk git branch --show-current)"
+if [[ "$current" != "$branch" ]]; then
+  if rtk git show-ref --verify --quiet "refs/heads/${branch}"; then
+    rtk git switch "$branch"
+  else
+    rtk git switch -c "$branch"
+  fi
+fi
+
+rtk git add -- "${paths[@]}"
+if rtk git diff --cached --quiet; then
+  echo "nothing staged for: ${paths[*]}" >&2
+  exit 0
+fi
+
+rtk git commit -m "$message" >/dev/null
+rtk git push -u "$remote" "$branch"
+
+# Show what the PR now contains (best-effort; quiet if no PR yet).
+if pr_files="$(rtk gh pr view "$branch" --json files --jq '.files[].path' 2>/dev/null)"; then
+  echo "PR files:"
+  echo "$pr_files"
+fi

--- a/scripts/worktree-diff.sh
+++ b/scripts/worktree-diff.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Emit the compact junk/scope signal for a finished worker's worktree, in ONE call, so the
+# sanity-check gate spends minimal tokens. Shows changed/untracked files (porcelain), the
+# per-file change stat vs origin/master, and flags any unusually large added files.
+#
+# Usage: scripts/worktree-diff.sh <worktree-path>
+
+set -euo pipefail
+
+wt="${1:?worktree path required}"
+[[ -d "$wt" ]] || { echo "worktree not found: $wt" >&2; exit 1; }
+
+echo "## status (porcelain: ?? = untracked/new)"
+git -C "$wt" status --porcelain
+
+echo "## diff --stat vs origin/master"
+git -C "$wt" diff --stat origin/master || true
+
+echo "## large additions (>200 KB, possible artifacts)"
+git -C "$wt" status --porcelain | awk '{print $2}' | while read -r f; do
+  [[ -f "$wt/$f" ]] || continue
+  sz=$(wc -c <"$wt/$f")
+  (( sz > 204800 )) && printf '%8d B  %s\n' "$sz" "$f"
+done

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Create a fresh git worktree for a task branch off the latest origin/master and print its path.
+# One call for the "new isolated workspace" phase — used by the conductor (claude engine) and by
+# scripts/agent-run.sh (codex/agy engines), so worktree creation is identical everywhere.
+#
+# Usage: scripts/worktree-new.sh <branch>   # prints the worktree path on stdout
+
+set -euo pipefail
+
+branch="${1:?branch required}"
+repo_root="$(git rev-parse --show-toplevel)"
+base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+[[ -n "$base" ]] || base="master"
+wt="${repo_root}/.claude/worktrees/${branch}"
+
+git -C "$repo_root" fetch origin "$base" --quiet || true
+git -C "$repo_root" worktree add -b "$branch" "$wt" "origin/${base}"
+echo "$wt"


### PR DESCRIPTION
## What

Adds a multi-agent workflow that works through GitHub issues with a parallel worker pool.

A **conductor** (`/orchestrate` skill) triages each open issue to the cheapest capable engine, runs up to **3 workers in parallel** in isolated git worktrees, and ships each via `./tree2m` (precommit/prepush hooks = quality gate, then push → CI → squash-merge).

### Worker engines (all headless)
- `claude` — Agent tool, `scala-coder` subagent with scala-semantic MCP (Scala-heavy tasks)
- `codex` — `codex exec` (general/mechanical coding)
- `agy` — `agy --print` (Gemini/Claude/GPT-OSS; large-context, docs)

### Files
- `.claude/skills/orchestrate/SKILL.md` — conductor loop, scheduling, cost-aware retry
- `.claude/agents/triage.md` — cheap Haiku router → JSON routing decision
- `.claude/agents/scala-coder.md` — Claude worker contract (work in worktree → tree2m)
- `.claude/orchestrate-routing.md` — static engine/model routing table
- `scripts/agent-run.sh` — codex|agy worker: fresh worktree → run engine → ship

### Design notes
- Gate = existing precommit/prepush hooks invoked by `tree2m`; no separate gate.
- Parallelism capped at 3; file-overlapping tasks (`touched_areas`) are serialized.
- Conflicts treated as normal multi-dev conflicts → retry off fresh `origin/master`.
- Failed task → escalate model once, then mark failed (bounded retry).

Agents/skill load at Claude Code startup, so `/orchestrate` and the `triage` subagent go live in a new session after merge.