### PR TITLE
chore: improve stryker4s workflow (#77)

### DIFF
--- a/scripts/mutation-summary.sh
+++ b/scripts/mutation-summary.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copy the Stryker4s JSON report to a committed, stable path.
+# Copy the Stryker4s JSON report to a committed, stable path and print alert categories.
 #
 # Stryker emits the machine-readable report (mutation-testing-elements schema) at
 #   analysis/target/stryker4s-report/<timestamp>/report.json   (the `json` reporter)
@@ -9,10 +9,25 @@
 # Usage:
 #   scripts/mutation-summary.sh [path/to/report.json]
 # With no arg, the newest report under analysis/target/stryker4s-report is used.
+#
+# Alerts are intentionally stricter than Stryker's built-in threshold reporting:
+#   - mutation score below MUTATION_SCORE_ALERT_THRESHOLD, or report thresholds.high when unset
+#   - surviving mutants with a mutator in MUTATION_ALERT_MUTATORS
 set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: missing required command: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd jq
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+
+alert_mutators="${MUTATION_ALERT_MUTATORS:-ConditionalExpression,EqualityOperator,LogicalOperator}"
 
 report="${1:-}"
 if [[ -z "$report" ]]; then
@@ -25,5 +40,99 @@ if [[ -z "$report" || ! -f "$report" ]]; then
   exit 1
 fi
 
-cp "$report" mutation-report.json
+report_abs="$(cd "$(dirname "$report")" && pwd)/$(basename "$report")"
+dest_abs="$repo_root/mutation-report.json"
+if [[ "$report_abs" != "$dest_abs" ]]; then
+  cp "$report" mutation-report.json
+fi
 echo "wrote mutation-report.json from $report"
+
+score_line="$(jq -r '
+  [.files[]?.mutants[]?] as $mutants
+  | ($mutants | map(select(.status == "Killed" or .status == "Timeout")) | length) as $detected
+  | ($mutants | map(select(.status == "Killed" or .status == "Timeout" or .status == "Survived" or .status == "NoCoverage")) | length) as $scored
+  | (if $scored == 0 then 100 else ((10000 * $detected / $scored) | round / 100) end) as $score
+  | [$score, $detected, $scored] | @tsv
+' mutation-report.json)"
+IFS=$'\t' read -r mutation_score detected_count scored_count <<<"$score_line"
+
+score_threshold="${MUTATION_SCORE_ALERT_THRESHOLD:-}"
+if [[ -z "$score_threshold" ]]; then
+  score_threshold="$(jq -r '.thresholds.high // .thresholds.low // 80' mutation-report.json)"
+fi
+
+echo "mutation score: ${mutation_score}% (${detected_count}/${scored_count} detected, alert threshold ${score_threshold}%)"
+
+status_counts="$(jq -r '
+  [.files[]?.mutants[]?]
+  | group_by(.status)
+  | map({status: .[0].status, count: length})
+  | sort_by(.status)
+  | .[]
+  | "  \(.status): \(.count)"
+' mutation-report.json)"
+if [[ -n "$status_counts" ]]; then
+  echo "mutants by status:"
+  echo "$status_counts"
+fi
+
+survivor_counts="$(jq -r '
+  [.files[]?.mutants[]? | select(.status == "Survived")]
+  | group_by(.mutatorName)
+  | map({mutator: .[0].mutatorName, count: length})
+  | sort_by(-.count, .mutator)
+  | .[]
+  | "  \(.mutator): \(.count)"
+' mutation-report.json)"
+if [[ -n "$survivor_counts" ]]; then
+  echo "surviving mutants by type:"
+  echo "$survivor_counts"
+fi
+
+error_counts="$(jq -r '
+  [.files[]?.mutants[]? | select(.status == "CompileError" or .status == "RuntimeError")]
+  | group_by(.status)
+  | map({status: .[0].status, count: length})
+  | sort_by(.status)
+  | .[]
+  | "  \(.status): \(.count)"
+' mutation-report.json)"
+if [[ -n "$error_counts" ]]; then
+  echo "error mutants:"
+  echo "$error_counts"
+fi
+
+score_alert="$(awk -v score="$mutation_score" -v threshold="$score_threshold" 'BEGIN { print (score < threshold ? 1 : 0) }')"
+surviving_alerts="$(jq -r --arg mutators "$alert_mutators" '
+  ($mutators | split(",") | map(gsub("^ +| +$"; "")) | map(select(length > 0))) as $alertMutators
+  | [
+      .files
+      | to_entries[]
+      | .key as $file
+      | .value.mutants[]?
+      | select(.status == "Survived" and (.mutatorName as $mutator | $alertMutators | index($mutator)))
+      | {file: $file, id: .id, mutator: .mutatorName, line: .location.start.line}
+    ]
+  | group_by(.mutator)
+  | map({
+      mutator: .[0].mutator,
+      count: length,
+      examples: (.[0:3] | map("\(.file):\(.line) #\(.id)") | join(", "))
+    })
+  | sort_by(.mutator)
+  | .[]
+  | "  \(.mutator): \(.count) (\(.examples))"
+' mutation-report.json)"
+
+alert=0
+if [[ "$score_alert" == "1" ]]; then
+  echo "alert: mutation score ${mutation_score}% is below ${score_threshold}%" >&2
+  alert=1
+fi
+if [[ -n "$surviving_alerts" ]]; then
+  echo "alert: surviving mutants match MUTATION_ALERT_MUTATORS=$alert_mutators" >&2
+  echo "$surviving_alerts" >&2
+  alert=1
+fi
+
+exit "$alert"

--- a/scripts/run-stryker.sh
+++ b/scripts/run-stryker.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run stryker4s mutation testing.
+#
+# Default mode runs in an isolated, reusable git worktree so the current checkout's target/
+# directories stay untouched. Use --local to run in this checkout and keep all Stryker churn under
+# the normal local ./target directories.
+#
+# Usage:
+#   scripts/run-stryker.sh <name>       # .worktrees/stryker4s-<name>
+#   scripts/run-stryker.sh --local      # current checkout, ./target
+#
+# On success it copies the stryker JSON report back to mutation-report.json and applies the alert
+# rules in scripts/mutation-summary.sh. The full sbt log is kept beside the run.
+set -euo pipefail
+
+usage() {
+  sed -n '3,13p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+local_run=0
+name=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --local) local_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$name" ]]; then
+        echo "unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      name="$1"
+      shift
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ "$local_run" -eq 0 && -z "$name" ]]; then
+  echo "usage: scripts/run-stryker.sh <name>" >&2
+  echo "       scripts/run-stryker.sh --local" >&2
+  exit 2
+fi
+if [[ "$local_run" -eq 1 && -n "$name" ]]; then
+  echo "error: --local does not take a worktree name" >&2
+  exit 2
+fi
+
+GIT="git"
+command -v rtk >/dev/null 2>&1 && GIT="rtk git"
+
+run_dir="$repo_root"
+run_label="local checkout"
+if [[ "$local_run" -eq 0 ]]; then
+  wt=".worktrees/stryker4s-$name"
+  abs_wt="$repo_root/$wt"
+  head_sha="$(git rev-parse HEAD)"
+
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "warning: uncommitted changes in the main tree are NOT included (worktree runs at $head_sha)" >&2
+  fi
+
+  if git worktree list --porcelain | grep -qx "worktree $abs_wt"; then
+    echo "reusing worktree $wt (syncing to $head_sha)"
+    $GIT -C "$abs_wt" checkout --quiet --detach "$head_sha"
+  else
+    echo "creating worktree $wt at $head_sha"
+    $GIT worktree add --quiet --detach "$wt" "$head_sha"
+  fi
+
+  run_dir="$abs_wt"
+  run_label="$wt"
+fi
+
+log="$run_dir/stryker-run.log"
+if [[ "$local_run" -eq 1 ]]; then
+  mkdir -p "$repo_root/target"
+  log="$repo_root/target/stryker-run.log"
+fi
+
+echo "running stryker4s in $run_label (full log: $log) ..."
+set +e
+(cd "$run_dir" && STRYKER=1 sbt -Dstryker=true "analysis/stryker") >"$log" 2>&1
+status=$?
+set -e
+
+grep -iE "error|exception|failed|mutation score|no code coverage|detected as static|Written JSON report|elapsed time" \
+  "$log" | tail -40 || true
+
+if [[ $status -ne 0 ]]; then
+  echo "stryker failed (exit $status). Full log: $log" >&2
+  exit $status
+fi
+
+report="$(find "$run_dir/analysis/target/stryker4s-report" -name report.json -print0 2>/dev/null \
+  | xargs -0 ls -t 2>/dev/null | head -1 || true)"
+if [[ -z "$report" || ! -f "$report" ]]; then
+  echo "error: no report.json produced under $run_label/analysis/target/stryker4s-report" >&2
+  exit 1
+fi
+
+"$repo_root/scripts/mutation-summary.sh" "$report"
+if [[ "$local_run" -eq 1 ]]; then
+  echo "done. local Stryker output kept under analysis/target and target/stryker-run.log"
+else
+  echo "done. worktree kept at $wt (rerun reuses it; remove with: git worktree remove $wt)"
+fi

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -35,6 +35,8 @@ stryker4s {
 
   # html → browsable report (stryker4s-report/<ts>/index.html); json → machine-readable
   # mutation-report.json (mutation-testing-elements schema) for tooling / post-processing.
+  # scripts/mutation-summary.sh applies stricter local alerts after the JSON report is written:
+  # score below the configured high threshold, or surviving behavior-critical mutator types.
   reporters = ["html", "json"]
 
   thresholds {


### PR DESCRIPTION
Closes #77. Adds --local target-dir option to run-stryker.sh, mutation alert rules/categorization in mutation-summary.sh, stryker4s.conf tuning. Sanity-checked: scripts/ + conf only.