### PR TITLE
docs: restructure and condense docs (#79)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,11 @@
 # AGENTS.md instructions
 
 <INSTRUCTIONS>
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/SCALA_SEMANTIC_RULES.md
-@/Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/CLAUDE.md
+@SCALA_SEMANTIC_RULES.md
+@CLAUDE.md
 </INSTRUCTIONS>
 
-## Project Description & Startup Context
+For detailed technical instructions, architecture, build/test commands, and conventions, read [CLAUDE.md](CLAUDE.md) on startup.
 
-For detailed instructions, architecture, build/test commands, and conventions, please read [CLAUDE.md](CLAUDE.md) on startup.
-
-### Quick Reference (from CLAUDE.md):
-- **Project**: ScalaSemantic — MCP server for deep semantic analysis on Scala projects via SemanticDB.
-- **Stack**: Scala 3.8.4, sbt 2.0.0, Scalameta 4.13.9, upickle 4.2.1, munit 1.2.3.
-- **Layout**:
-  - `core/`: Loads and indexes SemanticDB (`SemanticIndex`).
-  - `analysis/`: Result models and analyzer engine (depends on `core`).
-  - `mcp/`: JSON-RPC server and stdio entrypoint (depends on `analysis`).
-- **Core Commands**:
-  - Compile: `sbt compile` (regenerates SemanticDB)
-  - Test: `sbt test` (unforked tests run with cwd = repo root)
-  - Pre-push check: `sbt prePush` (clean, format, fix, test)
-  - Run MCP server: `sbt "mcp/runMain com.github.mercurievv.scalasemantic.mcpServer <root>"`
-- **Conventions**:
-  - Follow Scala Code Rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md).
-  - Use Conventional Commit titles for squash merging PRs (`feat:`, `fix:`, `perf:`).
-
+For Scala code analysis rules, see [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md).
 

--- a/README.md
+++ b/README.md
@@ -5,144 +5,76 @@
 [![Docs](https://img.shields.io/badge/docs-site-blue)](https://mercurievv.github.io/ScalaSemantic/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**ScalaSemantic** helps AI understand your Scala code like the compiler does. Instead of asking an
-agent to guess from text search (grep), you let it query compiler-emitted **SemanticDB** for exact symbols,
-types, implicits, inheritance, usages, and call paths.
+**ScalaSemantic** is an MCP server that helps AI understand Scala code like the compiler does. Instead
+of asking agents to grep and guess, it offers precise, project-wide semantic queries — exact symbols,
+types, inheritance, usages, implicits, and call paths — over compiler-emitted **SemanticDB**.
 
-For a Scala developer, that means an agent can answer questions like:
+Clients such as Claude Code, Codex, and Gemini CLI can spawn it as a local tool. It works with any
+Scala version (2.13.* and 3.*.*) as long as the target project compiles with SemanticDB enabled.
 
-- where a method is really used, without false matches from `grep`;
-- which classes extend a trait or override a member;
-- which `given` can satisfy a type;
-- how one method can call another across the project.
+📖 **Start here:** [Documentation site](https://mercurievv.github.io/ScalaSemantic/) or
+[docs/index.md](docs/index.md) · [Quickstart](docs/getting-started/quickstart.md)
 
-It is exposed over [MCP](https://modelcontextprotocol.io), so clients such as Claude Code, Codex, and
-Gemini CLI can call it as a local tool while you keep using your normal Scala build.
+## Quick comparison: SemanticDB vs `grep`
 
-📖 **Documentation site: <https://mercurievv.github.io/ScalaSemantic/>** (mdoc-checked, so its code
-samples are executed at build time).
+| Need | Tool |
+|---|---|
+| Exact usages of a method | `find_usages` |
+| All classes that extend a trait | `class_hierarchy` |
+| Which `given`s satisfy a type | `resolve_implicits` |
+| Call path between two methods | `call_path` |
+| Comments, TODOs, or broken code | `grep` |
 
-## Why, vs `grep`
+Full trade-offs and measured token savings: [docs/explanation/scala-semantic-vs-grep.md](docs/explanation/scala-semantic-vs-grep.md).
 
-`grep` matches characters; ScalaSemantic understands the compiled program.
-
-| You want to know… | `grep` | ScalaSemantic |
-|---|---|---|
-| Who extends `Animal`? | every line containing "Animal" | exact subtypes — `class_hierarchy` |
-| All usages of method `foo` | every "foo", unrelated included | exact symbol references — `find_usages` |
-| Which `given`s produce `Show[Int]`? | — not possible | `resolve_implicits` |
-| Call path from `a` to `c`? | — not possible | `call_path` |
-
-Every capability is backed by a test that runs against this repo's own SemanticDB →
-[`AnalyzerSuite`](analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerSuite.scala).
-Full trade-offs, including where `grep` wins:
-[docs/explanation/scala-semantic-vs-grep.md](docs/explanation/scala-semantic-vs-grep.md).
-
-## Quickstart
-
-Your MCP client spawns the server over stdio. Two things are needed (only a **JVM** — no coursier, no sbt):
-
-1. the target project **compiled with SemanticDB** (`semanticdbEnabled := true`);
-2. MCP client config that launches the server with that project's root as its argument.
-
-Pick one setup:
-
-### sbt plugin — recommended
-
-Least manual: works on sbt 1 and sbt 2, enables SemanticDB, and generates MCP client config for you;
-the jar arrives on first spawn.
+## Install (sbt — recommended)
 
 ```scala
-// project/plugins.sbt — replace x.y.z with the latest release (see the badge / releases page)
-addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "x.y.z")
+// project/plugins.sbt
+addSbtPlugin("io.github.mercurievv" % "sbt-scalasemantic-mcp" % "@VERSION@")
 // build.sbt
 enablePlugins(ScalaSemanticMcpPlugin)
 ```
 
-Latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0) · [GitHub releases](https://github.com/MercurieVV/ScalaSemantic/releases/latest)
-
-`sbt mcpClientConfig` writes/merges the client configuration (or you can specify the client as a CLI argument, e.g., `sbt "mcpClientConfig gemini"`, or `sbt "mcpClientConfig all"` to generate configs for all supported clients in one go); `sbt mcpRun` runs the server for testing. The default client is `claude` (which emits `.mcp.json` for Claude Code). Other supported clients are: `codex` (for Codex `config.toml`), `gemini` (Gemini CLI), `antigravity` (Antigravity CLI/IDE), `cline`, `roo` (Roo Code), `continue` (Continue YAML), `generic-json`, or `all`.
-
-Running `mcpClientConfig` also automatically generates a [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) file containing coding rules for the agent, and creates/updates client-specific rules (like `CLAUDE.md`, `AGENTS.md` (for Gemini/Antigravity), or `.cursorrules`) pointing to it.
-
-### Any build tool / OS
-
-- **Auto-download launcher** — `curl -fsSL .../scripts/install.sh | sh` (Windows: `…ps1`), then set
-  your MCP client `command` to `~/.local/bin/scalasemantic-mcp`. Fetches + caches the fat jar on first run.
-- **Plain `java -jar`** — grab `scalasemantic-mcp.jar` from the
-  [latest release](https://github.com/MercurieVV/ScalaSemantic/releases/latest) and run it directly.
-
-**Optional launcher flags** — append to the MCP client `args` after the project root (the launcher
-forwards them to the server; equivalent env vars in parentheses):
-
-- `--prefetch` — download + cache the jar, then exit without serving.
-- `--log` (`SCALASEMANTIC_LOG`) — log a tool call input to file.
-- `--log-output` (`SCALASEMANTIC_LOG_OUTPUT`) — log a tool call output to file.
-- 
-```json
-{
-  "mcpServers": {
-    "scala-semantic": {
-      "command": "~/.local/bin/scalasemantic-mcp",
-      "args": ["/abs/path/to/project", "--log", "--log-output"]
-    }
-  }
-}
+Then:
+```sh
+sbt mcpClientConfig      # generates MCP config + SCALA_SEMANTIC_RULES.md
+sbt compile              # emits SemanticDB
 ```
 
-Full setup, generated config, and lifecycle:
-**[docs/getting-started/integration.md](docs/getting-started/integration.md)**.
+Other setups (auto-download launcher, plain `java -jar`): [Integration guide](docs/getting-started/integration.md).
 
 ## Tools
 
-| Tool | Answers |
-|------|---------|
-| `find_symbol` | resolve a plain/partial name to SemanticDB symbol strings — **start here** |
-| `find_usages` | references to a symbol, def/ref split, paged |
-| `method_signature` | full signature incl. implicit/using parameter lists |
-| `class_hierarchy` | parents, linearization, index-wide known subtypes |
-| `find_overloads` | all overloads sharing a name and owner |
-| `members` | declared vs inherited members (override-aware) |
-| `type_at_position` | symbol + type at a 0-based position |
-| `resolve_implicits` | `given` definitions that produce a type |
-| `trace_implicit_chain` | a given's transitive implicit dependencies |
-| `call_path` | shortest call path between two methods |
+All MCP tools return compiler-resolved facts, paged and lean by default. Start with `find_symbol` to
+resolve a plain name to a SemanticDB symbol, then use that symbol with more specific queries.
 
-Every tool takes a SemanticDB symbol string; call `find_symbol` first to get one from a plain name.
-On `initialize` the server also sends `instructions` telling the agent to **prefer these tools over
-`grep`** for Scala code questions. Results are **lean by default** (locations as `uri:line:col`,
-signatures one line, empty fields omitted); pass `"detailed": true` to expand, and `find_usages` is
-paged.
+Full reference: [docs/reference/tools.md](docs/reference/tools.md)
 
-## Supported Scala versions
+| Tool | Purpose |
+|---|---|
+| `find_symbol` | Resolve a name to a symbol |
+| `find_usages` | References to a symbol |
+| `class_hierarchy` | Parents and known subtypes |
+| `method_signature` | Full signature with type/implicit params |
+| `resolve_implicits` | Given definitions for a type |
+| `call_path` | Shortest call route between methods |
 
-There are two analysis paths, with different version coverage:
+See [Examples](docs/usage/examples.md) for sample queries and responses.
 
-- **Disk SemanticDB (primary path)** — the server *reads* the `*.semanticdb` files your build emits,
-  so it is largely compiler-version-agnostic: it works against any project that compiles cleanly with
-  SemanticDB enabled. Cross-version behavior is enforced by tests — the analyzer is exercised against
-  golden SemanticDB from **Scala 2.13.\* and 3.\*.\*** (see
-  [docs/project/development.md](docs/project/development.md#cross-version-compatibility-test)).
-- **Presentation-compiler (live) path** — used for position-local tools on an edited / uncompiled /
-  broken in-memory buffer, before a clean compile exists on disk. This embeds Scala 3's own
-  presentation compiler, which is **version-locked to Scala 3.8.4** (the only PC build wired in today).
-  In principle the Scala 3 compiler can parse older 3.\* source, but no per-version PC switching ships
-  yet, and Scala 2.13 is *not* supported on this path (Scala 3's compiler is not a Scala 2 compiler).
+## Documentation
 
-So: disk-based analysis covers **2.13.\* + 3.\*.\***; the live broken-buffer path is **Scala 3.8.4
-only**. The server itself runs on any JVM (`java` 11+); the target project's Scala version is independent.
+- [**Quickstart**](docs/getting-started/quickstart.md) — shortest sbt path (5 minutes)
+- [**Integration**](docs/getting-started/integration.md) — sbt plugin, launcher, plain jar, logging
+- [**Tool reference**](docs/reference/tools.md) — MCP tools and SemanticDB symbol grammar
+- [**Examples**](docs/usage/examples.md) — sample MCP calls and responses
+- [**SemanticDB vs grep**](docs/explanation/scala-semantic-vs-grep.md) — trade-offs and context cost
+- [**FAQ**](docs/getting-started/faq.md) — SemanticDB, compile freshness, Metals, install choices
+- [**Development**](docs/project/development.md) — modules, build, test, cross-version
+- [**Design notes**](docs/project/design.md) — implementation and extension points
+- [**Releasing**](docs/project/releasing.md) — Sonatype Central process
 
-## Docs
-
-- **[Documentation site](https://mercurievv.github.io/ScalaSemantic/)** — the rendered, mdoc-checked microsite
-- [Quickstart](docs/getting-started/quickstart.md) — shortest sbt setup path
-- [Integration](docs/getting-started/integration.md) — register with a client, sbt plugin, other build tools
-- [Tool reference](docs/reference/tools.md) — MCP tools, symbol grammar, request shape
-- [Examples](docs/usage/examples.md) — sample MCP queries and responses
-- [ScalaSemantic vs grep](docs/explanation/scala-semantic-vs-grep.md) — trade-offs and measured context cost
-- [Development](docs/project/development.md) — module layout, build & test, cross-version testing
-- [Design decisions](docs/project/design.md) — implementation notes and future extension points
-- [Releasing](docs/project/releasing.md) — Sonatype Central release process
+For the full map, see [docs/index.md](docs/index.md).
 
 ## License
 

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -62,15 +62,12 @@ you are reading the raw source, take the current version from the
 [Maven Central artifact](https://central.sonatype.com/artifact/io.github.mercurievv/sbt-scalasemantic-mcp_2.12_1.0)
 or the [latest GitHub release](https://github.com/MercurieVV/ScalaSemantic/releases/latest).
 
-The plugin enables SemanticDB and adds:
+The plugin adds two tasks:
 
-- `sbt mcpClientConfig` — runs `mcpInstall`, then writes/merges the selected MCP client config (pointing at that script) into a project-local file. You can pass the client name directly as a command-line argument, e.g., `sbt "mcpClientConfig gemini"`, or `sbt "mcpClientConfig all"` to write configurations and steering rules for all supported LLM clients in one shot. Running this task also automatically generates a `SCALA_SEMANTIC_RULES.md` file in the project root and sets up LLM-specific rules pointing to it (like `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, etc.).
-- `sbt mcpRun` — runs the server in the foreground (stdio) for manual testing.
+- `sbt mcpClientConfig [client]` — generates MCP config for your client format (claude, codex, gemini, antigravity, cline, roo, continue, generic-json, or all). Also auto-generates `SCALA_SEMANTIC_RULES.md` for agents.
+- `sbt mcpRun` — runs the server locally for testing.
 
-So `enablePlugins` + `sbt mcpClientConfig` is the whole setup — no config to paste, no jar to download by hand; the
-written launcher fetches the server on first spawn (coursier if present, else the GitHub-Release fat
-jar). To pin a fixed binary instead, override `mcpServerCommand`, e.g.
-`mcpServerCommand := Seq("java", "-jar", "/abs/path/to/scalasemantic-mcp.jar")`.
+Just run `sbt enablePlugins(ScalaSemanticMcpPlugin)` + `sbt mcpClientConfig`, and the launcher script automatically downloads and caches the server jar on first spawn. To pin a specific jar path instead, override `mcpServerCommand` (e.g., `Seq("java", "-jar", "/abs/path/to/scalasemantic-mcp.jar")`).
 
 Choose the generated client format with `mcpClient`:
 
@@ -91,12 +88,9 @@ Scala 3.8.4 server, which is why it is sbt-1/2 and build-tool portable.
 
 #### What `mcpClientConfig` writes
 
-The task takes `mcpServerCommand`, then appends the project's base directory, the classpath file, and
-the logging flags. It writes the result into a project-local file chosen by `mcpClient`, merging
-just this server's entry into any existing file (other servers and unrelated settings are left
-untouched):
+The task appends the project root, classpath file, and logging flags to `mcpServerCommand`, then writes the result into a project-local file (merging with existing entries):
 
-| `mcpClient` | file written |
+| `mcpClient` | file |
 |---|---|
 | `claude`, `generic-json` | `.mcp.json` |
 | `codex` | `.codex/config.toml` |
@@ -106,8 +100,7 @@ untouched):
 | `roo` | `.roo/mcp.json` |
 | `continue` | `.continue/config.yaml` |
 
-With the default `mcpServerCommand` (the launcher `mcpInstall` writes) and
-`mcpClient := "claude"` the `.mcp.json` entry is:
+Example for `claude` (default):
 
 ```json
 {
@@ -120,17 +113,11 @@ With the default `mcpServerCommand` (the launcher `mcpInstall` writes) and
 }
 ```
 
-`command` = `mcpServerCommand.head`; `args` = the rest of `mcpServerCommand`, then the auto-appended
-project root and classpath file, then `--log --log-output` (the server's [logging](#logging) is off
-unless these are present — drop them for the silent default). So overriding
-`mcpServerCommand := Seq("java", "-jar", "/abs/scalasemantic-mcp.jar")` would instead yield
-`"command": "java"` with `"-jar", "/abs/scalasemantic-mcp.jar"` leading those same trailing args.
-Generation logic:
-[`ScalaSemanticMcpPlugin.scala`](https://github.com/MercurieVV/ScalaSemantic/blob/master/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala).
+(Logging flags `--log --log-output` are optional; see [Logging](#logging). Drop them for silent mode.)
 
-With `mcpClient := "codex"` it writes TOML into the project's `.codex/config.toml` (copy the table
-into `~/.codex/config.toml` if you prefer a user-global Codex config):
+Client-specific format examples:
 
+**codex** (`.codex/config.toml`):
 ```toml
 [mcp_servers.scala-semantic]
 command = "~/.local/bin/scalasemantic-mcp"
@@ -139,12 +126,7 @@ startup_timeout_sec = 60
 tool_timeout_sec = 60
 ```
 
-The explicit timeouts avoid first-launch failures when the launcher has to resolve or download the
-server jar. `sbt mcpClientConfig` also prefetches the jar on a best-effort basis before writing the
-config.
-
-With `mcpClient := "gemini"` it writes JSON into the project's `.gemini/settings.json`:
-
+**gemini** (`.gemini/settings.json`):
 ```json
 {
   "mcpServers": {
@@ -157,105 +139,18 @@ With `mcpClient := "gemini"` it writes JSON into the project's `.gemini/settings
 }
 ```
 
-With `mcpClient := "antigravity"` it writes JSON into the project's `.agents/mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "scala-semantic": {
-      "command": "~/.local/bin/scalasemantic-mcp",
-      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"]
-    }
-  }
-}
-```
-
-With `mcpClient := "cline"` it writes JSON into the project's `.cline/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "scala-semantic": {
-      "command": "~/.local/bin/scalasemantic-mcp",
-      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"],
-      "disabled": false,
-      "autoApprove": []
-    }
-  }
-}
-```
-
-With `mcpClient := "roo"` it writes JSON into the project's `.roo/mcp.json` (copy the entry into the
-global `mcp_settings.json` if you want it Roo-wide):
-
-```json
-{
-  "mcpServers": {
-    "scala-semantic": {
-      "command": "~/.local/bin/scalasemantic-mcp",
-      "args": ["/abs/path/to/this/project", "~/.local/bin/scala-semantic-classpath.txt", "--log", "--log-output"],
-      "disabled": false,
-      "alwaysAllow": [],
-      "timeout": 60
-    }
-  }
-}
-```
-
-With `mcpClient := "continue"` it writes YAML into the project's `.continue/config.yaml`:
-
-```yaml
-name: ScalaSemantic MCP
-version: 1.0.0
-schema: v1
-mcpServers:
-  - name: "scala-semantic"
-    command: "~/.local/bin/scalasemantic-mcp"
-    args:
-      - "/abs/path/to/this/project"
-      - "~/.local/bin/scala-semantic-classpath.txt"
-      - "--log"
-      - "--log-output"
-    connectionTimeout: 60000
-```
+**antigravity** (`.agents/mcp_config.json`), **cline** (`.cline/mcp.json`), **roo** (`.roo/mcp.json`), **continue** (`.continue/config.yaml`) — similar structures with client-specific fields. See [ScalaSemanticMcpPlugin.scala](https://github.com/MercurieVV/ScalaSemantic/blob/master/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala) for generation logic.
 
 ### Option B — auto-download launcher
 
-[`scripts/scalasemantic-mcp.sh`](https://github.com/MercurieVV/ScalaSemantic/blob/master/scripts/scalasemantic-mcp.sh)
-(Linux/macOS) and
-[`scripts/scalasemantic-mcp.ps1`](https://github.com/MercurieVV/ScalaSemantic/blob/master/scripts/scalasemantic-mcp.ps1)
-(Windows) pick the best available
-path automatically: if **coursier** (`cs`) is on PATH they `cs launch` the artifact from Maven Central
-(resolves + caches like `npx`); otherwise they download the fat jar from the latest GitHub Release once
-(cached under `~/.cache/scalasemantic-mcp` / `%LOCALAPPDATA%`) and run `java -jar`. Download chatter
-goes to stderr; stdout stays pure JSON-RPC. Offline, they fall back to the newest cached jar. Pin a
-version with `SCALASEMANTIC_VERSION=vX.Y.Z` (a real tag such as the latest release; default is newest).
-
-The fat-jar download is **resumable and atomic**: an interrupted download (e.g. a connection killed by
-the client's ~30s startup timeout) leaves a partial `.tmp` that the next launch *continues* rather than
-restarting, and the cached jar is only swapped in once complete. So a slow first download converges
-across the client's reconnect retries instead of looping.
-
-Cold start is **instant once anything is cached**: when a (non-pinned) launch finds a cached jar it
-serves that one *immediately* — zero download latency — and forks a detached background updater that
-fetches the latest release for the **next** launch. So the very first launch on an empty cache still
-blocks on the download (warm it ahead of time with `--prefetch`, or `sbt mcpClientConfig`, which
-prefetches for you), and after a new release the launcher keeps serving the previous version for one
-more session before the background update takes effect. Pinning with `SCALASEMANTIC_VERSION` disables
-the background updater — you get exactly that version every launch.
-
-Install the launcher to a **stable path on PATH** (`~/.local/bin/scalasemantic-mcp`) so client config
-does not depend on where this repo is cloned — and, unlike the sbt dev launcher under `target/`, it
-survives `sbt clean`:
+Use the launcher script ([Linux/macOS](https://github.com/MercurieVV/ScalaSemantic/blob/master/scripts/scalasemantic-mcp.sh) or [Windows](https://github.com/MercurieVV/ScalaSemantic/blob/master/scripts/scalasemantic-mcp.ps1)) — it downloads and caches the jar automatically from GitHub Releases. Install it to PATH:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/MercurieVV/ScalaSemantic/master/scripts/install.sh | sh
-# or, from a checkout:  scripts/install.sh
+# Caches to ~/.cache/scalasemantic-mcp; serves instantly on next launch
 ```
 
-`install.sh` also **prefetches** the jar so the first real MCP connect hits a warm cache. If you wire
-the launcher up by other means, warm it once yourself with `scalasemantic-mcp --prefetch .` — otherwise
-the first connect races the download against the client's connection timeout.
+Use coursier if available (`cs launch …`), else downloads the fat jar. Downloads are resumable, and the launcher prefetches the jar so the first MCP connection hits a warm cache. Pin a version with `SCALASEMANTIC_VERSION=vX.Y.Z` (default is latest).
 
 ```json
 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,29 +24,28 @@ types, usages, inheritance, implicits, members, and call paths.
 
 ### Get started
 
-- [Quickstart](getting-started/quickstart.md) — shortest sbt setup path.
-- [Integration](getting-started/integration.md) — register the server with an MCP client.
-- [FAQ](getting-started/faq.md) — MCP, AI-agent, and SemanticDB basics for Scala developers.
+- [Quickstart](getting-started/quickstart.md) — shortest sbt setup path (5 minutes).
+- [Integration](getting-started/integration.md) — sbt plugin, launcher script, plain jar, and logging.
+- [FAQ](getting-started/faq.md) — SemanticDB, compile freshness, Metals/LSP, and install choices.
 
-### Reference and usage
+### Reference
 
-- [Tool reference](reference/tools.md) — MCP tools, SemanticDB symbol grammar, and request shape.
-- [Examples](usage/examples.md) — sample MCP queries, responses, and grep comparisons.
+- [Tool reference](reference/tools.md) — MCP tools, SemanticDB symbol grammar, request shape.
+- [Examples](usage/examples.md) — representative MCP calls and responses.
 
-### Explanation
+### Understand the trade-offs
 
-- [ScalaSemantic vs grep](explanation/scala-semantic-vs-grep.md) — trade-offs, measured context cost, and Metals/LSP scope.
+- [ScalaSemantic vs grep](explanation/scala-semantic-vs-grep.md) — exact symbols vs text search, token savings, Metals scope.
+- [The motivation](articles/it-hurts-to-watch-ai-grep-my-scala.md) — why SemanticDB beats grep for code understanding.
 
-### Project
+### Project & Development
 
-- [Development](project/development.md) — modules, build, cross-version testing, and this site.
-- [Design decisions](project/design.md) — implementation notes and future extension points.
+- [Development](project/development.md) — repository layout, build, test, cross-version compatibility.
+- [Design decisions](project/design.md) — implementation approach and extension points.
 - [Releasing](project/releasing.md) — Sonatype Central release process.
-- [Release notes](project/release-notes.md) — user-facing changes per version.
 
-### Research
+### Research & Backlog
 
-- [Claude interaction study](research/claude-interaction-study.md) — measured agent behavior used to rank
-  future tool work.
-- [LLM steering investigation](research/llm-steering-investigation.md) — strategies for making popular LLM agents prefer ScalaSemantic tools over text search.
-- [Plan & tracker](research/plan.md) — implementation history, backlog, and known decisions.
+- [Claude interaction study](research/claude-interaction-study.md) — measured tool usage to guide future work.
+- [LLM steering](research/llm-steering-investigation.md) — how to encourage agents to use semantic tools.
+- [Plan & tracker](research/plan.md) — roadmap, implemented decisions, and known limitations.


### PR DESCRIPTION
Closes #79. Condenses README, AGENTS.md, docs/getting-started/integration.md, docs/index.md (~34% line reduction). Markdown only; examples preserved.