### PR TITLE
chore: orchestration infra fixes (worktree-new, tree2m, agent-merge, check-push-workflow)

### DIFF
--- a/scripts/agent-merge.sh
+++ b/scripts/agent-merge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Resume shipping a branch that is ALREADY committed + pushed (e.g. after agent-ship.sh/tree2m
+# aborted at "nothing to commit" following a manual fixup). Waits for CI, squash-merges, removes
+# the worktree. Same final gate as tree2m but skips the commit/push phase.
+#
+# Usage: scripts/agent-merge.sh <branch>
+
+set -euo pipefail
+
+branch="${1:?branch required}"
+repo_root="$(git rev-parse --show-toplevel)"
+wt="${repo_root}/.claude/worktrees/${branch}"
+
+cd "$repo_root"
+# Remove worktree BEFORE merge so gh --delete-branch can drop the local branch
+# (git refuses to delete a branch still checked out in a worktree).
+git worktree remove --force "$wt" 2>/dev/null || true
+rtk scripts/check-push-workflow.sh --branch "$branch"
+rtk gh pr merge "$branch" --squash --delete-branch
+echo "MERGED $branch"

--- a/scripts/check-push-workflow.sh
+++ b/scripts/check-push-workflow.sh
@@ -35,6 +35,12 @@ require_cmd curl
 run_id="$(gh run list --repo "$repo" --workflow "$workflow_name" --branch "$branch_name" \
   --event push --limit 1 --json databaseId --jq '.[0].databaseId')"
 
+# Fall back to pull_request-triggered run if push run is absent or already failed
+if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+  run_id="$(gh run list --repo "$repo" --workflow "$workflow_name" --branch "$branch_name" \
+    --event pull_request --limit 1 --json databaseId --jq '.[0].databaseId')"
+fi
+
 if [[ -z "$run_id" || "$run_id" == "null" ]]; then
   echo "No push-triggered run of '$workflow_name' on '$branch_name'." >&2
   exit 1

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -15,5 +15,5 @@ base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | 
 wt="${repo_root}/.claude/worktrees/${branch}"
 
 git -C "$repo_root" fetch origin "$base" --quiet || true
-git -C "$repo_root" worktree add -b "$branch" "$wt" "origin/${base}"
+git -C "$repo_root" worktree add -b "$branch" "$wt" "origin/${base}" >&2
 echo "$wt"

--- a/tree2m
+++ b/tree2m
@@ -97,7 +97,7 @@ else
 fi
 
 rtk git add -A
-rtk git commit -m "$message"
+rtk git commit -m "$message" || echo "nothing new to commit; resuming with existing branch state"
 rtk git push -u "$remote" "$branch"
 
 existing_pr_url="$(rtk gh pr view "$branch" --json url --jq '.url' 2>/dev/null || true)"


### PR DESCRIPTION
Fixes discovered during parallel agent orchestration session:
- scripts/worktree-new.sh: redirect git worktree add stdout to stderr (was polluting captured path)
- tree2m: tolerate 'nothing to commit' to allow resume on already-pushed branch
- scripts/agent-merge.sh: new script — merge an already-pushed branch (CI-wait + squash-merge + cleanup)
- scripts/check-push-workflow.sh: fall back to pull_request-triggered CI run when push run is absent