### PR TITLE
docs: restore Quick Reference in AGENTS.md (#87)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,25 @@
 @CLAUDE.md
 </INSTRUCTIONS>
 
-For detailed technical instructions, architecture, build/test commands, and conventions, read [CLAUDE.md](CLAUDE.md) on startup.
+## Quick Start
 
-For Scala code analysis rules, see [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md).
+**Project**: ScalaSemantic — MCP server for deep semantic analysis on Scala projects via SemanticDB.
+
+**Stack**: Scala 3.8.4, sbt 2.0.0, Scalameta 4.13.9, upickle 4.2.1, munit 1.2.3.
+
+**Module Layout**:
+- `core/`: Loads and indexes SemanticDB (`SemanticIndex`).
+- `analysis/`: Result models and analyzer engine (depends on `core`).
+- `mcp/`: JSON-RPC server and stdio entrypoint (depends on `analysis`).
+
+**Core Commands**:
+- Compile: `sbt compile` (regenerates SemanticDB)
+- Test: `sbt test` (unforked tests run with cwd = repo root)
+- Pre-push check: `sbt prePush` (clean, format, fix, test)
+- Run MCP server: `sbt "mcp/runMain com.github.mercurievv.scalasemantic.mcpServer <root>"`
+- Worktree PR flow: `./tree2m <branch> "<commit-message>"` (creates branch, commits, pushes, merges)
+
+**Conventions**: Follow [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for Scala code rules. Use Conventional Commit titles for PRs (`feat:`, `fix:`, `perf:`).
+
+For detailed technical instructions, architecture, and additional context, read [CLAUDE.md](CLAUDE.md).
 


### PR DESCRIPTION
Closes #87. Restores stack versions, module layout, core commands, and tree2m workflow to AGENTS.md that were removed in the docs condensation PR. These are genuinely needed by LLM agents that may not have CLAUDE.md in context.