### PR TITLE
refactor: analysis module readability cleanups (#73)

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -83,15 +83,15 @@ final class Analyzer(
   ): List[(SymbolStructure, DimensionMetrics)] =
     val keepModule = h.globMatcher(pathFilter.filter(_.nonEmpty))
     structureResult.symbols
-      .filter(s => keepModule(s.module))
-      .map(s => s -> selectedMetrics(s, dimension))
+      .filter(sym => keepModule(sym.module))
+      .map(sym => sym -> selectedMetrics(sym, dimension))
       .sortBy((_, metrics) => -rankStructureMetrics(metrics, sort))
       .take(limit.value)
 
   private lazy val structureResult: StructureResult = StructureMetrics(index).result()
 
   private lazy val structureBySymbol: Map[String, SymbolStructure] =
-    structureResult.symbols.iterator.map(s => s.symbol -> s).toMap
+    structureResult.symbols.iterator.map(sym => sym.symbol -> sym).toMap
 
   private def selectedMetrics(
       symbol: SymbolStructure,
@@ -132,8 +132,7 @@ final class Analyzer(
         .distinctBy(_._1)
       val definedSet = defs.map(_._1).toSet
       def parentOf(sym: String): Option[String] =
-        val o = index.owner(sym)
-        if definedSet.contains(o) then Some(o) else None
+        Some(index.owner(sym)).filter(definedSet.contains)
       def build(sym: String, line: Int): OutlineEntry =
         val kids = defs.filter((c, _) => parentOf(c).contains(sym)).sortBy(_._2)
         OutlineEntry(
@@ -599,14 +598,12 @@ final class Analyzer(
     def bfs(frontier: List[List[String]], seen: Set[String]): List[String] =
       frontier match
         case Nil => Nil
-        case path :: rest =>
-          path match
-            case node :: _ =>
-              if node == toSym then path.reverse
-              else
-                val nexts = adjacency.getOrElse(node, Nil).map(_._1).filterNot(seen.contains)
-                bfs(rest ::: nexts.map(_ :: path), seen ++ nexts)
-            case Nil => bfs(rest, seen)
+        case (path @ (node :: _)) :: rest =>
+          if node == toSym then path.reverse
+          else
+            val nexts = adjacency.getOrElse(node, Nil).map(_._1).filterNot(seen.contains)
+            bfs(rest ::: nexts.map(_ :: path), seen ++ nexts)
+        case _ :: rest => bfs(rest, seen) // unreachable: paths are always non-empty
     // bfs already yields List(fromSym) when fromSym == toSym (it matches on the first node), so no
     // special case is needed for the trivial path.
     val nodes = bfs(List(List(fromSym)), Set(fromSym))

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/DuplicationAnalyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/DuplicationAnalyzer.scala
@@ -49,14 +49,7 @@ object DuplicationAnalyzer:
     val candidateSubtrees = index.documents.iterator
       .filter(doc => keepUri(doc.uri))
       .flatMap { doc =>
-        val text =
-          if (doc.text.nonEmpty) doc.text
-          else {
-            val p = root.resolve(doc.uri)
-            if (Files.exists(p))
-              new String(Files.readAllBytes(p), java.nio.charset.StandardCharsets.UTF_8)
-            else ""
-          }
+        val text = readSourceText(doc.text, doc.uri, root)
         if (text.isEmpty) Iterator.empty
         else
           Try(dialects.Scala3(text).parse[Source].get).toOption match
@@ -78,7 +71,6 @@ object DuplicationAnalyzer:
     // 3. Filter groups with size > 1 (i.e. duplicates exist)
     val duplicateGroups = grouped.values.iterator
       .filter(_.size > 1)
-      .map(_.map { case (doc, tree, enclosing) => (doc, tree, enclosing) })
       .toList
 
     // 4. Filter out groups that are completely subsumed by another larger group
@@ -157,6 +149,17 @@ object DuplicationAnalyzer:
       current ++ t.children.flatMap(c => traverse(c, nextEnclosing))
 
     traverse(tree, None)
+
+  /** Read the source text for a document: use the embedded text when available, otherwise read from
+    * disk. Returns an empty string when the file does not exist.
+    */
+  private def readSourceText(docText: String, docUri: String, root: Path): String =
+    if docText.nonEmpty then docText
+    else
+      val p = root.resolve(docUri)
+      if Files.exists(p) then
+        new String(Files.readAllBytes(p), java.nio.charset.StandardCharsets.UTF_8)
+      else ""
 
   private def isDescendant(child: Tree, parent: Tree): Boolean =
     if (child eq parent) false

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
@@ -154,12 +154,9 @@ object InputTypes:
         start <- SourcePosition.from(startLine, startCharacter)
         end <- SourcePosition.from(endLine, endCharacter)
         range <-
-          if before(start, end) then Right(SourceRange(start, end))
+          if start.before(end) then Right(SourceRange(start, end))
           else Left("range end must be after range start")
       yield range
-
-    private def before(start: SourcePosition, end: SourcePosition): Boolean =
-      start.before(end)
 
   opaque type ScalaIdentifier = NonEmptyString
   object ScalaIdentifier:


### PR DESCRIPTION
Closes #73. Targeted readability improvements in the analysis module:
- DuplicationAnalyzer: removed dead identity-mapping no-op; extracted readSourceText helper
- Analyzer: flattened nested BFS match; simplified parentOf with filter; renamed shadow lambda params s→sym
- InputTypes: inlined one-shot private wrapper before()