### PR TITLE
fix: resolve scripted-sbt_2.13 resolution failure on sbt 2.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -459,11 +459,13 @@ lazy val sbtPlugin = (project in file("sbt-plugin"))
   .settings(
     name := "sbt-scalasemantic-mcp",
     Compile / unmanagedSources += (ThisBuild / baseDirectory).value / "project" / "ScalaSemanticConfigMerger.scala",
-    crossScalaVersions := Seq("2.12.21", scalaVersion.value),
+    // Hard-code both axes so sbt 2.0.1's SbtPlugin rewrite of scalaVersion (to 2.13.x) does not
+    // pollute the cross-build matrix and produce an unresolvable scripted-sbt_2.13:2.0.x request.
+    crossScalaVersions := Seq("2.12.21", "3.8.4"),
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
-        case "2.12" => "1.11.6"
-        case _      => "2.0.0"
+        case "2.12" | "2.13" => "1.11.6"
+        case _               => "2.0.1"
       }
     },
     // munit unit-tests the pure config-merge helpers (no sbt/scripted machinery needed). munit 1.2.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 2.0.0
+sbt.version = 2.0.1


### PR DESCRIPTION
## Summary

- Hardcode `crossScalaVersions := Seq("2.12.21", "3.8.4")` in sbtPlugin instead of using `scalaVersion.value`, which sbt 2.0.1's SbtPlugin now rewrites to 2.13.x in the plugin context, adding a spurious 2.13 cross-build axis
- Add `"2.13"` case in `pluginCrossBuild / sbtVersion` → `"1.11.6"` as a defensive guard (previously fell through to `case _ => "2.0.0"`, requesting the nonexistent `scripted-sbt_2.13:2.0.0`)
- Bump `build.properties` to `sbt.version=2.0.1` to match what `sbt/setup-sbt@v1` installs

## Root cause

`sbt/setup-sbt@v1` started installing sbt 2.0.1. In 2.0.1, `SbtPlugin` changes the project's `scalaVersion` to 2.13.x for the sbt-1.x plugin axis, so `crossScalaVersions := Seq("2.12.21", scalaVersion.value)` evaluated to `Seq("2.12.21", "2.13.18")`. The 2.13 axis hit `case _ => "2.0.0"` in the sbt-version matcher, causing sbt to request `scripted-sbt_2.13:2.0.0` — an artifact that does not exist on Maven Central.

## Test plan

- `sbt +sbtPlugin/compile` should now cross-build for Scala 2.12.21 (sbt 1.11.6) and Scala 3.8.4 (sbt 2.0.1) only