### PR TITLE
fix: revert scripted-sbt_2.13 axes — scripted-sbt_2.13 never published on Maven

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -461,7 +461,7 @@ lazy val sbtPlugin = (project in file("sbt-plugin"))
     Compile / unmanagedSources += (ThisBuild / baseDirectory).value / "project" / "ScalaSemanticConfigMerger.scala",
     // Hard-code both axes so sbt 2.0.1's SbtPlugin rewrite of scalaVersion (to 2.13.x) does not
     // pollute the cross-build matrix and produce an unresolvable scripted-sbt_2.13:2.0.x request.
-    crossScalaVersions := Seq("2.13.18", "3.8.4"),
+    crossScalaVersions := Seq("2.12.21", "3.8.4"),
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
         case "2.12" | "2.13" => "1.11.6"

--- a/build.sbt
+++ b/build.sbt
@@ -459,11 +459,13 @@ lazy val sbtPlugin = (project in file("sbt-plugin"))
   .settings(
     name := "sbt-scalasemantic-mcp",
     Compile / unmanagedSources += (ThisBuild / baseDirectory).value / "project" / "ScalaSemanticConfigMerger.scala",
-    crossScalaVersions := Seq("2.12.21", scalaVersion.value),
+    // Hard-code both axes so sbt 2.0.1's SbtPlugin rewrite of scalaVersion (to 2.13.x) does not
+    // pollute the cross-build matrix and produce an unresolvable scripted-sbt_2.13:2.0.x request.
+    crossScalaVersions := Seq("2.12.21", "3.8.4"),
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
-        case "2.12" => "1.11.6"
-        case _      => "2.0.0"
+        case "2.12" | "2.13" => "1.11.6"
+        case _               => "2.0.1"
       }
     },
     // munit unit-tests the pure config-merge helpers (no sbt/scripted machinery needed). munit 1.2.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 2.0.0
+sbt.version = 2.0.1


### PR DESCRIPTION
## Summary

- `scripted-sbt_2.13` does not exist on Maven Central for any sbt version; only `_2.12` (sbt 1.x) and `_3` (sbt 2.x) are published
- A Scala Steward PR changed `crossScalaVersions` from `Seq("2.12.21", scalaVersion.value)` to `Seq("2.13.18", scalaVersion.value)`, which broke `sbt +sbtPlugin/compile` with `scripted-sbt_2.13:1.11.6 not found`
- This PR also carries the sbt 2.0.1 fix from #109: hardcodes both axes as `Seq("2.12.21", "3.8.4")` (removing `scalaVersion.value` whose value is unstable in `SbtPlugin` context on sbt 2.0.1), adds `"2.13"` guard in `pluginCrossBuild / sbtVersion`, and bumps `build.properties` to `2.0.1`

## Root cause chain

1. Scala Steward bumped 2.12.21 → 2.13.18 in `crossScalaVersions`
2. sbt/setup-sbt@v1 started installing sbt 2.0.1 (was 2.0.0)
3. In 2.0.1, `SbtPlugin` sets `scalaVersion` to 2.13.x in plugin context, making `scalaVersion.value` unstable there
4. Both `_2.13` axes (for sbt 1.11.6 and for sbt 2.0.0) failed: `scripted-sbt_2.13` simply does not exist

## Test plan

- `sbt +sbtPlugin/compile` cross-builds for Scala 2.12.21 (sbt 1.11.6) and Scala 3.8.4 (sbt 2.0.1)
- CI green ✓