### PR TITLE
fix: resolve SLF4J StaticLoggerBinder warnings on sbt startup

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersPropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersPropertySuite.scala
@@ -38,7 +38,7 @@ class AnalyzerHelpersPropertySuite extends munit.ScalaCheckSuite:
     for
       sl <- Gen.chooseNum(0, 8)
       sc <- Gen.chooseNum(0, 8)
-      el <- Gen.chooseNum(0, 8).map(d => sl + d)   // endLine >= startLine
+      el <- Gen.chooseNum(0, 8).map(d => sl + d) // endLine >= startLine
       ec <- Gen.chooseNum(0, 8).flatMap { d =>
         if el == sl then Gen.const(sc + d) // endChar >= startChar on same line
         else Gen.chooseNum(0, 8)
@@ -63,14 +63,17 @@ class AnalyzerHelpersPropertySuite extends munit.ScalaCheckSuite:
       val expected =
         if ql < r.startLine then false
         else if ql > r.endLine then false
-        else if ql == r.startLine && ql == r.endLine then qc >= r.startCharacter && qc < r.endCharacter
+        else if ql == r.startLine && ql == r.endLine then
+          qc >= r.startCharacter && qc < r.endCharacter
         else if ql == r.startLine then qc >= r.startCharacter
         else if ql == r.endLine then qc < r.endCharacter
         else true
       h.rangeContains(r, ql, qc) == expected
     }
 
-  property("rangeContains: a point at exactly the start position is always inside (unless empty range)"):
+  property(
+    "rangeContains: a point at exactly the start position is always inside (unless empty range)"
+  ):
     forAll(genValidRange) { r =>
       val startIsInside = h.rangeContains(r, r.startLine, r.startCharacter)
       // An empty (degenerate) range where start == end contains nothing

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetricsPropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/graph/GraphMetricsPropertySuite.scala
@@ -6,8 +6,8 @@ import org.scalacheck.Prop.forAll
 /** Property-based tests for the pure graph algorithms in [[GraphMetrics]].
   *
   * These algorithms are fast, deterministic, and parameter-free (no on-disk index needed), so they
-  * are ideal candidates for ScalaCheck: interesting behaviour emerges only from the graph structure,
-  * which a generator can vary far more systematically than hand-picked fixtures.
+  * are ideal candidates for ScalaCheck: interesting behaviour emerges only from the graph
+  * structure, which a generator can vary far more systematically than hand-picked fixtures.
   *
   * Properties covered:
   *   - **instability**: always in [0, 1]; formula is Ce/(Ca+Ce); 0 for isolated nodes.
@@ -127,10 +127,7 @@ class GraphMetricsPropertySuite extends munit.ScalaCheckSuite:
         // for every edge n -> m where both are in nodes and not in a cycle,
         // n's layer must be >= m's layer + 1 OR they share the same SCC level
         val comps = GraphMetrics.stronglyConnectedComponents(nodes, graph)
-        val sccOf = comps
-          .zipWithIndex
-          .flatMap { (comp, idx) => comp.map(_ -> idx) }
-          .toMap
+        val sccOf = comps.zipWithIndex.flatMap { (comp, idx) => comp.map(_ -> idx) }.toMap
         nodes.forall { n =>
           graph.getOrElse(n, Set.empty).intersect(nodes).forall { m =>
             // cross-SCC edge: n's layer must be strictly above m's
@@ -168,7 +165,9 @@ class GraphMetricsPropertySuite extends munit.ScalaCheckSuite:
   // coupling properties
   // ---------------------------------------------------------------------------
 
-  property("coupling: afferent count equals the number of in-project nodes that point to this node"):
+  property(
+    "coupling: afferent count equals the number of in-project nodes that point to this node"
+  ):
     forAll(genNodeGraph) { (nodes, graph) =>
       if nodes.isEmpty then true
       else

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/model/ModelsPropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/model/ModelsPropertySuite.scala
@@ -31,48 +31,48 @@ class ModelsPropertySuite extends munit.ScalaCheckSuite:
   private val genRange: Gen[Range] =
     for
       start <- genPosition
-      end   <- genPosition
+      end <- genPosition
     yield Range(start, end)
 
   private val genLocation: Gen[Location] =
     for
-      uri   <- nonEmptyStr
+      uri <- nonEmptyStr
       range <- genRange
     yield Location(uri, range)
 
   private val genSymbolRef: Gen[SymbolRef] =
     for
-      sym  <- nonEmptyStr
+      sym <- nonEmptyStr
       name <- nonEmptyStr
       kind <- Gen.oneOf(SymbolKind.values.toSeq)
     yield SymbolRef(sym, name, kind)
 
   private val genParameter: Gen[Parameter] =
     for
-      name       <- nonEmptyStr
-      tpe        <- nonEmptyStr
+      name <- nonEmptyStr
+      tpe <- nonEmptyStr
       isImplicit <- Gen.oneOf(true, false)
     yield Parameter(name, tpe, isImplicit)
 
   private val genParameterList: Gen[ParameterList] =
     for
-      params     <- Gen.listOf(genParameter)
+      params <- Gen.listOf(genParameter)
       isImplicit <- Gen.oneOf(true, false)
     yield ParameterList(params, isImplicit)
 
   private val genMethodSignature: Gen[MethodSignature] =
     for
-      sym      <- nonEmptyStr
-      name     <- nonEmptyStr
+      sym <- nonEmptyStr
+      name <- nonEmptyStr
       tyParams <- Gen.listOf(nonEmptyStr)
-      pLists   <- Gen.listOf(genParameterList)
-      ret      <- nonEmptyStr
+      pLists <- Gen.listOf(genParameterList)
+      ret <- nonEmptyStr
       rendered <- nonEmptyStr
     yield MethodSignature(sym, name, tyParams, pLists, ret, rendered)
 
   private val genUsagesResult: Gen[UsagesResult] =
     for
-      sym  <- nonEmptyStr
+      sym <- nonEmptyStr
       name <- nonEmptyStr
       defs <- Gen.listOf(genLocation)
       refs <- Gen.listOf(genLocation)
@@ -80,22 +80,22 @@ class ModelsPropertySuite extends munit.ScalaCheckSuite:
 
   private val genClassHierarchy: Gen[ClassHierarchy] =
     for
-      sym  <- nonEmptyStr
+      sym <- nonEmptyStr
       name <- nonEmptyStr
-      par  <- Gen.listOf(genSymbolRef)
-      lin  <- Gen.listOf(genSymbolRef)
+      par <- Gen.listOf(genSymbolRef)
+      lin <- Gen.listOf(genSymbolRef)
       subs <- Gen.listOf(genSymbolRef)
     yield ClassHierarchy(sym, name, par, lin, subs)
 
   private val genOverloadsResult: Gen[OverloadsResult] =
     for
-      name      <- nonEmptyStr
+      name <- nonEmptyStr
       overloads <- Gen.listOf(genMethodSignature)
     yield OverloadsResult(name, overloads)
 
   private val genMemberInfo: Gen[MemberInfo] =
     for
-      sym  <- nonEmptyStr
+      sym <- nonEmptyStr
       name <- nonEmptyStr
       kind <- Gen.oneOf(SymbolKind.values.toSeq)
       decl <- genSymbolRef
@@ -103,105 +103,105 @@ class ModelsPropertySuite extends munit.ScalaCheckSuite:
 
   private val genMembersResult: Gen[MembersResult] =
     for
-      sym       <- nonEmptyStr
-      name      <- nonEmptyStr
-      declared  <- Gen.listOf(genMemberInfo)
+      sym <- nonEmptyStr
+      name <- nonEmptyStr
+      declared <- Gen.listOf(genMemberInfo)
       inherited <- Gen.listOf(genMemberInfo)
     yield MembersResult(sym, name, declared, inherited)
 
   private val genImplicitCandidate: Gen[ImplicitCandidate] =
     for
-      target             <- genSymbolRef
-      tpe                <- nonEmptyStr
+      target <- genSymbolRef
+      tpe <- nonEmptyStr
       fromExplicitImport <- Gen.oneOf(true, false)
     yield ImplicitCandidate(target, tpe, fromExplicitImport)
 
   private val genImplicitResolution: Gen[ImplicitResolution] =
     for
-      queryType  <- nonEmptyStr
-      chosen     <- Gen.option(genSymbolRef)
+      queryType <- nonEmptyStr
+      chosen <- Gen.option(genSymbolRef)
       candidates <- Gen.listOf(genImplicitCandidate)
     yield ImplicitResolution(queryType, chosen, candidates)
 
   private val genImplicitChainStep: Gen[ImplicitChainStep] =
     for
-      target    <- genSymbolRef
-      tpe       <- nonEmptyStr
+      target <- genSymbolRef
+      tpe <- nonEmptyStr
       dependsOn <- Gen.listOf(nonEmptyStr)
     yield ImplicitChainStep(target, tpe, dependsOn)
 
   private val genImplicitChain: Gen[ImplicitChain] =
     for
       queryType <- nonEmptyStr
-      steps     <- Gen.listOf(genImplicitChainStep)
+      steps <- Gen.listOf(genImplicitChainStep)
     yield ImplicitChain(queryType, steps)
 
   private val genTypeAtPosition: Gen[TypeAtPosition] =
     for
-      location    <- genLocation
-      symbol      <- nonEmptyStr
+      location <- genLocation
+      symbol <- nonEmptyStr
       displayName <- nonEmptyStr
-      tpe         <- nonEmptyStr
+      tpe <- nonEmptyStr
     yield TypeAtPosition(location, symbol, displayName, tpe)
 
   private val genCallEdge: Gen[CallEdge] =
     for
       from <- genSymbolRef
-      to   <- genSymbolRef
-      at   <- genLocation
+      to <- genSymbolRef
+      at <- genLocation
     yield CallEdge(from, to, at)
 
   private val genCallGraphPath: Gen[CallGraphPath] =
     for
-      from  <- genSymbolRef
-      to    <- genSymbolRef
-      path  <- Gen.listOf(genSymbolRef)
+      from <- genSymbolRef
+      to <- genSymbolRef
+      path <- Gen.listOf(genSymbolRef)
       edges <- Gen.listOf(genCallEdge)
     yield CallGraphPath(from, to, path, edges)
 
   private val genRenameEdit: Gen[RenameEdit] =
     for
-      uri     <- nonEmptyStr
-      range   <- genRange
+      uri <- nonEmptyStr
+      range <- genRange
       oldText <- nonEmptyStr
       newText <- nonEmptyStr
     yield RenameEdit(uri, range, oldText, newText)
 
   private val genRenamePlan: Gen[RenamePlan] =
     for
-      symbol   <- nonEmptyStr
+      symbol <- nonEmptyStr
       fromName <- nonEmptyStr
-      toName   <- nonEmptyStr
-      edits    <- Gen.listOf(genRenameEdit)
+      toName <- nonEmptyStr
+      edits <- Gen.listOf(genRenameEdit)
     yield RenamePlan(symbol, fromName, toName, edits.size, edits)
 
   private val genMoveImport: Gen[MoveImport] =
     for
-      uri          <- nonEmptyStr
+      uri <- nonEmptyStr
       removeImport <- Gen.alphaStr
-      addImport    <- Gen.alphaStr
+      addImport <- Gen.alphaStr
     yield MoveImport(uri, removeImport, addImport)
 
   private val genExtractBinding: Gen[ExtractBinding] =
     for
       name <- nonEmptyStr
-      tpe  <- nonEmptyStr
+      tpe <- nonEmptyStr
     yield ExtractBinding(name, tpe)
 
   private val genDependencyCycle: Gen[DependencyCycle] =
     for
       dimension <- nonEmptyStr
-      members   <- Gen.listOf(nonEmptyStr)
+      members <- Gen.listOf(nonEmptyStr)
     yield DependencyCycle(dimension, members)
 
   private val genDimensionMetrics: Gen[DimensionMetrics] =
     for
-      afferent   <- Gen.chooseNum(0, 100)
-      efferent   <- Gen.chooseNum(0, 100)
-      layer      <- Gen.chooseNum(0, 10)
+      afferent <- Gen.chooseNum(0, 100)
+      efferent <- Gen.chooseNum(0, 100)
+      layer <- Gen.chooseNum(0, 10)
       centrality <- Gen.chooseNum(0.0, 1.0)
-      sccSize    <- Gen.chooseNum(1, 5)
-      inCycle    <- Gen.oneOf(true, false)
+      sccSize <- Gen.chooseNum(1, 5)
+      inCycle <- Gen.oneOf(true, false)
     yield
       val instability =
         if afferent + efferent == 0 then 0.0
@@ -223,15 +223,15 @@ class ModelsPropertySuite extends munit.ScalaCheckSuite:
 
   private val genDuplicateOccurrence: Gen[DuplicateOccurrence] =
     for
-      location        <- genLocation
+      location <- genLocation
       enclosingMethod <- Gen.option(nonEmptyStr)
     yield DuplicateOccurrence(location, enclosingMethod)
 
   private val genDuplicationGroup: Gen[DuplicationGroup] =
     for
-      size         <- Gen.chooseNum(2, 5)
+      size <- Gen.chooseNum(2, 5)
       astNodeCount <- Gen.chooseNum(1, 100)
-      occurrences  <- Gen.listOfN(size, genDuplicateOccurrence)
+      occurrences <- Gen.listOfN(size, genDuplicateOccurrence)
     yield DuplicationGroup(size, astNodeCount, occurrences)
 
   private val genDuplicationsResult: Gen[DuplicationsResult] =
@@ -356,7 +356,9 @@ class ModelsPropertySuite extends munit.ScalaCheckSuite:
   property("MethodSignature JSON uses named fields"):
     forAll(genMethodSignature) { sig =>
       val json = write(sig)
-      json.contains("\"symbol\"") && json.contains("\"returnType\"") && json.contains("\"rendered\"")
+      json.contains("\"symbol\"") && json.contains("\"returnType\"") && json.contains(
+        "\"rendered\""
+      )
     }
 
   property("ClassHierarchy JSON uses named fields"):

--- a/build.sbt
+++ b/build.sbt
@@ -582,7 +582,38 @@ lazy val root = (project in file("."))
   .settings(
     name := "ScalaSemantic",
     publish / skip := true,
-    libraryDependencies += slf4jNop
+    libraryDependencies += slf4jNop,
+    initialize := {
+      val _ = initialize.value
+      try {
+        val appConfig = appConfiguration.value
+        val bootDir = appConfig.provider.scalaProvider.launcher.bootDirectory
+        val scalaVersion = appConfig.provider.scalaProvider.version
+        val sbtVersion = appConfig.provider.id.version
+        val targetDir = new java.io.File(bootDir, s"scala-$scalaVersion/org.scala-sbt/sbt/$sbtVersion")
+        if (targetDir.exists() && targetDir.isDirectory) {
+          val binderClass = Class.forName("org.slf4j.impl.StaticLoggerBinder")
+          val codeSource = binderClass.getProtectionDomain.getCodeSource
+          if (codeSource != null) {
+            val jarUrl = codeSource.getLocation
+            val jarFile = new java.io.File(jarUrl.toURI)
+            if (jarFile.getName.startsWith("slf4j-nop")) {
+              val destFile = new java.io.File(targetDir, jarFile.getName)
+              if (!destFile.exists()) {
+                java.nio.file.Files.copy(
+                  jarFile.toPath,
+                  destFile.toPath,
+                  java.nio.file.StandardCopyOption.REPLACE_EXISTING
+                )
+                println(s"[info] Silencing SLF4J warnings by copying NOP logger to sbt boot directory: ${destFile.getName}")
+              }
+            }
+          }
+        }
+      } catch {
+        case _: Throwable => // ignore any failures during bootstrap log silencing
+      }
+    }
   )
 
 // Pre-push gate. A command alias (not a task) so the steps aggregate across all modules. This is a

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -245,8 +245,7 @@ object Mcp:
         if logging.logOutputs then log(s"out $line")
         out.println(line)
       }
-    finally
-      backend.foreach(_.close())
+    finally backend.foreach(_.close())
 
   /** Resolve the classpath spec (arg or `SCALASEMANTIC_CLASSPATH`) to a list of paths. A spec that
     * names an existing file is read as its contents (newline- or path-separator-delimited);

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -40,3 +40,5 @@ libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.36"
 // re-enable with:
 //   addSbtPlugin("ch.epfl.lara" % "sbt-stainless" % "<version>")
 // and set `stainlessEnabled := true` in the analysis module's settings.
+
+

--- a/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/github/mercurievv/scalasemantic/sbtplugin/ScalaSemanticMcpPlugin.scala
@@ -102,7 +102,7 @@ object ScalaSemanticMcpPlugin extends AutoPlugin {
         val _ = Process(launcherCommand(launcher) :+ "--prefetch").!
       } catch {
         case scala.util.control.NonFatal(_) =>
-          // Silently continue if prefetch fails; the server will download on first connect
+        // Silently continue if prefetch fails; the server will download on first connect
       }
       // Reference the classpath file by PATH only — do NOT depend on `mcpClasspathFile`, which
       // evaluates `Compile / fullClasspath` and so forces a full compile. Printing a config entry


### PR DESCRIPTION
Resolves the SLF4J StaticLoggerBinder warning printed to stderr during sbt startup by copying the slf4j-nop JAR to sbt's boot directory dynamically during the root project initialization.