### PR TITLE
fix: use visible symlink for agy --add-dir to avoid hidden .worktrees path rejection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ build/
 
 # Local agent/worktree metadata.
 /.agents/mcp_config.json
+/worktrees/
 /.claude/worktrees/
 /.cline/
 /.continue/config.yaml

--- a/scripts/agent-run.sh
+++ b/scripts/agent-run.sh
@@ -76,7 +76,12 @@ case "$engine" in
     output=$(cd "$wt" && codex exec ${model:+--model "$model"} --dangerously-bypass-approvals-and-sandbox "$prompt" 2>&1) || engine_exit=$?
     ;;
   agy)
-    output=$(agy --print --add-dir "$wt" ${model:+--model "$model"} --dangerously-skip-permissions "$prompt" 2>&1) || engine_exit=$?
+    # agy --add-dir silently falls back when any path component starts with '.'.
+    # .worktrees/<branch> has a hidden component, so use a visible symlink instead.
+    agy_wt="${repo_root}/worktrees/${branch}"
+    ln -sfn "$wt" "$agy_wt"
+    output=$(agy --print --add-dir "$agy_wt" ${model:+--model "$model"} --dangerously-skip-permissions "$prompt" 2>&1) || engine_exit=$?
+    rm -f "$agy_wt"
     ;;
   *)
     echo "unknown engine: $engine" >&2; exit 2 ;;


### PR DESCRIPTION
Created by ./tree2m.