### PR TITLE
feat: resume interrupted agent flows

### DIFF
--- a/.claude/agents/scala-coder.md
+++ b/.claude/agents/scala-coder.md
@@ -4,21 +4,29 @@ description: Implements a single coding task end-to-end in an assigned git workt
 tools: Bash, Read, Edit, Write, Glob, Grep, mcp__scala-semantic__find_symbol, mcp__scala-semantic__find_usages, mcp__scala-semantic__class_hierarchy, mcp__scala-semantic__members, mcp__scala-semantic__method_signature, mcp__scala-semantic__document_outline, mcp__scala-semantic__annotated_source, mcp__scala-semantic__call_path, mcp__scala-semantic__resolve_implicits, mcp__scala-semantic__rename_plan, mcp__scala-semantic__move_plan, mcp__scala-semantic__extract_method_plan
 ---
 
-You implement ONE task end-to-end. You own everything from worktree to merged PR.
+You implement ONE task end-to-end. The conductor assigns your worktree; you own everything from
+that assigned worktree to merged PR.
 
 ## CRITICAL: Working directory = your worktree
 
-You will be given a `branch` name. Your worktree lives at `<repo-root>/.worktrees/<branch>`.
+You will be given a `branch` name and an assigned worktree path chosen by the conductor. Usually it
+is `<repo-root>/.worktrees/<branch>`, but on resume it may be an existing path from
+`.claude/state.json`.
 
 **`cd` to your worktree path at the very start and stay there for all file edits and build commands.**
 All git commands, builds, and file operations must run from this path. Never touch other worktrees or the main checkout.
 
-Verify with `pwd` after cd. If the worktree does not exist yet, create it first:
+Verify with `pwd` after cd. If the assigned worktree does not exist yet, create that exact assigned
+path from the assigned branch:
 ```bash
 # from repo root
-scripts/worktree-new.sh <branch>   # prints path
-cd <printed-path>
+git worktree add -b <branch> <assigned-worktree> origin/master
+cd <assigned-worktree>
 ```
+
+Do not choose a different worktree. If the assigned worktree already exists, assume this may be an
+interrupted run, not a fresh task. Do not delete or recreate it. Treat the task as resumable unless
+the task state or GitHub comments clearly say `halted`.
 
 ## Scala tooling rule
 
@@ -27,13 +35,30 @@ For ANY question about Scala symbols, types, references, hierarchies, implicits,
 ## Workflow
 
 1. **Setup** — create or verify worktree; `cd` into it. Confirm with `pwd`.
-?2. **Initialize SemanticDB** — run `sbt --error compile` from inside the worktree. This generates fresh SemanticDB so that scala-semantic MCP tools (`find_symbol`, `annotated_source`, `find_usages`, etc.) work against the actual code in this worktree. Do this BEFORE any MCP tool calls — tools return stale or empty results without it.
-3. **Understand** — locate code with `document_outline`, `find_symbol`, `find_usages`. Don't read whole files unless necessary.
-4. **Implement** — make the change. Match existing style. Touch only files the task requires. No scratch files, notes, build artifacts, or unrelated edits. If your changes affect types/symbols that other MCP calls depend on, re-run `sbt --error compile` after editing.
-5. **Local check** — run the project's local build/test command (see CLAUDE.md in the worktree). Fix obvious errors.
-6. **Self-sanity** — spawn the `sanity-check` agent (Haiku) with your worktree path and the task's `touched_areas`. If `fail`: remove the offending files/edits and repeat from step 5. Do NOT proceed past a sanity fail.
-7. **Ship** — from inside your worktree run `./tree2m --auto <branch> "<Conventional-Commit message>"`. This commits all changes, pushes, enters the merge queue, and waits for merge.
-8. **Report** — emit the result JSON below and stop.
+2. **Resume check** — before editing, decide whether this is an interrupted run:
+   - Inspect `.claude/state.json` in the main checkout for the matching `inflight[]` record:
+     `status`, `worktree`, `agent_workdir`, `last_stdout_line`, and `last_update`.
+   - Inspect `.claude/task-state.json` and the GitHub issue comments/task-tree marker for this task.
+   - Run `git status --short`, inspect existing diffs, and check recent commits/PR state.
+   - If the task was `started` or `in-progress` but not `halted`, infer the last proven completed
+     step and continue from the earliest unsafe/incomplete step. Preserve useful existing work and
+     remove only clear junk or out-of-scope edits.
+3. **Live status** — immediately update the orchestration pool state from inside the worktree:
+   ```bash
+   scripts/agent-status.sh <branch> \
+     --worktree "$PWD" \
+     --agent-workdir "$PWD" \
+     --last-stdout-line "entered worktree: $PWD"
+   ```
+   After long commands, update `--last-stdout-line` with the last meaningful stdout/stderr line so
+   `.claude/state.json` shows current progress for the matching `inflight[]` entry.
+4. **Initialize SemanticDB** — run `sbt --error compile` from inside the worktree if SemanticDB is absent/stale or the resume check cannot prove compile already completed after the latest edits. This initializes scala-semantic analysis tools for the worktree's code before MCP code analysis.
+5. **Understand** — locate code with `document_outline`, `find_symbol`, `find_usages`. Don't read whole files unless necessary.
+6. **Implement** — make the change. Match existing style. Touch only files the task requires. No scratch files, notes, build artifacts, or unrelated edits. If your changes affect types/symbols that other MCP calls depend on, re-run `sbt --error compile` after editing.
+7. **Local check** — run the project's local build/test command (see CLAUDE.md in the worktree). Fix obvious errors.
+8. **Self-sanity** — spawn the `sanity-check` agent (Haiku) with your worktree path and the task's `touched_areas`. If `fail`: remove the offending files/edits and repeat from step 7. Do NOT proceed past a sanity fail.
+9. **Ship** — from inside your worktree run `./tree2m --auto <branch> "<Conventional-Commit message>"`. This commits all changes, pushes, enters the merge queue, and waits for merge.
+10. **Report** — emit the result JSON below and stop.
 
 ## Merge conflict
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -41,6 +41,17 @@ Let user inspect and approve before executing. Only spend tree-building (Haiku) 
 ### Resume (partial failure)
 `/orchestrate --resume` — read `.claude/task-state.json`, continue from last halted/incomplete task, skip done tasks.
 
+### Resume (interruption)
+If a task is still `started` or `in-progress` and was not marked `halted`, treat a new launch for
+the same branch as an interrupted worker resume. Do not discard the worktree or start over. The
+replacement worker must inspect the existing worktree, state files, GitHub comments, git status,
+recent commits, and the last recorded live status line, then continue from the earliest step that is
+not proven complete.
+
+The conductor chooses the worktree for every child agent. Child agents do not pick or create an
+arbitrary worktree by themselves. If `.claude/state.json` has a non-halted `inflight[]` item with a
+usable `worktree`, assign the replacement worker to that exact path.
+
 ### Merge queue
 `./tree2m --auto` is used by all task agents. Requires "Allow auto-merge" enabled in repo branch protection (Settings → General → "Allow auto-merge"). Without it, remove `--auto` flag from task prompts.
 
@@ -137,6 +148,13 @@ Create `.claude/task-state.json` with meta, tree, tasks. Persist after each chan
 
 **While roots or orphans remain unstarted or in-progress**:
 - Spawn one worker agent per eligible root/orphan (up to 3 total workers)
+- If a root/orphan already has a non-halted `inflight[]` record and its previous worker is gone or
+  interrupted, relaunch the same branch in resume mode and assign the new worker to the recorded
+  `worktree`/`agent_workdir` instead of creating a fresh task.
+- Before launching any worker, choose its worktree path:
+  - Prefer the existing non-halted `inflight[].worktree` when resuming.
+  - Otherwise use `<repo-root>/.worktrees/<branch>`.
+  - Include the chosen path in the worker prompt and live status update.
 - Each worker agent:
   - Walks its subtree depth-first
   - Fetches task from issue comment/body
@@ -171,10 +189,19 @@ When all roots + orphans and all their descendants are `completed` or `halted`: 
 Tree task: #<root-issue>
 Subtree: <list of all child issues in this root's tree>
 Executor: <engine/model for this root>
+Assigned worktree: <absolute path chosen by conductor>
 
 Your job:
-1. Walk your subtree depth-first (see below for order)
-2. For each task:
+1. Detect resume state before doing task work:
+   a. Use the assigned worktree from the conductor. Do not choose a different worktree.
+   b. If this branch has an existing worktree or `.claude/state.json` `inflight[]` entry with status
+      `started`/`in-progress` and no halted/error marker, assume a prior run was interrupted.
+   c. Inspect the worktree, `git status --short`, recent commits, open PR/result comments, task-tree
+      marker status, `.claude/task-state.json`, and the last `last_stdout_line`/`last_update`.
+   d. Decide the last proven completed step and continue from the earliest unsafe/incomplete step.
+      Keep useful existing work; remove only clear junk or out-of-scope edits.
+2. Walk your subtree depth-first (see below for order)
+3. For each task:
    a. Fetch issue #N body & comments from GitHub
    b. Extract task description from issue body or "Task:" section in task-tree-marker comment
    c. Check "Depends on: #M" note in issue body
@@ -184,7 +211,7 @@ Your job:
    g. Update the issue's task-tree-marker status field to "in-progress" then "completed"
    h. If task has children, move to first unblocked child
    i. If no children, backtrack to sibling or parent's next unblocked sibling
-3. On error: post error comment, update status to "halted", STOP (do not process siblings/children)
+4. On error: post error comment, update status to "halted", STOP (do not process siblings/children)
 
 Subtree depth-first order:
 <traversal list, e.g.
@@ -233,14 +260,41 @@ Agent tool:
   prompt: <worker agent prompt above>
 ```
 
-The scala-coder agent creates its own worktree, implements each task depth-first, updates GitHub + state.json, and emits final summary.
+The conductor chooses or reuses the worktree path before launch and passes it to scala-coder.
+Scala-coder implements each task depth-first, updates GitHub + state.json, and emits final summary.
+It may create the exact assigned path only if the conductor assigned it and it does not exist; it
+must not pick another path.
+
+Live status for `.claude/state.json`: when launching a claude/scala-coder worker, include the branch
+name and tell it to update its matching `inflight[]` item with:
+
+```bash
+scripts/agent-status.sh <branch> \
+  --worktree "$PWD" \
+  --agent-workdir "$PWD" \
+  --last-stdout-line "<latest command or agent status>"
+```
+
+The first update must happen immediately after the worker creates or enters its worktree. During
+long commands, update `last_stdout_line` with the last meaningful stdout/stderr line so running
+flows show `worktree`, `agent_workdir`, `last_stdout_line`, and `last_update`.
+
+If the worktree already exists and the task was not halted, launch the scala-coder worker with an
+explicit resume instruction: it must inspect the existing worktree and GitHub/task state, infer the
+last completed step, and continue from that point.
 
 ### Engine `codex` or `agy`
 Write worker prompt to scratchpad file, then:
 ```bash
-scripts/agent-run.sh <engine> <branch> "<model>" <worker-prompt-file> '<subtree-issues-json>'
+scripts/agent-run.sh <engine> <branch> "<model>" <worker-prompt-file> '<subtree-issues-json>' '<assigned-worktree>'
 ```
 Run with `run_in_background: true`. Script handles full lifecycle, posts result comments, and notifies conductor on completion.
+It also updates `.claude/state.json` `inflight[]` entries with `worktree`, `agent_workdir`,
+`last_stdout_line`, and `last_update` while the worker runs.
+If the assigned worktree or branch already exists, `agent-run.sh` reuses it and injects an
+interruption-resume context into the worker prompt. If the conductor omits `<assigned-worktree>`,
+`agent-run.sh` falls back to any non-halted `inflight[].worktree`, then to
+`<repo-root>/.worktrees/<branch>`.
 
 Both engines notify conductor on completion — conductor does NOT poll.
 

--- a/scripts/agent-run.sh
+++ b/scripts/agent-run.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 
 # Run one external worker engine (codex|agy) on one task — FULL LIFECYCLE.
-# Creates the worktree, runs the engine (which self-sanity-checks and ships via tree2m),
+# Creates or resumes the worktree, runs the engine (which self-sanity-checks and ships via tree2m),
 # then reports the result as JSON.
 #
 # Used by /orchestrate for non-Claude engines. The "claude" engine (scala-coder agent)
 # is driven directly by the conductor via the Agent tool and also owns its full lifecycle.
 #
 # Usage:
-#   scripts/agent-run.sh <engine> <branch> <model> <task-file> [touched-areas-json]
+#   scripts/agent-run.sh <engine> <branch> <model> <task-file> [touched-areas-json] [assigned-worktree]
 #     engine              codex | agy
 #     branch              git-safe branch name (also the worktree dir name)
 #     model               engine-specific model string ("" = engine default)
 #     task-file           path to a file containing the self-contained task description
 #     touched-areas-json  JSON array string e.g. '["core/src","analysis/src"]' (optional)
+#     assigned-worktree   worktree path chosen by the conductor (optional)
 #
 # Prints JSON result on stdout:
 #   {"status":"success","branch":"...","pr_url":"...","details":"..."}
@@ -29,15 +30,59 @@ branch="${2:?branch required}"
 model="${3-}"
 task_file="${4:?task-file required}"
 touched_areas="${5:-[]}"
+assigned_worktree="${6:-}"
 
 [[ -f "$task_file" ]] || { echo "task-file not found: $task_file" >&2; exit 1; }
 task="$(cat "$task_file")"
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+state_root="$repo_root"
+case "$repo_root" in
+  */.worktrees/*)
+    state_root="${repo_root%%/.worktrees/*}"
+    ;;
+esac
 
-# ── 1. Create worktree ────────────────────────────────────────────────────────
-wt="$("$script_dir/worktree-new.sh" "$branch")"
+state_worktree="$(
+  python3 - "$state_root/.claude/state.json" "$branch" <<'PY' 2>/dev/null || true
+import json
+import sys
+
+state_path, branch = sys.argv[1], sys.argv[2]
+try:
+    with open(state_path, "r", encoding="utf-8") as fh:
+        state = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    sys.exit(0)
+
+for task in state.get("inflight", []):
+    if task.get("branch") == branch and task.get("status") != "halted":
+        worktree = task.get("worktree") or task.get("agent_workdir")
+        if worktree:
+            print(worktree)
+        break
+PY
+)"
+
+# ── 1. Create or resume worktree ──────────────────────────────────────────────
+wt="${assigned_worktree:-${state_worktree:-${repo_root}/.worktrees/${branch}}}"
+resume_mode=0
+if [[ -d "$wt/.git" || -f "$wt/.git" ]]; then
+  resume_mode=1
+elif git -C "$repo_root" show-ref --verify --quiet "refs/heads/${branch}"; then
+  git -C "$repo_root" worktree add "$wt" "$branch" >&2
+  resume_mode=1
+elif git -C "$repo_root" show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+  git -C "$repo_root" worktree add -b "$branch" "$wt" "origin/${branch}" >&2
+  resume_mode=1
+else
+  wt="$("$script_dir/worktree-new.sh" "$branch")"
+fi
+"$script_dir/agent-status.sh" "$branch" \
+  --worktree "$wt" \
+  --agent-workdir "$wt" \
+  --last-stdout-line "$([[ "$resume_mode" -eq 1 ]] && echo "resuming existing worktree: $wt" || echo "worktree created: $wt")" || true
 
 # Copy gitignored engine configs into the worktree (not tracked, so not present by default).
 [[ -f "$repo_root/.codex/config.toml" ]] && { mkdir -p "$wt/.codex"; cp "$repo_root/.codex/config.toml" "$wt/.codex/config.toml"; }
@@ -46,8 +91,36 @@ wt="$("$script_dir/worktree-new.sh" "$branch")"
 # ── 2. Run engine ─────────────────────────────────────────────────────────────
 # CRITICAL: engine workdir = worktree ($wt). All file ops, builds, git commands
 # must stay inside that path.
-prompt="You are one developer. Your working directory for this task is: ${wt}
+resume_context=""
+if [[ "$resume_mode" -eq 1 ]]; then
+  status_snapshot="$(git -C "$wt" status --short 2>/dev/null || true)"
+  commit_snapshot="$(git -C "$wt" log --oneline --decorate -5 2>/dev/null || true)"
+  resume_context="INTERRUPTION RESUME MODE:
+This branch/worktree already existed before this launch and the task was not marked halted.
+The conductor assigned this worktree to you: ${wt}
+Assume a previous agent run was interrupted. Do not restart blindly and do not choose a different worktree.
+
+Before editing:
+1. cd into ${wt} and inspect the current state.
+2. Read .claude/state.json in the main checkout if useful; the matching inflight item may include last_stdout_line, worktree, agent_workdir, and last_update.
+3. Run 'git status --short' and inspect existing diffs before making changes.
+4. Infer the last completed step from current files, git status, recent commits, and any PR/result comments.
+5. Continue from the earliest unsafe/incomplete step. Keep useful existing work, remove only clear junk, and do not overwrite prior progress without checking it.
+
+Current git status snapshot:
+${status_snapshot:-<clean>}
+
+Recent commits snapshot:
+${commit_snapshot:-<none>}
+"
+else
+  resume_context="Fresh task run. The conductor assigned this worktree to you: ${wt}."
+fi
+
+prompt="You are one developer. The orchestrator/conductor assigned this working directory for this task: ${wt}
 Work ONLY inside that directory. Do NOT touch other paths.
+
+${resume_context}
 
 Implement this task, scoped and matching existing style:
 
@@ -70,26 +143,57 @@ If tree2m fails because the PR is not mergeable (merge conflict), print exactly:
 MERGE_CONFLICT: <list conflicting files>
 Then stop. Do NOT attempt to resolve the conflict — the orchestrator handles it."
 
+run_and_capture() {
+  local output_file="$1"
+  shift
+
+  set +e
+  "$@" 2>&1 | while IFS= read -r line || [[ -n "$line" ]]; do
+    printf '%s\n' "$line" >> "$output_file"
+    "$script_dir/agent-status.sh" "$branch" --last-stdout-line "$line" || true
+  done
+  local status="${PIPESTATUS[0]}"
+  set -e
+  return "$status"
+}
+
+output_file="$(mktemp)"
+trap 'rm -f "$output_file"; [[ -n "${agy_wt:-}" ]] && rm -f "$agy_wt"' EXIT
+
 engine_exit=0
 case "$engine" in
   codex)
-    output=$(cd "$wt" && codex exec ${model:+--model "$model"} --dangerously-bypass-approvals-and-sandbox "$prompt" 2>&1) || engine_exit=$?
+    "$script_dir/agent-status.sh" "$branch" \
+      --agent-workdir "$wt" \
+      --last-stdout-line "starting codex worker in $wt" || true
+    codex_cmd=(codex exec)
+    [[ -z "$model" ]] || codex_cmd+=(--model "$model")
+    codex_cmd+=(--dangerously-bypass-approvals-and-sandbox "$prompt")
+    run_and_capture "$output_file" bash -c 'cd "$1" && shift && "$@"' bash "$wt" "${codex_cmd[@]}" || engine_exit=$?
     ;;
   agy)
     # agy --add-dir silently falls back when any path component starts with '.'.
     # .worktrees/<branch> has a hidden component, so use a visible symlink instead.
     agy_wt="${repo_root}/worktrees/${branch}"
     ln -sfn "$wt" "$agy_wt"
-    output=$(agy --print --add-dir "$agy_wt" ${model:+--model "$model"} --dangerously-skip-permissions "$prompt" 2>&1) || engine_exit=$?
-    rm -f "$agy_wt"
+    "$script_dir/agent-status.sh" "$branch" \
+      --agent-workdir "$agy_wt" \
+      --last-stdout-line "starting agy worker with add-dir $agy_wt" || true
+    agy_cmd=(agy --print --add-dir "$agy_wt")
+    [[ -z "$model" ]] || agy_cmd+=(--model "$model")
+    agy_cmd+=(--dangerously-skip-permissions "$prompt")
+    run_and_capture "$output_file" "${agy_cmd[@]}" || engine_exit=$?
     ;;
   *)
     echo "unknown engine: $engine" >&2; exit 2 ;;
 esac
 
+output="$(cat "$output_file")"
+
 # ── 3. Parse result ───────────────────────────────────────────────────────────
 if echo "$output" | grep -qi "^MERGE_CONFLICT\|not mergeable\|merge conflict"; then
   conflict_detail=$(echo "$output" | grep -i "MERGE_CONFLICT\|conflict" | head -3 | tr '\n' ' ' | sed 's/"/\\"/g')
+  "$script_dir/agent-status.sh" "$branch" --last-stdout-line "merge conflict: $conflict_detail" || true
   printf '{"status":"merge_conflict","branch":"%s","pr_url":"","details":"%s"}\n' \
     "$branch" "$conflict_detail"
   exit 0
@@ -97,6 +201,7 @@ fi
 
 if [[ $engine_exit -ne 0 ]]; then
   error_detail=$(echo "$output" | tail -5 | tr '\n' ' ' | sed 's/"/\\"/g')
+  "$script_dir/agent-status.sh" "$branch" --last-stdout-line "worker error: $error_detail" || true
   printf '{"status":"error","branch":"%s","pr_url":"","details":"%s"}\n' \
     "$branch" "$error_detail"
   exit 1
@@ -106,6 +211,7 @@ pr_url=$(echo "$output" | grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+'
 
 # Cleanup worktree on success (tree2m removes the branch; worktree may already be gone)
 git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null || true
+"$script_dir/agent-status.sh" "$branch" --last-stdout-line "worker completed successfully" || true
 
 printf '{"status":"success","branch":"%s","pr_url":"%s","details":"engine=%s model=%s"}\n' \
   "$branch" "${pr_url:-}" "$engine" "${model:-default}"

--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Update live worker status in .claude/state.json.
+#
+# Usage:
+#   scripts/agent-status.sh <branch> [--worker-id ID] [--worktree PATH] \
+#     [--agent-workdir PATH] [--last-stdout-line LINE]
+#
+# The update is best-effort: missing state files or missing inflight records are
+# not fatal, because workers should not fail just because the conductor state is
+# absent or stale.
+
+set -euo pipefail
+
+branch="${1:?branch required}"
+shift
+
+worker_id=""
+worktree=""
+agent_workdir=""
+last_stdout_line=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --worker-id)
+      worker_id="${2:?--worker-id requires a value}"
+      shift 2
+      ;;
+    --worktree)
+      worktree="${2:?--worktree requires a value}"
+      shift 2
+      ;;
+    --agent-workdir)
+      agent_workdir="${2:?--agent-workdir requires a value}"
+      shift 2
+      ;;
+    --last-stdout-line)
+      last_stdout_line="${2:?--last-stdout-line requires a value}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+state_root="$repo_root"
+case "$repo_root" in
+  */.worktrees/*)
+    state_root="${repo_root%%/.worktrees/*}"
+    ;;
+esac
+state_file="${state_root}/.claude/state.json"
+
+[[ -f "$state_file" ]] || exit 0
+
+lock_dir="${state_file}.lock.d"
+locked=0
+for _ in {1..50}; do
+  if mkdir "$lock_dir" 2>/dev/null; then
+    locked=1
+    break
+  fi
+  sleep 0.1
+done
+
+[[ "$locked" -eq 1 ]] || exit 0
+trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
+
+export AGENT_STATUS_BRANCH="$branch"
+export AGENT_STATUS_WORKER_ID="$worker_id"
+export AGENT_STATUS_WORKTREE="$worktree"
+export AGENT_STATUS_AGENT_WORKDIR="$agent_workdir"
+export AGENT_STATUS_LAST_STDOUT_LINE="$last_stdout_line"
+
+python3 - "$state_file" <<'PY'
+import datetime
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+state_path = pathlib.Path(sys.argv[1])
+branch = os.environ["AGENT_STATUS_BRANCH"]
+worker_id = os.environ["AGENT_STATUS_WORKER_ID"]
+worktree = os.environ["AGENT_STATUS_WORKTREE"]
+agent_workdir = os.environ["AGENT_STATUS_AGENT_WORKDIR"]
+last_stdout_line = os.environ["AGENT_STATUS_LAST_STDOUT_LINE"]
+now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+try:
+    with state_path.open("r", encoding="utf-8") as fh:
+        state = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    sys.exit(0)
+
+updated = False
+for task in state.get("inflight", []):
+    branch_matches = task.get("branch") == branch
+    worker_matches = bool(worker_id) and task.get("worker_id") == worker_id
+    if not branch_matches and not worker_matches:
+        continue
+
+    if worktree:
+        task["worktree"] = worktree
+    if agent_workdir:
+        task["agent_workdir"] = agent_workdir
+    if last_stdout_line:
+        task["last_stdout_line"] = last_stdout_line
+    task["last_update"] = now
+    updated = True
+
+if not updated:
+    sys.exit(0)
+
+state["timestamp"] = now
+tmp_fd, tmp_name = tempfile.mkstemp(prefix=state_path.name, suffix=".tmp", dir=state_path.parent)
+try:
+    with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+        json.dump(state, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp_name, state_path)
+except OSError:
+    try:
+        os.unlink(tmp_name)
+    except OSError:
+        pass
+    sys.exit(0)
+PY


### PR DESCRIPTION
## Summary
- add live status updates for running orchestration workers
- let interrupted codex/agy workers resume assigned worktrees
- document conductor-owned worktree assignment for Claude workers

## Validation
- bash -n scripts/agent-run.sh
- bash -n scripts/agent-status.sh