### PR TITLE
ci: roll out stryker4s mutation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,17 @@ jobs:
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Check formatting
-        run: sbt scalafmtCheckAll
+        run: sbt --batch scalafmtCheckAll
       - name: Regenerate cross-version compat golden SemanticDB
         # Recompiles compat-fixtures under every Scala in `compatScalaVersions` so CompatSuite runs
         # against THIS runner's freshly emitted *.semanticdb. (We don't byte-compare against the
         # committed golden: SemanticDB output isn't guaranteed identical across environments/compiler
         # patches. The committed copies exist for local `sbt test` without a cross-compile.)
-        run: sbt compatGoldenAll
+        run: sbt --batch compatGoldenAll
       - name: Compile sbt plugin for sbt 1 and sbt 2
-        run: sbt +sbtPlugin/compile
+        run: sbt --batch +sbtPlugin/compile
       - name: Test
-        run: sbt test
+        run: sbt --batch test
 
   verify:
     name: Stainless verification
@@ -75,7 +75,7 @@ jobs:
         # sbt task shells out to scripts/stainless-verify.sh; fails iff a VC is INVALID (the
         # nonlinear rangeSpan VC that the bundled solver can only mark `unknown` is tolerated).
         # Generous per-VC timeout here (prePush uses a tighter default for speed).
-        run: sbt stainlessVerify
+        run: sbt --batch stainlessVerify
         env:
           STAINLESS_TIMEOUT: '30'
 
@@ -107,7 +107,7 @@ jobs:
       - name: Generate release notes page from tags
         run: scripts/gen-release-notes.sh # writes docs/RELEASE_NOTES.md (gitignored, build-time only)
       - name: Render docs with mdoc
-        run: sbt docs/run # writes executed Markdown into website/docs
+        run: sbt --batch docs/run # writes executed Markdown into website/docs
       - name: Build Docusaurus site
         working-directory: website
         run: |
@@ -162,7 +162,7 @@ jobs:
       # ci-release still needs PGP_SECRET/PGP_PASSPHRASE in ITS env or it logs
       # "No access to secret variables, doing nothing" and skips publishing.
       - name: Publish (sign + upload via ci-release)
-        run: sbt ci-release
+        run: sbt --batch ci-release
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -190,7 +190,7 @@ jobs:
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Build fat jar
-        run: sbt "mcp/assembly"
+        run: sbt --batch "mcp/assembly"
       - name: Collect asset
         run: |
           jar=$(find . -name scalasemantic-mcp.jar | head -1)
@@ -209,4 +209,3 @@ jobs:
         with:
           files: release-assets/scalasemantic-mcp.jar
           body_path: release-notes.md
-

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,27 +1,40 @@
 name: Mutation Testing
 
 on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      modules:
+        description: 'Space-separated modules to mutate: analysis, core, mcp, or all'
+        required: false
+        default: 'analysis'
   pull_request:
-    branches: ['**']
-    paths:
-      - 'analysis/**'
-    paths-ignore:
-      - 'reports/mutation/**'
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: write
+  issues: write
 
 env:
   STRYKER4S_COMMIT: '2c0f5bd7'
+  STRYKER4S_PLUGIN_VERSION: '0.21.0+33-2c0f5bd7-SNAPSHOT'
+  STRYKER: '1'
+  MUTATION_HIGH_THRESHOLD: '80'
+  MUTATION_LOW_THRESHOLD: '60'
+  # Initial rollout grace period from docs/research/stryker4s-alert-strategy.md:
+  # Stryker exits non-zero for tooling errors, but not for advisory score drops yet.
+  MUTATION_BREAK_THRESHOLD: '0'
+  MUTATION_ALERTS_FAIL: '0'
 
 jobs:
   stryker:
-    name: Stryker4s (analysis)
+    name: Stryker4s
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - uses: actions/setup-java@v4
@@ -32,77 +45,115 @@ jobs:
 
       - uses: sbt/setup-sbt@v1
 
-      # sbt-stryker4s 0.21.0 has an ABI incompatibility with sbt 2.0.0 final; we use a snapshot
-      # built from master at commit 2c0f5bd7. Cache the published local ivy artifacts; on miss,
-      # clone and publishLocal. See project/plugins.sbt for context.
+      - name: Decide mutation scope
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_MODULES: ${{ github.event.inputs.modules }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABEL_RUN: ${{ contains(github.event.pull_request.labels.*.name, 'ci:run-mutation') }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          modules=""
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            modules="${DISPATCH_MODULES:-analysis}"
+            [[ "$modules" == "all" ]] && modules="core analysis mcp"
+          elif [[ "$EVENT_NAME" == "schedule" || "$LABEL_RUN" == "true" ]]; then
+            modules="analysis"
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            files="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')"
+            if grep -qE '^(stryker4s\.conf|scripts/(run-stryker|mutation-summary)\.sh|\.github/workflows/mutation\.yml)$' <<<"$files"; then
+              modules="analysis"
+            else
+              grep -q '^analysis/src/main/scala/' <<<"$files" && modules="$modules analysis"
+            fi
+          fi
+
+          modules="$(xargs <<<"$modules")"
+          echo "modules=$modules" >> "$GITHUB_OUTPUT"
+          if [[ -z "$modules" ]]; then
+            echo "No mutation-relevant module changes detected; skipping heavy Stryker4s run."
+          else
+            echo "Mutation modules: $modules"
+          fi
+
+      # sbt-stryker4s 0.21.0 has an ABI incompatibility with sbt 2.0.0 final; use the pinned
+      # snapshot built from master at commit 2c0f5bd7. See project/plugins.sbt for context.
       - name: Restore stryker4s local ivy cache
+        if: steps.scope.outputs.modules != ''
         id: stryker-cache
         uses: actions/cache@v4
         with:
           path: ~/.ivy2/local/io.stryker-mutator
           key: stryker4s-${{ env.STRYKER4S_COMMIT }}
 
-      - name: Build and publishLocal stryker4s (cache miss only)
-        if: steps.stryker-cache.outputs.cache-hit != 'true'
+      - name: Build and publishLocal stryker4s
+        if: steps.scope.outputs.modules != '' && steps.stryker-cache.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/stryker-mutator/stryker4s.git /tmp/stryker4s
           cd /tmp/stryker4s
-          git checkout ${{ env.STRYKER4S_COMMIT }}
+          git checkout "$STRYKER4S_COMMIT"
           sbt sbtPlugin3/publishLocal
 
-      - name: Compile (generates SemanticDB used by tests)
-        run: sbt compile
+      - name: Compile clean sources
+        if: steps.scope.outputs.modules != ''
+        run: sbt --batch compile
 
-      # Run stryker4s.  stryker4s.conf sets `thresholds.break = 60`, so this step exits non-zero
-      # when the mutation score drops below 60%.  We capture the exit code here (continue-on-error)
-      # so that subsequent steps can still collect and commit the JSON report for post-mortem
-      # inspection before we re-raise the failure.
-      #
-      # Note on target/ vs worktree:
-      #   CI always starts from a clean checkout with an empty target/, so running stryker directly
-      #   in the checkout is safe — there is no "stale build state" to corrupt.  The worktree mode
-      #   in scripts/run-stryker.sh is a LOCAL-development convenience: it isolates stryker's
-      #   compile+test churn from your current build cache so `sbt test` in the main tree keeps
-      #   working while a long mutation run proceeds in parallel in .worktrees/stryker4s-<name>.
-      - name: Run stryker4s on analysis module
-        id: stryker
-        continue-on-error: true
-        run: sbt "analysis/stryker"
+      - name: Run Stryker4s modules
+        if: steps.scope.outputs.modules != ''
         env:
-          STRYKER: 'true'
-
-      - name: Collect and evaluate report
-        # Run even when stryker fails (break threshold) so the report is always committed.
-        if: always()
+          MODULES: ${{ steps.scope.outputs.modules }}
         run: |
+          set -euo pipefail
           mkdir -p reports/mutation
-          report="$(find analysis/target/stryker4s-report -name report.json -print0 2>/dev/null \
-            | xargs -0 ls -t 2>/dev/null | head -1 || true)"
-          if [[ -z "$report" || ! -f "$report" ]]; then
-            echo "error: no report.json found under analysis/target/stryker4s-report/" >&2
-            exit 1
-          fi
-          cp "$report" reports/mutation/report.json
-          # Print score and per-mutator breakdown; also alerts on surviving behaviour-critical
-          # mutators (ConditionalExpression, EqualityOperator, LogicalOperator).
-          scripts/mutation-summary.sh reports/mutation/report.json || true
+          for module in $MODULES; do
+            mkdir -p "reports/mutation/$module"
+            MUTATION_MODULE="$module" \
+            MUTATION_REPORT_DEST="reports/mutation/$module/report.json" \
+              scripts/run-stryker.sh --local --module "$module" 2>&1 \
+              | tee "reports/mutation/$module/summary.txt"
+          done
 
-      - name: Commit mutation report
-        if: always()
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add reports/mutation/report.json
-          git diff --staged --quiet || git commit -m "chore: update mutation report [skip ci]"
-          git push
+      - name: Verify clean dogfood tests after mutation
+        if: steps.scope.outputs.modules != ''
+        run: sbt --batch test
 
-      # Re-raise the stryker failure AFTER the report has been committed so reviewers can inspect
-      # the score even for a failing run.  The break threshold (60 %) is configured in
-      # stryker4s.conf and is the single source of truth for the gate.
-      - name: Enforce mutation score gate
-        if: steps.stryker.outcome == 'failure'
+      - name: Build mutation PR comment
+        if: steps.scope.outputs.modules != '' && github.event_name == 'pull_request'
         run: |
-          echo "stryker4s exited non-zero — mutation score is below the break threshold (60 %)" \
-               "or stryker encountered an error.  Check the report at reports/mutation/report.json" \
-               "and the step log above for details." >&2
-          exit 1
+          set -euo pipefail
+          {
+            echo "### Stryker4s mutation summary"
+            echo
+            echo "Modules: ${{ steps.scope.outputs.modules }}"
+            echo
+            for summary in reports/mutation/*/summary.txt; do
+              module="$(basename "$(dirname "$summary")")"
+              echo "#### $module"
+              echo '```text'
+              grep -E 'mutation score:|mutants by status:|  (Killed|Survived|NoCoverage|Timeout|CompileError|Ignored):|surviving mutants by type:|  [A-Za-z]+:|alert:' "$summary" || true
+              echo '```'
+              echo
+            done
+            echo "HTML and JSON reports are attached to the workflow run as the stryker4s-report artifact."
+          } > reports/mutation/comment.md
+
+      - name: Upload mutation reports
+        if: steps.scope.outputs.modules != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: stryker4s-report
+          path: |
+            reports/mutation/**
+            */target/stryker4s-report/**
+          if-no-files-found: error
+
+      - name: Comment mutation summary on PR
+        if: steps.scope.outputs.modules != '' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr comment "$PR_NUMBER" --body-file reports/mutation/comment.md

--- a/docs/research/stryker4s-alert-strategy.md
+++ b/docs/research/stryker4s-alert-strategy.md
@@ -61,6 +61,23 @@ We recommend rolling out mutation testing in phases:
 2. **Phase 2: `core` module** ([core](file:///Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/core/)): Roll out once `analysis` is stable. Since `core` handles static SemanticDB parsing and has stable structure, its threshold can be set higher (e.g. `85%`).
 3. **Phase 3: `mcp` module** ([mcp](file:///Users/viktorskalinins/IdeaProjects/my/ScalaSemanticMCP/mcp/)): The stdio JSON-RPC loop contains infinite loops and blocking network channels that are difficult to mutate without triggering infinite loops or timeouts. We recommend excluding the stdio channel from mutations.
 
+### Implementation note from #133
+
+The initial CI rollout implements Phase 1 as the automatic path: nightly runs, label-gated PR runs,
+and analysis-source PR changes run the `analysis` module. The shared runner also accepts
+`--module core`, `--module mcp`, and `--module all`, and the workflow_dispatch input can request
+those modules manually. They remain manual/experimental until their Stryker-specific blockers are
+resolved:
+
+- The automatic `analysis` run currently excludes `DuplicationAnalyzer.scala` because the pinned
+  Stryker4s snapshot exits non-zero when a generated `java.nio.file.Files.exists` mutant compiles to
+  an invalid `Files.forall` call. The rest of `analysis/src/main/scala` remains in the Phase 1 run.
+- `core/stryker` currently fails its initial test run after Stryker removes compile-error mutants
+  around `java.nio.file.Files.exists` mutations.
+- `mcp/stryker` needs a larger heap and still has high runtime/heap pressure while pretty-printing
+  800+ mutants. The runner sets `SBT_OPTS=-Xmx4G` by default for mutation runs, but this module
+  should not be a required PR gate until a stable baseline is recorded.
+
 ---
 
 ## 5. Configuration Sketch

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,14 @@ libraryDependencies += "com.guardsquare" % "proguard-base" % "7.9.1"
 // enable it only when actually mutation-testing:
 //   sbt -Dstryker=true "analysis/stryker"      (config in stryker4s.conf)
 if (sys.props.get("stryker").contains("true") || sys.env.contains("STRYKER"))
-  Seq(addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.0.0+1-2c0f5bd7-SNAPSHOT"))
+  Seq(
+    addSbtPlugin(
+      "io.stryker-mutator" % "sbt-stryker4s" % sys.props
+        .get("stryker4s.version")
+        .orElse(sys.env.get("STRYKER4S_PLUGIN_VERSION"))
+        .getOrElse("0.21.0+33-2c0f5bd7-SNAPSHOT")
+    )
+  )
 else Seq.empty[Setting[?]]
 
 // SLF4J NOP binding to silence the StaticLoggerBinder warning during sbt initialization.
@@ -40,5 +47,4 @@ libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.36"
 // re-enable with:
 //   addSbtPlugin("ch.epfl.lara" % "sbt-stainless" % "<version>")
 // and set `stainlessEnabled := true` in the analysis module's settings.
-
 

--- a/scripts/mutation-summary.sh
+++ b/scripts/mutation-summary.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-# Copy the Stryker4s JSON report to a committed, stable path and print alert categories.
+# Copy the Stryker4s JSON report to a stable path and print alert categories.
 #
 # Stryker emits the machine-readable report (mutation-testing-elements schema) at
-#   analysis/target/stryker4s-report/<timestamp>/report.json   (the `json` reporter)
-# which lives under the gitignored target/ dir. Copy it verbatim to the repo root so the
-# stryker4s json output is committed and tracked:
-#   mutation-report.json
+#   <module>/target/stryker4s-report/<timestamp>/report.json   (the `json` reporter)
+# which lives under the gitignored target/ dir. Copy it verbatim to MUTATION_REPORT_DEST, or to the
+# historical repo-root mutation-report.json when that variable is unset.
 # Usage:
 #   scripts/mutation-summary.sh [path/to/report.json]
-# With no arg, the newest report under analysis/target/stryker4s-report is used.
+# With no arg, the newest report under any module's target/stryker4s-report is used.
 #
 # Alerts are intentionally stricter than Stryker's built-in threshold reporting:
 #   - mutation score below MUTATION_SCORE_ALERT_THRESHOLD, or report thresholds.high when unset
@@ -29,23 +28,29 @@ cd "$repo_root"
 
 alert_mutators="${MUTATION_ALERT_MUTATORS:-ConditionalExpression,EqualityOperator,LogicalOperator}"
 
+module_label="${MUTATION_MODULE:-mutation}"
 report="${1:-}"
 if [[ -z "$report" ]]; then
-  report="$(find analysis/target/stryker4s-report -name report.json -print0 2>/dev/null \
+  report="$(find . -path '*/target/stryker4s-report/*/report.json' -print0 2>/dev/null \
     | xargs -0 ls -t 2>/dev/null | head -1 || true)"
 fi
 if [[ -z "$report" || ! -f "$report" ]]; then
-  echo "error: no report.json found (looked under analysis/target/stryker4s-report/*/)" >&2
-  echo "       run 'sbt -Dstryker=true \"analysis/stryker\"' first, or pass the report path explicitly." >&2
+  echo "error: no report.json found (looked under */target/stryker4s-report/*/)" >&2
+  echo "       run 'sbt -Dstryker=true \"<module>/stryker\"' first, or pass the report path explicitly." >&2
   exit 1
 fi
 
 report_abs="$(cd "$(dirname "$report")" && pwd)/$(basename "$report")"
-dest_abs="$repo_root/mutation-report.json"
-if [[ "$report_abs" != "$dest_abs" ]]; then
-  cp "$report" mutation-report.json
+dest="${MUTATION_REPORT_DEST:-mutation-report.json}"
+dest_dir="$(dirname "$dest")"
+if [[ "$dest_dir" != "." ]]; then
+  mkdir -p "$dest_dir"
 fi
-echo "wrote mutation-report.json from $report"
+dest_abs="$(cd "$dest_dir" && pwd)/$(basename "$dest")"
+if [[ "$report_abs" != "$dest_abs" ]]; then
+  cp "$report" "$dest"
+fi
+echo "wrote $dest from $report"
 
 score_line="$(jq -r '
   [.files[]?.mutants[]?] as $mutants
@@ -53,15 +58,15 @@ score_line="$(jq -r '
   | ($mutants | map(select(.status == "Killed" or .status == "Timeout" or .status == "Survived" or .status == "NoCoverage")) | length) as $scored
   | (if $scored == 0 then 100 else ((10000 * $detected / $scored) | round / 100) end) as $score
   | [$score, $detected, $scored] | @tsv
-' mutation-report.json)"
+' "$dest")"
 IFS=$'\t' read -r mutation_score detected_count scored_count <<<"$score_line"
 
 score_threshold="${MUTATION_SCORE_ALERT_THRESHOLD:-}"
 if [[ -z "$score_threshold" ]]; then
-  score_threshold="$(jq -r '.thresholds.high // .thresholds.low // 80' mutation-report.json)"
+  score_threshold="$(jq -r '.thresholds.high // .thresholds.low // 80' "$dest")"
 fi
 
-echo "mutation score: ${mutation_score}% (${detected_count}/${scored_count} detected, alert threshold ${score_threshold}%)"
+echo "${module_label} mutation score: ${mutation_score}% (${detected_count}/${scored_count} detected, alert threshold ${score_threshold}%)"
 
 status_counts="$(jq -r '
   [.files[]?.mutants[]?]
@@ -70,7 +75,7 @@ status_counts="$(jq -r '
   | sort_by(.status)
   | .[]
   | "  \(.status): \(.count)"
-' mutation-report.json)"
+' "$dest")"
 if [[ -n "$status_counts" ]]; then
   echo "mutants by status:"
   echo "$status_counts"
@@ -83,7 +88,7 @@ survivor_counts="$(jq -r '
   | sort_by(-.count, .mutator)
   | .[]
   | "  \(.mutator): \(.count)"
-' mutation-report.json)"
+' "$dest")"
 if [[ -n "$survivor_counts" ]]; then
   echo "surviving mutants by type:"
   echo "$survivor_counts"
@@ -96,7 +101,7 @@ error_counts="$(jq -r '
   | sort_by(.status)
   | .[]
   | "  \(.status): \(.count)"
-' mutation-report.json)"
+' "$dest")"
 if [[ -n "$error_counts" ]]; then
   echo "error mutants:"
   echo "$error_counts"
@@ -122,11 +127,11 @@ surviving_alerts="$(jq -r --arg mutators "$alert_mutators" '
   | sort_by(.mutator)
   | .[]
   | "  \(.mutator): \(.count) (\(.examples))"
-' mutation-report.json)"
+' "$dest")"
 
 alert=0
 if [[ "$score_alert" == "1" ]]; then
-  echo "alert: mutation score ${mutation_score}% is below ${score_threshold}%" >&2
+  echo "alert: ${module_label} mutation score ${mutation_score}% is below ${score_threshold}%" >&2
   alert=1
 fi
 if [[ -n "$surviving_alerts" ]]; then

--- a/scripts/run-stryker.sh
+++ b/scripts/run-stryker.sh
@@ -6,8 +6,10 @@
 # the normal local ./target directories.
 #
 # Usage:
-#   scripts/run-stryker.sh <name>       # .worktrees/stryker4s-<name>
-#   scripts/run-stryker.sh --local      # current checkout, ./target
+#   scripts/run-stryker.sh <name>                         # .worktrees/stryker4s-<name>
+#   scripts/run-stryker.sh --module core <name>           # one module in a worktree
+#   scripts/run-stryker.sh --module all <name>            # core, analysis, and mcp
+#   scripts/run-stryker.sh --local --module analysis      # current checkout, ./target
 #
 # On success it copies the stryker JSON report back to mutation-report.json and applies the alert
 # rules in scripts/mutation-summary.sh. The full sbt log is kept beside the run.
@@ -18,10 +20,19 @@ usage() {
 }
 
 local_run=0
+module="analysis"
 name=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --local) local_run=1; shift ;;
+    --module)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --module requires analysis, core, mcp, or all" >&2
+        exit 2
+      fi
+      module="$2"
+      shift 2
+      ;;
     -h|--help) usage; exit 0 ;;
     -*)
       echo "unknown argument: $1" >&2
@@ -43,9 +54,14 @@ done
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+if [[ "$module" != "analysis" && "$module" != "core" && "$module" != "mcp" && "$module" != "all" ]]; then
+  echo "error: unknown module '$module' (expected analysis, core, mcp, or all)" >&2
+  exit 2
+fi
+
 if [[ "$local_run" -eq 0 && -z "$name" ]]; then
-  echo "usage: scripts/run-stryker.sh <name>" >&2
-  echo "       scripts/run-stryker.sh --local" >&2
+  echo "usage: scripts/run-stryker.sh [--module analysis|core|mcp|all] <name>" >&2
+  echo "       scripts/run-stryker.sh --local [--module analysis|core|mcp|all]" >&2
   exit 2
 fi
 if [[ "$local_run" -eq 1 && -n "$name" ]]; then
@@ -86,29 +102,107 @@ if [[ "$local_run" -eq 1 ]]; then
 fi
 
 echo "running stryker4s in $run_label (full log: $log) ..."
-set +e
-(cd "$run_dir" && STRYKER=1 sbt -Dstryker=true "analysis/stryker") >"$log" 2>&1
-status=$?
-set -e
 
-grep -iE "error|exception|failed|mutation score|no code coverage|detected as static|Written JSON report|elapsed time" \
-  "$log" | tail -40 || true
+module_test_filters() {
+  case "$1" in
+    analysis)
+      printf '%s\n' \
+        "com.github.mercurievv.scalasemantic.analysis.CompatSuite" \
+        "com.github.mercurievv.scalasemantic.model.ModelsSuite" \
+        "com.github.mercurievv.scalasemantic.model.InputTypesSuite" \
+        "com.github.mercurievv.scalasemantic.analysis.AnalyzerHelpersSuite" \
+        "com.github.mercurievv.scalasemantic.analysis.AnalyzerCoreSuite" \
+        "com.github.mercurievv.scalasemantic.analysis.graph.StructureMetricsSuite" \
+        "com.github.mercurievv.scalasemantic.analysis.AnalyzerToolsSuite" \
+        "com.github.mercurievv.scalasemantic.analysis.DuplicationAnalyzerSuite"
+      ;;
+    core)
+      printf '%s\n' "com.github.mercurievv.scalasemantic.semanticdb.SemanticIndexSuite"
+      ;;
+    mcp)
+      printf '%s\n' \
+        "com.github.mercurievv.scalasemantic.mcp.McpSuite" \
+        "com.github.mercurievv.scalasemantic.mcp.TokenMetricsSuite"
+      ;;
+  esac
+}
 
-if [[ $status -ne 0 ]]; then
-  echo "stryker failed (exit $status). Full log: $log" >&2
-  exit $status
+module_mutate_patterns() {
+  case "$1" in
+    analysis)
+      printf '%s\n' \
+        "src/main/scala/**/*.scala" \
+        "!src/main/scala/com/github/mercurievv/scalasemantic/analysis/DuplicationAnalyzer.scala"
+      ;;
+    core)
+      printf '%s\n' "src/main/scala/**/*.scala"
+      ;;
+    mcp)
+      printf '%s\n' \
+        "src/main/scala/**/*.scala" \
+        "!src/main/scala/com/github/mercurievv/scalasemantic/Main.scala"
+      ;;
+  esac
+}
+
+run_module() {
+  local target_module="$1"
+  local module_log="$log"
+  if [[ "$module" == "all" ]]; then
+    module_log="${log%.log}-$target_module.log"
+  fi
+
+  local args=("$target_module / stryker")
+  while IFS= read -r pattern; do
+    args+=("--mutate" "$pattern")
+  done < <(module_mutate_patterns "$target_module")
+  while IFS= read -r filter; do
+    args+=("--test-filter" "$filter")
+  done < <(module_test_filters "$target_module")
+  args+=("--reporters" "html" "--reporters" "json")
+  args+=("--thresholds.high" "${MUTATION_HIGH_THRESHOLD:-80}")
+  args+=("--thresholds.low" "${MUTATION_LOW_THRESHOLD:-60}")
+  args+=("--thresholds.break" "${MUTATION_BREAK_THRESHOLD:-0}")
+  args+=("--timeout" "${MUTATION_TIMEOUT:-30s}")
+  args+=("--timeout-factor" "${MUTATION_TIMEOUT_FACTOR:-3.0}")
+
+  echo "running module $target_module (log: $module_log) ..."
+  set +e
+  (cd "$run_dir" && STRYKER=1 SBT_OPTS="${SBT_OPTS:--Xmx4G}" sbt --batch -Dstryker=true "${args[*]}") >"$module_log" 2>&1
+  local status=$?
+  set -e
+
+  grep -iE "error|exception|failed|mutation score|no code coverage|detected as static|Written JSON report|elapsed time" \
+    "$module_log" | tail -40 || true
+
+  if [[ $status -ne 0 ]]; then
+    echo "stryker failed for $target_module (exit $status). Full log: $module_log" >&2
+    exit $status
+  fi
+
+  report="$(find "$run_dir/$target_module/target/stryker4s-report" -name report.json -print0 2>/dev/null \
+    | xargs -0 ls -t 2>/dev/null | head -1 || true)"
+  if [[ -z "$report" || ! -f "$report" ]]; then
+    echo "error: no report.json produced under $run_label/$target_module/target/stryker4s-report" >&2
+    exit 1
+  fi
+
+  summary_status=0
+  MUTATION_MODULE="$target_module" "$repo_root/scripts/mutation-summary.sh" "$report" || summary_status=$?
+  if [[ "${MUTATION_ALERTS_FAIL:-1}" != "0" && "$summary_status" -ne 0 ]]; then
+    exit "$summary_status"
+  fi
+}
+
+if [[ "$module" == "all" ]]; then
+  run_module core
+  run_module analysis
+  run_module mcp
+else
+  run_module "$module"
 fi
-
-report="$(find "$run_dir/analysis/target/stryker4s-report" -name report.json -print0 2>/dev/null \
-  | xargs -0 ls -t 2>/dev/null | head -1 || true)"
-if [[ -z "$report" || ! -f "$report" ]]; then
-  echo "error: no report.json produced under $run_label/analysis/target/stryker4s-report" >&2
-  exit 1
-fi
-
-"$repo_root/scripts/mutation-summary.sh" "$report"
 if [[ "$local_run" -eq 1 ]]; then
-  echo "done. local Stryker output kept under analysis/target and target/stryker-run.log"
+  echo "done. local Stryker output kept under */target and target/stryker-run*.log"
 else
   echo "done. worktree kept at $wt (rerun reuses it; remove with: git worktree remove $wt)"
 fi

--- a/stryker4s.conf
+++ b/stryker4s.conf
@@ -1,15 +1,18 @@
 stryker4s {
   # --- Mutation testing (sbt plugin) --------------------------------------------------------------
-  # Run from the repo root: sbt -Dstryker=true "analysis/stryker"
+  # Run from the repo root:
+  #   scripts/run-stryker.sh --module analysis <name>
+  #   scripts/run-stryker.sh --module all <name>
+  # or directly:
+  #   sbt -Dstryker=true "analysis/stryker"
   # (the -Dstryker flag loads the local-only sbt-stryker4s snapshot; see project/plugins.sbt)
   # The plugin auto-derives the Scala dialect from the build, instruments coverage, and honours
   # test-filter (unlike the command-runner). See docs/project/development.md ("Mutation testing").
 
-  # Mutate the analysis engine — the real query logic (hierarchy, usages, signature printing,
-  # overloads, members, implicits, call-path). core's SemanticIndex is exercised transitively by
-  # CompatSuite; it is not mutated directly yet because its only test dogfoods this repo's own live
-  # SemanticDB (mutating its source would mutate the data it analyses → a meaningless score).
-  # Paths are relative to the stryker base-dir = the `analysis` sub-project's baseDirectory.
+  # Direct sbt runs default to the analysis engine. scripts/run-stryker.sh and CI override mutate
+  # and test-filter per module through Stryker4s CLI options, so the same root config can cover
+  # core, analysis, and mcp without copying temporary config files.
+  # Paths are relative to the stryker base-dir = the selected sbt sub-project's baseDirectory.
   mutate = [
     "src/main/scala/**/*.scala"
   ]
@@ -33,17 +36,16 @@ stryker4s {
     "com.github.mercurievv.scalasemantic.analysis.DuplicationAnalyzerSuite"
   ]
 
-  # html → browsable report (stryker4s-report/<ts>/index.html); json → machine-readable
-  # mutation-report.json (mutation-testing-elements schema) for tooling / post-processing.
-  # scripts/mutation-summary.sh applies stricter local alerts after the JSON report is written:
-  # score below the configured high threshold, or surviving behavior-critical mutator types.
+  # html → browsable report (stryker4s-report/<ts>/index.html); json → machine-readable report for
+  # scripts/mutation-summary.sh and CI comments/artifacts.
   reporters = ["html", "json"]
 
   thresholds {
     high = 80
     low = 60
-    # POC mode: do not hard-fail the Stryker task on mutation score yet. The follow-up alerting
-    # strategy task chooses the eventual break threshold after reviewing the measured baseline.
+    # Rollout grace period: do not hard-fail the Stryker task on mutation score yet. CI posts the
+    # advisory summary and uploads the HTML report; raise this with MUTATION_BREAK_THRESHOLD after
+    # the first stable nightly/label-gated runs establish a per-module baseline.
     break = 0
   }
 


### PR DESCRIPTION
## Summary
- roll out the Phase 1 Stryker4s CI workflow for analysis-module mutation checks
- add nightly/manual/label-gated workflow triggers, report artifact upload, PR comments, and post-mutation sbt test safety verification
- extend local mutation tooling with --module analysis|core|mcp|all, per-module report destinations, timeout/heap defaults, and advisory alert handling
- document the Phase 1 automatic analysis rollout and manual/experimental core/mcp status
- include the required CompatSuite scalafmt fix so prePush stays green on this branch

## Verification
- rtk sbt --batch compile
- bash -n scripts/run-stryker.sh
- bash -n scripts/mutation-summary.sh
- Ruby YAML parse of .github/workflows/mutation.yml
- rtk sbt --batch test
- MUTATION_ALERTS_FAIL=0 MUTATION_REPORT_DEST=reports/mutation/analysis/report.json rtk scripts/run-stryker.sh --local --module analysis
- post-mutation rtk sbt --batch test
- rtk sbt --batch prePush

## Notes
- analysis mutation score remains the POC baseline: 69.33% (563/812 detected).
- core and mcp are wired for manual runs but not automatic PR gating yet; docs record their current Stryker-specific blockers.