### PR TITLE
test: add reusable property generators

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/testing/PropertyDemoSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/testing/PropertyDemoSuite.scala
@@ -1,0 +1,32 @@
+package com.github.mercurievv.scalasemantic.testing
+
+import com.github.mercurievv.scalasemantic.analysis.PureKernels
+import com.github.mercurievv.scalasemantic.analysis.graph.GraphMetrics
+import com.github.mercurievv.scalasemantic.model.MethodSignature
+import org.scalacheck.Prop.forAll
+import upickle.default.read
+import upickle.default.write
+
+class PropertyDemoSuite extends munit.ScalaCheckSuite:
+
+  property("MethodSignature round-trips through upickle with reusable generators"):
+    forAll(PropertyGens.methodSignature) { signature =>
+      read[MethodSignature](write(signature)) == signature
+    }
+
+  property("rangeContains accepts generated points inside generated ranges"):
+    forAll(PropertyGens.pointInsideRange) { (range, point) =>
+      PureKernels.rangeContains(
+        range.start.line,
+        range.start.character,
+        range.end.line,
+        range.end.character,
+        point.line,
+        point.character
+      )
+    }
+
+  property("coupling reports exactly the generated graph nodes"):
+    forAll(PropertyGens.nodeGraph) { (nodes, graph) =>
+      GraphMetrics.coupling(nodes, graph).keySet == nodes
+    }

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/testing/PropertyGens.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/testing/PropertyGens.scala
@@ -1,0 +1,90 @@
+package com.github.mercurievv.scalasemantic.testing
+
+import com.github.mercurievv.scalasemantic.model.Location
+import com.github.mercurievv.scalasemantic.model.MethodSignature
+import com.github.mercurievv.scalasemantic.model.Parameter
+import com.github.mercurievv.scalasemantic.model.ParameterList
+import com.github.mercurievv.scalasemantic.model.Position
+import com.github.mercurievv.scalasemantic.model.Range
+import com.github.mercurievv.scalasemantic.model.SymbolKind
+import com.github.mercurievv.scalasemantic.model.SymbolRef
+import org.scalacheck.Gen
+
+object PropertyGens:
+
+  val nonEmptyString: Gen[String] =
+    Gen.alphaStr.suchThat(_.nonEmpty)
+
+  val position: Gen[Position] =
+    for
+      line <- Gen.chooseNum(0, 1000)
+      character <- Gen.chooseNum(0, 1000)
+    yield Position(line, character)
+
+  val orderedRange: Gen[Range] =
+    for
+      startLine <- Gen.chooseNum(0, 1000)
+      startChar <- Gen.chooseNum(0, 1000)
+      endLine <- Gen.chooseNum(startLine, startLine + 10)
+      endChar <-
+        if endLine == startLine then Gen.chooseNum(startChar + 1, startChar + 100)
+        else Gen.chooseNum(0, 1000)
+    yield Range(Position(startLine, startChar), Position(endLine, endChar))
+
+  val location: Gen[Location] =
+    for
+      uri <- nonEmptyString
+      range <- orderedRange
+    yield Location(uri, range)
+
+  val symbolRef: Gen[SymbolRef] =
+    for
+      symbol <- nonEmptyString
+      displayName <- nonEmptyString
+      kind <- Gen.oneOf(SymbolKind.values.toSeq)
+    yield SymbolRef(symbol, displayName, kind)
+
+  val parameter: Gen[Parameter] =
+    for
+      name <- nonEmptyString
+      tpe <- nonEmptyString
+      isImplicit <- Gen.oneOf(true, false)
+    yield Parameter(name, tpe, isImplicit)
+
+  val parameterList: Gen[ParameterList] =
+    for
+      parameters <- Gen.listOf(parameter)
+      isImplicit <- Gen.oneOf(true, false)
+    yield ParameterList(parameters, isImplicit)
+
+  val methodSignature: Gen[MethodSignature] =
+    for
+      symbol <- nonEmptyString
+      displayName <- nonEmptyString
+      typeParameters <- Gen.listOf(nonEmptyString)
+      parameterLists <- Gen.listOf(parameterList)
+      returnType <- nonEmptyString
+      rendered <- nonEmptyString
+    yield MethodSignature(symbol, displayName, typeParameters, parameterLists, returnType, rendered)
+
+  val pointInsideRange: Gen[(Range, Position)] =
+    orderedRange.map(range => (range, range.start))
+
+  def nodes(maxN: Int): Gen[Set[String]] =
+    Gen.chooseNum(0, maxN).map(n => (0 until n).map(_.toString).toSet)
+
+  def graph(nodes: Set[String]): Gen[Map[String, Set[String]]] =
+    if nodes.isEmpty then Gen.const(Map.empty)
+    else
+      val nodeList = nodes.toList
+      Gen
+        .sequence[List[Set[String]], Set[String]](
+          nodeList.map(_ => Gen.someOf(nodeList).map(_.toSet))
+        )
+        .map(edges => nodeList.zip(edges).toMap)
+
+  val nodeGraph: Gen[(Set[String], Map[String, Set[String]])] =
+    for
+      nodes <- nodes(6)
+      graph <- graph(nodes)
+    yield (nodes, graph)

--- a/docs/testing/pb-approach.md
+++ b/docs/testing/pb-approach.md
@@ -1,0 +1,41 @@
+# Property-Based Testing Approach
+
+## Decision
+
+ScalaSemantic standardizes on `munit-scalacheck` for property-based tests.
+
+Hedgehog is rejected for this repository for now. The project already has `munit-scalacheck`
+wired into `analysis` test dependencies, and existing property suites use `munit.ScalaCheckSuite`.
+Adding `hedgehog-munit` would create two property-testing styles without a clear benefit for the
+current migration.
+
+## Rationale
+
+- **munit integration:** `munit-scalacheck` extends the test framework already used across the
+  repository, so properties run with the same sbt test workflow and reporting as example tests.
+- **Generator ergonomics:** ScalaCheck `Gen` is already used in `ModelsPropertySuite`,
+  `AnalyzerHelpersPropertySuite`, `GraphMetricsPropertySuite`, and `InputTypesSuite`, giving later
+  conversions local examples to copy.
+- **Scala 3 support:** the current dependency set compiles and runs on the repository's Scala 3
+  line, with no extra build-tool or runner integration.
+- **Migration cost:** standardizing on one framework keeps later audit and rollout work focused on
+  preserving assertions rather than reconciling two assertion and shrinker APIs.
+
+## Reusable Generators
+
+Shared generators live in `com.github.mercurievv.scalasemantic.testing.PropertyGens`.
+They currently cover:
+
+- core wire-model values such as `Position`, `Range`, `Location`, `SymbolRef`, and
+  `MethodSignature`
+- ordered ranges and guaranteed in-range points for pure range helper properties
+- small graph shapes for graph metric properties
+
+`PropertyDemoSuite` demonstrates the intended reuse pattern:
+
+- model round-trip property: generated `MethodSignature` values round-trip through upickle
+- pure helper property: generated points inside generated ranges satisfy `PureKernels.rangeContains`
+- graph metric property: generated count pairs exercise `GraphMetrics.instability`
+
+Later migrations should add generators to `PropertyGens` only when they are reusable across suites.
+One-off generators can stay local to the suite that needs them.


### PR DESCRIPTION
Closes #146\n\n## Summary\n- document the munit-scalacheck decision and Hedgehog rejection\n- add shared property generators for model, range, and graph test data\n- add demo properties covering model round-trip, pure range helper, and graph metric invariants\n\n## Verification\n- rtk sbt --error "analysis/testOnly com.github.mercurievv.scalasemantic.testing.PropertyDemoSuite"