### PR TITLE
test: add live token metrics harness

### DIFF
--- a/docs/research/token-metrics-live-runs.sample.json
+++ b/docs/research/token-metrics-live-runs.sample.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "kind": "sample",
+    "description": "Synthetic fixture data for validating the live token metrics aggregation harness. Do not treat these numbers as research results.",
+    "targetProject": "ScalaSemanticMCP",
+    "targetCommit": "sample",
+    "scalaSemanticCommit": "sample",
+    "repetitionsRequired": 3
+  },
+  "measurements": [
+    {
+      "id": "find-usages-animal",
+      "query": "Find all definitions and references of the Animal trait.",
+      "tool": "find_usages",
+      "baseline": "Text grep for Animal across fixture source trees.",
+      "engine": "codex",
+      "model": "sample-model",
+      "runs": [
+        { "arm": "with-mcp", "run": 1, "inputTokens": 1120, "outputTokens": 210, "cacheTokens": 0 },
+        { "arm": "with-mcp", "run": 2, "inputTokens": 1180, "outputTokens": 200, "cacheTokens": 0 },
+        { "arm": "with-mcp", "run": 3, "inputTokens": 1100, "outputTokens": 230, "cacheTokens": 0 },
+        { "arm": "without-mcp", "run": 1, "inputTokens": 4920, "outputTokens": 340, "cacheTokens": 0 },
+        { "arm": "without-mcp", "run": 2, "inputTokens": 5100, "outputTokens": 360, "cacheTokens": 0 },
+        { "arm": "without-mcp", "run": 3, "inputTokens": 4860, "outputTokens": 330, "cacheTokens": 0 }
+      ]
+    },
+    {
+      "id": "trace-implicit-show",
+      "query": "Trace givens that produce Show and their dependencies.",
+      "tool": "trace_implicit_chain",
+      "baseline": "Read the fixture source and follow given definitions manually.",
+      "engine": "codex",
+      "model": "sample-model",
+      "runs": [
+        { "arm": "with-mcp", "run": 1, "inputTokens": 980, "outputTokens": 180, "cacheTokens": 0 },
+        { "arm": "with-mcp", "run": 2, "inputTokens": 1010, "outputTokens": 175, "cacheTokens": 0 },
+        { "arm": "with-mcp", "run": 3, "inputTokens": 995, "outputTokens": 190, "cacheTokens": 0 },
+        { "arm": "without-mcp", "run": 1, "inputTokens": 3420, "outputTokens": 280, "cacheTokens": 0 },
+        { "arm": "without-mcp", "run": 2, "inputTokens": 3550, "outputTokens": 300, "cacheTokens": 0 },
+        { "arm": "without-mcp", "run": 3, "inputTokens": 3490, "outputTokens": 290, "cacheTokens": 0 }
+      ]
+    }
+  ]
+}

--- a/docs/research/token-metrics-live.sample.json
+++ b/docs/research/token-metrics-live.sample.json
@@ -1,0 +1,167 @@
+{
+  "schemaVersion": 1,
+  "measurement": "end-to-end-agent-context",
+  "source": {
+    "kind": "sample",
+    "description": "Synthetic fixture data for validating the live token metrics aggregation harness. Do not treat these numbers as research results.",
+    "targetProject": "ScalaSemanticMCP",
+    "targetCommit": "sample",
+    "scalaSemanticCommit": "sample",
+    "repetitionsRequired": 3
+  },
+  "summary": {
+    "measurementCount": 2,
+    "taskCount": 2,
+    "engineCount": 1,
+    "toolMeanTokens": 2523.4,
+    "baselineMeanTokens": 9080,
+    "tokenDelta": 6556.6,
+    "savingsPercent": 72.2
+  },
+  "measurements": [
+    {
+      "id": "find-usages-animal",
+      "query": "Find all definitions and references of the Animal trait.",
+      "tool": "find_usages",
+      "baseline": "Text grep for Animal across fixture source trees.",
+      "engine": "codex",
+      "model": "sample-model",
+      "withMcp": {
+        "runs": [
+          {
+            "run": 1,
+            "inputTokens": 1120,
+            "outputTokens": 210,
+            "cacheTokens": 0,
+            "totalTokens": 1330
+          },
+          {
+            "run": 2,
+            "inputTokens": 1180,
+            "outputTokens": 200,
+            "cacheTokens": 0,
+            "totalTokens": 1380
+          },
+          {
+            "run": 3,
+            "inputTokens": 1100,
+            "outputTokens": 230,
+            "cacheTokens": 0,
+            "totalTokens": 1330
+          }
+        ],
+        "meanTokens": 1346.7,
+        "medianTokens": 1330,
+        "variance": 555.6,
+        "meanInputTokens": 1133.3,
+        "meanOutputTokens": 213.3,
+        "meanCacheTokens": 0
+      },
+      "withoutMcp": {
+        "runs": [
+          {
+            "run": 1,
+            "inputTokens": 4920,
+            "outputTokens": 340,
+            "cacheTokens": 0,
+            "totalTokens": 5260
+          },
+          {
+            "run": 2,
+            "inputTokens": 5100,
+            "outputTokens": 360,
+            "cacheTokens": 0,
+            "totalTokens": 5460
+          },
+          {
+            "run": 3,
+            "inputTokens": 4860,
+            "outputTokens": 330,
+            "cacheTokens": 0,
+            "totalTokens": 5190
+          }
+        ],
+        "meanTokens": 5303.3,
+        "medianTokens": 5260,
+        "variance": 13088.9,
+        "meanInputTokens": 4960,
+        "meanOutputTokens": 343.3,
+        "meanCacheTokens": 0
+      },
+      "tokenDelta": 3956.6,
+      "savingsPercent": 74.6
+    },
+    {
+      "id": "trace-implicit-show",
+      "query": "Trace givens that produce Show and their dependencies.",
+      "tool": "trace_implicit_chain",
+      "baseline": "Read the fixture source and follow given definitions manually.",
+      "engine": "codex",
+      "model": "sample-model",
+      "withMcp": {
+        "runs": [
+          {
+            "run": 1,
+            "inputTokens": 980,
+            "outputTokens": 180,
+            "cacheTokens": 0,
+            "totalTokens": 1160
+          },
+          {
+            "run": 2,
+            "inputTokens": 1010,
+            "outputTokens": 175,
+            "cacheTokens": 0,
+            "totalTokens": 1185
+          },
+          {
+            "run": 3,
+            "inputTokens": 995,
+            "outputTokens": 190,
+            "cacheTokens": 0,
+            "totalTokens": 1185
+          }
+        ],
+        "meanTokens": 1176.7,
+        "medianTokens": 1185,
+        "variance": 138.9,
+        "meanInputTokens": 995,
+        "meanOutputTokens": 181.7,
+        "meanCacheTokens": 0
+      },
+      "withoutMcp": {
+        "runs": [
+          {
+            "run": 1,
+            "inputTokens": 3420,
+            "outputTokens": 280,
+            "cacheTokens": 0,
+            "totalTokens": 3700
+          },
+          {
+            "run": 2,
+            "inputTokens": 3550,
+            "outputTokens": 300,
+            "cacheTokens": 0,
+            "totalTokens": 3850
+          },
+          {
+            "run": 3,
+            "inputTokens": 3490,
+            "outputTokens": 290,
+            "cacheTokens": 0,
+            "totalTokens": 3780
+          }
+        ],
+        "meanTokens": 3776.7,
+        "medianTokens": 3780,
+        "variance": 3755.6,
+        "meanInputTokens": 3486.7,
+        "meanOutputTokens": 290,
+        "meanCacheTokens": 0
+      },
+      "tokenDelta": 2600,
+      "savingsPercent": 68.8
+    }
+  ]
+}

--- a/docs/research/token-metrics-methodology.md
+++ b/docs/research/token-metrics-methodology.md
@@ -267,9 +267,23 @@ With an overall savings rate of **90.4%** across 5 queries:
 This part defines how the **live run** subtask(s) should measure real agent
 token consumption. It specifies the counting approach, baseline definition,
 comparison strategy, per-engine capture method, target-project selection
-rules, and rerun protocol. **No harness is implemented yet** — that is
-delegated to a later subtask ("Run measurements"), which must consume the
-definitions below without re-deriving them.
+rules, and rerun protocol.
+
+The aggregation harness is now implemented:
+
+- raw run input format:
+  [`docs/research/token-metrics-live-runs.sample.json`](token-metrics-live-runs.sample.json)
+- sample aggregate output:
+  [`docs/research/token-metrics-live.sample.json`](token-metrics-live.sample.json)
+- verification / regeneration suite:
+  [`mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/TokenLiveMetricsSuite.scala`](../../mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/TokenLiveMetricsSuite.scala)
+- driver script:
+  [`scripts/token-live-metrics.sh`](../../scripts/token-live-metrics.sh)
+
+The sample files use synthetic fixture numbers only; they validate the harness
+shape and must not be interpreted as research results. The later live-run
+subtask should copy the raw input shape, fill it with real engine usage records,
+and generate a real sibling aggregate file with the same script.
 
 ### Token-counting approach
 
@@ -437,6 +451,36 @@ To keep the live run reproducible across time and across whoever executes it:
    target engine ships a major version bump, since either can shift the
    comparison; routine ScalaSemantic patch releases that don't change tool
    output shape do not require a live rerun.
+
+### Live harness usage
+
+The driver regenerates an aggregate JSON file from raw per-run usage records:
+
+```bash
+scripts/token-live-metrics.sh <raw-runs-json> <aggregate-output-json>
+```
+
+With no arguments it regenerates the checked-in synthetic sample:
+
+```bash
+scripts/token-live-metrics.sh
+```
+
+Verification mode runs the Scala suite directly and compares the aggregate
+output to the raw input:
+
+```bash
+sbt "mcp/testOnly com.github.mercurievv.scalasemantic.mcp.TokenLiveMetricsSuite"
+```
+
+The live-run subtask should use a real raw input path and a real aggregate path,
+for example:
+
+```bash
+scripts/token-live-metrics.sh \
+  docs/research/token-metrics-live-runs.json \
+  docs/research/token-metrics-live.json
+```
 
 ### Limitations (Part 2, anticipated)
 

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/TokenLiveMetricsSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/TokenLiveMetricsSuite.scala
@@ -1,0 +1,187 @@
+package com.github.mercurievv.scalasemantic.mcp
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class TokenLiveMetricsSuite extends munit.FunSuite:
+
+  private val root = Path.of(".").toAbsolutePath.nn.normalize().nn
+  private val defaultRunsPath =
+    "docs/research/token-metrics-live-runs.sample.json"
+  private val defaultOutputPath =
+    "docs/research/token-metrics-live.sample.json"
+
+  private val runsPath =
+    root.resolve(sys.env.getOrElse("TOKEN_LIVE_RUNS", defaultRunsPath)).nn
+  private val outputPath =
+    root.resolve(sys.env.getOrElse("TOKEN_LIVE_OUTPUT", defaultOutputPath)).nn
+
+  private case class RunTokens(
+      arm: String,
+      run: Int,
+      inputTokens: Int,
+      outputTokens: Int,
+      cacheTokens: Int
+  ):
+    val totalTokens: Int = inputTokens + outputTokens
+
+  private case class Measurement(
+      id: String,
+      query: String,
+      tool: String,
+      baseline: String,
+      engine: String,
+      model: String,
+      runs: List[RunTokens]
+  )
+
+  private case class Stats(
+      runs: List[RunTokens],
+      meanTokens: Double,
+      medianTokens: Double,
+      variance: Double,
+      meanInputTokens: Double,
+      meanOutputTokens: Double,
+      meanCacheTokens: Double
+  )
+
+  private def rounded(value: Double): Double =
+    BigDecimal(value).setScale(1, BigDecimal.RoundingMode.HALF_UP).toDouble
+
+  private def stats(runs: List[RunTokens]): Stats =
+    assert(runs.size >= 3, "each arm must have at least 3 runs")
+    val totals = runs.map(_.totalTokens).sorted
+    val mean = totals.sum.toDouble / totals.size
+    val median =
+      if totals.size % 2 == 1 then totals(totals.size / 2).toDouble
+      else
+        val upper = totals.size / 2
+        (totals(upper - 1) + totals(upper)).toDouble / 2.0
+    val variance =
+      totals.map(total => math.pow(total - mean, 2.0)).sum / totals.size
+    Stats(
+      runs = runs.sortBy(_.run),
+      meanTokens = rounded(mean),
+      medianTokens = rounded(median),
+      variance = rounded(variance),
+      meanInputTokens = rounded(runs.map(_.inputTokens).sum.toDouble / runs.size),
+      meanOutputTokens = rounded(runs.map(_.outputTokens).sum.toDouble / runs.size),
+      meanCacheTokens = rounded(runs.map(_.cacheTokens).sum.toDouble / runs.size)
+    )
+
+  private def parseRun(value: ujson.Value): RunTokens =
+    val obj = value.obj
+    RunTokens(
+      arm = obj("arm").str,
+      run = obj("run").num.toInt,
+      inputTokens = obj("inputTokens").num.toInt,
+      outputTokens = obj("outputTokens").num.toInt,
+      cacheTokens = obj.get("cacheTokens").map(_.num.toInt).getOrElse(0)
+    )
+
+  private def parseMeasurement(value: ujson.Value): Measurement =
+    val obj = value.obj
+    Measurement(
+      id = obj("id").str,
+      query = obj("query").str,
+      tool = obj("tool").str,
+      baseline = obj("baseline").str,
+      engine = obj("engine").str,
+      model = obj("model").str,
+      runs = obj("runs").arr.map(parseRun).toList
+    )
+
+  private def parseMeasurements(raw: ujson.Value): List[Measurement] =
+    val schemaVersion = raw("schemaVersion").num.toInt
+    assertEquals(schemaVersion, 1, "unsupported live metrics schema version")
+    raw("measurements").arr.map(parseMeasurement).toList
+
+  private def armStats(measurement: Measurement, arm: String): Stats =
+    val armRuns = measurement.runs.filter(_.arm == arm)
+    assertEquals(
+      armRuns.map(_.run).sorted,
+      armRuns.map(_.run).distinct.sorted,
+      s"${measurement.id}/${measurement.engine}/$arm has duplicate run numbers"
+    )
+    stats(armRuns)
+
+  private def savingsPercent(baselineMean: Double, toolMean: Double): Double =
+    if baselineMean == 0.0 then 0.0
+    else rounded((baselineMean - toolMean) * 100.0 / baselineMean)
+
+  private def runJson(run: RunTokens): ujson.Value =
+    ujson.Obj(
+      "run" -> run.run,
+      "inputTokens" -> run.inputTokens,
+      "outputTokens" -> run.outputTokens,
+      "cacheTokens" -> run.cacheTokens,
+      "totalTokens" -> run.totalTokens
+    )
+
+  private def statsJson(stats: Stats): ujson.Value =
+    ujson.Obj(
+      "runs" -> ujson.Arr.from(stats.runs.map(runJson)),
+      "meanTokens" -> stats.meanTokens,
+      "medianTokens" -> stats.medianTokens,
+      "variance" -> stats.variance,
+      "meanInputTokens" -> stats.meanInputTokens,
+      "meanOutputTokens" -> stats.meanOutputTokens,
+      "meanCacheTokens" -> stats.meanCacheTokens
+    )
+
+  private def aggregate(rawText: String): String =
+    val raw = ujson.read(rawText)
+    val measurements = parseMeasurements(raw)
+    val rows = measurements.sortBy(m => (m.id, m.engine)).map { measurement =>
+      val withMcp = armStats(measurement, "with-mcp")
+      val withoutMcp = armStats(measurement, "without-mcp")
+      val delta = rounded(withoutMcp.meanTokens - withMcp.meanTokens)
+      ujson.Obj(
+        "id" -> measurement.id,
+        "query" -> measurement.query,
+        "tool" -> measurement.tool,
+        "baseline" -> measurement.baseline,
+        "engine" -> measurement.engine,
+        "model" -> measurement.model,
+        "withMcp" -> statsJson(withMcp),
+        "withoutMcp" -> statsJson(withoutMcp),
+        "tokenDelta" -> delta,
+        "savingsPercent" -> savingsPercent(withoutMcp.meanTokens, withMcp.meanTokens)
+      )
+    }
+    val withTotal = rounded(
+      rows.map(row => row("withMcp")("meanTokens").num).sum
+    )
+    val withoutTotal = rounded(
+      rows.map(row => row("withoutMcp")("meanTokens").num).sum
+    )
+    val delta = rounded(withoutTotal - withTotal)
+    ujson
+      .Obj(
+        "schemaVersion" -> 1,
+        "measurement" -> "end-to-end-agent-context",
+        "source" -> raw("source"),
+        "summary" -> ujson.Obj(
+          "measurementCount" -> rows.size,
+          "taskCount" -> rows.map(_("id").str).distinct.size,
+          "engineCount" -> rows.map(_("engine").str).distinct.size,
+          "toolMeanTokens" -> withTotal,
+          "baselineMeanTokens" -> withoutTotal,
+          "tokenDelta" -> delta,
+          "savingsPercent" -> savingsPercent(withoutTotal, withTotal)
+        ),
+        "measurements" -> ujson.Arr.from(rows)
+      )
+      .render(indent = 2) + "\n"
+
+  test("live token metrics sample aggregate matches raw run fixture") {
+    val generated = aggregate(Files.readString(runsPath).nn)
+    if sys.env.get("UPDATE_TOKEN_LIVE_METRICS").contains("1") then
+      Files.writeString(outputPath, generated)
+    else
+      assertEquals(
+        Files.readString(outputPath).nn,
+        generated,
+        "live token metrics aggregate is stale"
+      )
+  }

--- a/scripts/token-live-metrics.sh
+++ b/scripts/token-live-metrics.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat <<'USAGE'
+Usage: scripts/token-live-metrics.sh [raw-runs-json] [aggregate-output-json]
+
+Aggregates live WITH-vs-WITHOUT ScalaSemantic token measurements using the
+Scala test harness. The raw input must follow
+docs/research/token-metrics-live-runs.sample.json.
+
+Defaults:
+  raw-runs-json          docs/research/token-metrics-live-runs.sample.json
+  aggregate-output-json  docs/research/token-metrics-live.sample.json
+USAGE
+  exit 0
+fi
+
+raw_runs="${1:-docs/research/token-metrics-live-runs.sample.json}"
+output_json="${2:-docs/research/token-metrics-live.sample.json}"
+
+UPDATE_TOKEN_LIVE_METRICS=1 \
+TOKEN_LIVE_RUNS="$raw_runs" \
+TOKEN_LIVE_OUTPUT="$output_json" \
+sbt --batch "mcp/testOnly com.github.mercurievv.scalasemantic.mcp.TokenLiveMetricsSuite"


### PR DESCRIPTION
Closes #138\n\n## Summary\n- add a live token metrics raw-runs sample and generated aggregate sample\n- add TokenLiveMetricsSuite to validate and aggregate WITH-vs-WITHOUT MCP run data\n- add scripts/token-live-metrics.sh driver for future live measurement runs\n- document the implemented harness in token-metrics-methodology.md\n\n## Verification\n- rtk sbt --error "mcp/testOnly com.github.mercurievv.scalasemantic.mcp.TokenLiveMetricsSuite"\n- rtk sbt --error scalafmtCheckAll