### PR TITLE
refactor: simplify selected readability patterns

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -250,15 +250,16 @@ final class Analyzer(
     // One import edit per referencing file, decided by that file's own package.
     val imports = references
       .map(_.uri)
-      .distinct
-      .filterNot(defUri.contains) // the definition's file moves with it
-      .flatMap { uri =>
-        val pkg = h.documentPackage(uri)
-        if pkg.contains(toOwner) then None // already in the destination package
-        else if pkg.contains(fromOwner) then Some(MoveImport(uri, "", toFqn))
-        else Some(MoveImport(uri, fromFqn, toFqn))
-      }
-    MovePlan(
+        .distinct
+        .filterNot(defUri.contains) // the definition's file moves with it
+        .flatMap { uri =>
+          val pkg = h.documentPackage(uri)
+          pkg match
+            case p if p.contains(toOwner)   => None // already in the destination package
+            case p if p.contains(fromOwner) => Some(MoveImport(uri, "", toFqn))
+            case _                          => Some(MoveImport(uri, fromFqn, toFqn))
+        }
+      MovePlan(
       sym,
       name,
       h.kindName(sym),

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/Mcp.scala
@@ -272,25 +272,26 @@ object Mcp:
       .orElse(Option(System.getenv("SCALASEMANTIC_CLASSPATH")))
       .map(_.trim)
       .filter(_.nonEmpty)
-      .map { spec =>
-        // A spec with no path separator that names nothing on disk is a classpath FILE that hasn't
-        // been written yet (e.g. `mcpClientConfig` printed the path before `mcpClasspathFile` ran).
-        // Treat it as "no classpath" → index-only, rather than a bogus single-entry classpath.
-        val asFile = Paths.get(spec)
-        val missingFileRef =
-          !spec.contains(java.io.File.pathSeparator) && !Files.exists(asFile)
-        if missingFileRef then Vector.empty
-        else
-          val raw = if Files.isRegularFile(asFile) then Files.readString(asFile) else spec
-          raw
-            .split("[\n" + java.io.File.pathSeparator + "]")
-            .iterator
-            .map(_.trim)
-            .filter(_.nonEmpty)
-            .map(Paths.get(_))
-            .toVector
-      }
+      .map(resolveClasspathSpec)
       .filter(_.nonEmpty)
+
+  private def resolveClasspathSpec(spec: String): Seq[Path] =
+    // A spec with no path separator that names nothing on disk is a classpath FILE that hasn't
+    // been written yet (e.g. `mcpClientConfig` printed the path before `mcpClasspathFile` ran).
+    // Treat it as "no classpath" -> index-only, rather than a bogus single-entry classpath.
+    val asFile = Paths.get(spec)
+    val missingFileRef =
+      !spec.contains(java.io.File.pathSeparator) && !Files.exists(asFile)
+    if missingFileRef then Vector.empty
+    else
+      val raw = if Files.isRegularFile(asFile) then Files.readString(asFile) else spec
+      raw
+        .split("[\n" + java.io.File.pathSeparator + "]")
+        .iterator
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .map(Paths.get(_))
+        .toVector
 
   // --- JSON-RPC envelope helpers --------------------------------------------
 

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -1008,33 +1008,53 @@ object McpTools:
   private def argBool(a: ujson.Value, k: String, d: Boolean): Boolean =
     a.obj.get(k).map(_.bool).getOrElse(d)
 
+  private def validatedArg[A](result: Either[String, A]): A =
+    result.fold(error, identity)
+
+  private def argRefinedString[A](a: ujson.Value, k: String)(from: String => Either[String, A]): A =
+    validatedArg(from(argStr(a, k)))
+
+  private def argRefinedString[A](
+      a: ujson.Value,
+      k: String,
+      default: String
+  )(from: String => Either[String, A]): A =
+    val raw = argStr(a, k)
+    validatedArg(from(if raw.isEmpty then default else raw))
+
+  private def argRefinedInt[A](
+      a: ujson.Value,
+      k: String,
+      default: Int
+  )(from: (Int, String) => Either[String, A]): A =
+    validatedArg(from(argInt(a, k, default), k))
+
   private def argSymbol(a: ujson.Value, k: String): SemanticDbSymbol =
-    SemanticDbSymbol.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(SemanticDbSymbol.from)
 
   private def argMethodSymbol(a: ujson.Value, k: String): MethodSymbol =
-    MethodSymbol.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(MethodSymbol.from)
 
   private def argTypeSymbol(a: ujson.Value, k: String): TypeSymbol =
-    TypeSymbol.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(TypeSymbol.from)
 
   private def argPackageSymbol(a: ujson.Value, k: String): PackageSymbol =
-    PackageSymbol.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(PackageSymbol.from)
 
   private def argUri(a: ujson.Value, k: String): DocumentUri =
-    DocumentUri.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(DocumentUri.from)
 
   private def argIdentifier(a: ujson.Value, k: String): ScalaIdentifier =
-    ScalaIdentifier.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(ScalaIdentifier.from)
 
   private def argIdentifier(a: ujson.Value, k: String, default: String): ScalaIdentifier =
-    val raw = argStr(a, k)
-    ScalaIdentifier.from(if raw.isEmpty then default else raw).fold(error, identity)
+    argRefinedString(a, k, default)(ScalaIdentifier.from)
 
   private def argNonNegativeInt(a: ujson.Value, k: String, default: Int): NonNegativeInt =
-    NonNegativeInt.from(argInt(a, k, default), k).fold(error, identity)
+    argRefinedInt(a, k, default)(NonNegativeInt.from)
 
   private def argPositiveInt(a: ujson.Value, k: String, default: Int): PositiveInt =
-    PositiveInt.from(argInt(a, k, default), k).fold(error, identity)
+    argRefinedInt(a, k, default)(PositiveInt.from)
 
   private def argPosition(a: ujson.Value, lineKey: String, characterKey: String): SourcePosition =
     SourcePosition
@@ -1052,10 +1072,10 @@ object McpTools:
       .fold(error, identity)
 
   private def argDimension(a: ujson.Value, k: String): StructureDimension =
-    StructureDimension.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(StructureDimension.from)
 
   private def argSort(a: ujson.Value, k: String): StructureSort =
-    StructureSort.from(argStr(a, k)).fold(error, identity)
+    argRefinedString(a, k)(StructureSort.from)
 
   private def argFormat(a: ujson.Value, k: String): SourceFormat =
     SourceFormat.from(argStr(a, k))


### PR DESCRIPTION
Implements #143 based on the phase-2 selection in #137.\n\nChanges:\n- Deduplicate MCP refined argument parsing through shared validation helpers.\n- Rewrite Analyzer.movePlan import selection as explicit destination/source/elsewhere cases.\n- Extract MCP classpath spec parsing from resolveClasspath.\n\nLocal verification:\n- rtk sbt --error compile\n- rtk sbt --error test