### PR TITLE
fix: ignore disappearing semanticdb artifacts

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -250,16 +250,16 @@ final class Analyzer(
     // One import edit per referencing file, decided by that file's own package.
     val imports = references
       .map(_.uri)
-        .distinct
-        .filterNot(defUri.contains) // the definition's file moves with it
-        .flatMap { uri =>
-          val pkg = h.documentPackage(uri)
-          pkg match
-            case p if p.contains(toOwner)   => None // already in the destination package
-            case p if p.contains(fromOwner) => Some(MoveImport(uri, "", toFqn))
-            case _                          => Some(MoveImport(uri, fromFqn, toFqn))
-        }
-      MovePlan(
+      .distinct
+      .filterNot(defUri.contains) // the definition's file moves with it
+      .flatMap { uri =>
+        val pkg = h.documentPackage(uri)
+        pkg match
+          case p if p.contains(toOwner)   => None // already in the destination package
+          case p if p.contains(fromOwner) => Some(MoveImport(uri, "", toFqn))
+          case _                          => Some(MoveImport(uri, fromFqn, toFqn))
+      }
+    MovePlan(
       sym,
       name,
       h.kindName(sym),

--- a/core/src/main/scala/com/github/mercurievv/scalasemantic/semanticdb/SemanticIndex.scala
+++ b/core/src/main/scala/com/github/mercurievv/scalasemantic/semanticdb/SemanticIndex.scala
@@ -93,8 +93,10 @@ object SemanticIndex:
   def fromRoots(roots: Seq[Path]): SemanticIndex =
     val files = roots.filter(Files.exists(_)).flatMap(findSemanticdb)
     val docs = files.flatMap { f =>
-      val bytes = Files.readAllBytes(f)
-      s.TextDocuments.parseFrom(bytes).documents
+      try
+        val bytes = Files.readAllBytes(f)
+        s.TextDocuments.parseFrom(bytes).documents
+      catch case _: IOException => Nil
     }.toVector
     new SemanticIndex(docs)
 


### PR DESCRIPTION
Follow-up for #143 after PR #189.\n\nChanges:\n- Applies the scalafmt indentation change generated by the pre-push hook for Analyzer.movePlan.\n- Makes SemanticIndex.fromRoots skip SemanticDB files that disappear between discovery and read, which fixes Stryker's clean dogfood verification when temporary mutation artifacts are removed.\n\nLocal verification:\n- rtk sbt --error compile\n- rtk sbt --error test