### PR TITLE
test: property-based tests for linearize, method-signature, resolve-implicits, and duplication minSize (#149)

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerCorePropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerCorePropertySuite.scala
@@ -1,0 +1,114 @@
+package com.github.mercurievv.scalasemantic.analysis
+
+import com.github.mercurievv.scalasemantic.model.InputTypes.*
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+
+import scala.meta.internal.semanticdb as s
+
+/** Property-based complement to [[AnalyzerCoreSuite]] for the two orchestration branches that are
+  * crisp boolean invariants rather than scenario-shaped output. Each is checked in
+  * [[AnalyzerCoreSuite]] against a couple of hand-built cases; here they are generalised over
+  * generated inputs so the invariant — not just the sampled points — is asserted:
+  *
+  *   - **methodSignature implicit-list flag**: a parameter list is flagged implicit iff it is
+  *     non-empty AND every parameter is implicit (`params.nonEmpty && params.forall(isImplicit)`).
+  *   - **resolveImplicits uniqueness**: `chosen` is defined iff exactly one candidate produces the
+  *     queried type, and the candidate count equals the number of givens in the index.
+  *
+  * Both build small in-memory indexes (filter-safe, no dogfooding), matching the fixtures in
+  * [[AnalyzerCoreSuite]].
+  */
+class AnalyzerCorePropertySuite extends munit.ScalaCheckSuite:
+
+  private val P = "com/x/"
+
+  private def tref(sym: String): s.Type = s.TypeRef(s.Type.Empty, sym, Nil)
+  private val ObjectT = tref("java/lang/Object#")
+  private val IntT = tref("scala/Int#")
+
+  private def info(
+      symbol: String,
+      kind: s.SymbolInformation.Kind,
+      displayName: String,
+      signature: s.Signature,
+      properties: Int = 0
+  ): s.SymbolInformation =
+    s.SymbolInformation(
+      symbol = symbol,
+      kind = kind,
+      displayName = displayName,
+      signature = signature,
+      properties = properties
+    )
+
+  private def analyzer(symbols: s.SymbolInformation*): Analyzer =
+    Analyzer(
+      SemanticIndex(Vector(s.TextDocument(uri = "x.scala", symbols = symbols.toVector)))
+    )
+
+  private def tpe(v: String) = TypeSymbol.from(v).fold(fail(_), identity)
+  private def method(v: String) = MethodSymbol.from(v).fold(fail(_), identity)
+
+  // ---------------------------------------------------------------------------
+  // methodSignature: implicit-list flag
+  // ---------------------------------------------------------------------------
+
+  private def param(symbol: String, display: String, isImplicit: Boolean) =
+    info(
+      symbol,
+      s.SymbolInformation.Kind.PARAMETER,
+      display,
+      s.ValueSignature(IntT),
+      if isImplicit then s.SymbolInformation.Property.IMPLICIT.value else 0
+    )
+
+  property(
+    "methodSignature flags a parameter list implicit iff it is non-empty and all params are implicit"
+  ):
+    forAll(Gen.listOf(Gen.oneOf(true, false))) { flags =>
+      val params = flags.zipWithIndex.map { (imp, i) =>
+        param(s"${P}C#f().(p$i)", s"p$i", isImplicit = imp)
+      }
+      val m =
+        info(
+          s"${P}C#f().",
+          s.SymbolInformation.Kind.METHOD,
+          "f",
+          s.MethodSignature(None, Seq(s.Scope(hardlinks = params.toVector)), IntT)
+        )
+      val lists = analyzer(m).methodSignature(method(s"${P}C#f().")).get.parameterLists
+      // A method with one parameter list always yields exactly one ParameterList result.
+      lists.map(_.isImplicit) == List(flags.nonEmpty && flags.forall(identity))
+    }
+
+  // ---------------------------------------------------------------------------
+  // resolveImplicits: chosen iff unique
+  // ---------------------------------------------------------------------------
+
+  private val showCls =
+    info(
+      s"${P}Show#",
+      s.SymbolInformation.Kind.CLASS,
+      "Show",
+      s.ClassSignature(None, List(ObjectT), s.Type.Empty, None)
+    )
+
+  private def givenObj(symbol: String, display: String) =
+    info(
+      symbol,
+      s.SymbolInformation.Kind.OBJECT,
+      display,
+      s.ClassSignature(None, List(tref(s"${P}Show#"), ObjectT), s.Type.Empty, None),
+      s.SymbolInformation.Property.IMPLICIT.value
+    )
+
+  property(
+    "resolveImplicits: candidate count is the number of givens; chosen is defined iff exactly one"
+  ):
+    forAll(Gen.chooseNum(0, 5)) { n =>
+      val givens = (0 until n).map(i => givenObj(s"${P}show$i.", s"show$i"))
+      val r = analyzer((showCls +: givens)*).resolveImplicits(tpe(s"${P}Show#"))
+      r.candidates.size == n && (r.chosen.isDefined == (n == 1))
+    }

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersPropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersPropertySuite.scala
@@ -177,3 +177,68 @@ class AnalyzerHelpersPropertySuite extends munit.ScalaCheckSuite:
           matcher(haystack) == haystack.contains(lit)
         else true
     }
+
+  // ---------------------------------------------------------------------------
+  // linearize (transitive parents over an arbitrary class DAG)
+  // ---------------------------------------------------------------------------
+  //
+  // Generalises the fixed diamond in AnalyzerHelpersSuite ("linearize de-duplicates a diamond"):
+  // over any acyclic class hierarchy, linearize must (a) return each ancestor exactly once, and
+  // (b) return exactly the transitive parent set of the root. Acyclicity is guaranteed by only
+  // letting a class `c$i` extend classes `c$j` with `j > i`, so parent edges always point to a
+  // strictly higher index and no cycle can form.
+
+  /** A class hierarchy over `c0 .. c{n-1}`: the built index plus the root symbol and the raw
+    * parent map used to compute the expected transitive-ancestor set independently.
+    */
+  private val genClassDag: Gen[(SemanticIndex, String, Map[String, Set[String]])] =
+    def sym(i: Int): String = s"d/c$i#"
+    for
+      n <- Gen.chooseNum(1, 8)
+      parentLists <- Gen.sequence[List[List[Int]], List[Int]](
+        (0 until n).toList.map { i =>
+          Gen.someOf((i + 1) until n).map(_.toList)
+        }
+      )
+    yield
+      val parentMap = (0 until n).map(i => sym(i) -> parentLists(i).map(sym).toSet).toMap
+      val symbols = (0 until n).toVector.map { i =>
+        s.SymbolInformation(
+          symbol = sym(i),
+          kind = s.SymbolInformation.Kind.CLASS,
+          displayName = s"c$i",
+          signature = s.ClassSignature(
+            None,
+            parentLists(i).map(p => s.TypeRef(s.Type.Empty, sym(p), Nil)),
+            s.Type.Empty,
+            None
+          )
+        )
+      }
+      val index = new SemanticIndex(Vector(s.TextDocument(uri = "d.scala", symbols = symbols)))
+      (index, sym(0), parentMap)
+
+  /** The transitive parents of `root` in `parents` (root excluded), computed by a plain reachability
+    * walk that is independent of the linearize implementation under test.
+    */
+  private def transitiveAncestors(root: String, parents: Map[String, Set[String]]): Set[String] =
+    @annotation.tailrec
+    def loop(frontier: List[String], seen: Set[String]): Set[String] =
+      frontier match
+        case Nil          => seen
+        case head :: tail =>
+          val next = parents.getOrElse(head, Set.empty).filterNot(seen.contains)
+          loop(next.toList ::: tail, seen ++ next)
+    loop(List(root), Set.empty)
+
+  property("linearize returns each ancestor exactly once (no duplicates) over any class DAG"):
+    forAll(genClassDag) { (index, root, _) =>
+      val lin = AnalyzerHelpers(index).linearize(root)
+      lin.distinct == lin
+    }
+
+  property("linearize yields exactly the transitive parent set of the root"):
+    forAll(genClassDag) { (index, root, parents) =>
+      val lin = AnalyzerHelpers(index).linearize(root)
+      lin.toSet == transitiveAncestors(root, parents)
+    }

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersPropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpersPropertySuite.scala
@@ -188,8 +188,8 @@ class AnalyzerHelpersPropertySuite extends munit.ScalaCheckSuite:
   // letting a class `c$i` extend classes `c$j` with `j > i`, so parent edges always point to a
   // strictly higher index and no cycle can form.
 
-  /** A class hierarchy over `c0 .. c{n-1}`: the built index plus the root symbol and the raw
-    * parent map used to compute the expected transitive-ancestor set independently.
+  /** A class hierarchy over `c0 .. c{n-1}`: the built index plus the root symbol and the raw parent
+    * map used to compute the expected transitive-ancestor set independently.
     */
   private val genClassDag: Gen[(SemanticIndex, String, Map[String, Set[String]])] =
     def sym(i: Int): String = s"d/c$i#"
@@ -218,8 +218,8 @@ class AnalyzerHelpersPropertySuite extends munit.ScalaCheckSuite:
       val index = new SemanticIndex(Vector(s.TextDocument(uri = "d.scala", symbols = symbols)))
       (index, sym(0), parentMap)
 
-  /** The transitive parents of `root` in `parents` (root excluded), computed by a plain reachability
-    * walk that is independent of the linearize implementation under test.
+  /** The transitive parents of `root` in `parents` (root excluded), computed by a plain
+    * reachability walk that is independent of the linearize implementation under test.
     */
   private def transitiveAncestors(root: String, parents: Map[String, Set[String]]): Set[String] =
     @annotation.tailrec

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/DuplicationAnalyzerPropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/DuplicationAnalyzerPropertySuite.scala
@@ -1,0 +1,47 @@
+package com.github.mercurievv.scalasemantic.analysis
+
+import com.github.mercurievv.scalasemantic.semanticdb.SemanticIndex
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+
+import java.nio.file.Paths
+import scala.meta.internal.semanticdb as s
+
+/** Property-based complement to [[DuplicationAnalyzerSuite]] for the `minSize` size guard.
+  *
+  * [[DuplicationAnalyzerSuite]] pins the "inclusive floor" behaviour at two hand-picked points (an
+  * absurdly high floor admits nothing; a floor equal to the block's own node count still admits it).
+  * This suite generalises that to the full boundary contract: `minSize` only *filters* the fixed set
+  * of duplicate blocks the fixture contains, so `analyze(minSize).groups.nonEmpty` holds exactly
+  * when `minSize` is at most the largest duplicated block's node count. Raising the floor can only
+  * remove blocks (never add larger ones), so the largest block size is a stable threshold.
+  */
+class DuplicationAnalyzerPropertySuite extends munit.ScalaCheckSuite:
+
+  // two identical method bodies in different files — the same cross-file duplicate fixture the
+  // example suite uses.
+  private def dupIndex = SemanticIndex(
+    Vector(
+      s.TextDocument(
+        uri = "a/foo.scala",
+        text = "object Foo:\n  def add(x: Int, y: Int): Int =\n    val sum = x + y\n    sum\n"
+      ),
+      s.TextDocument(
+        uri = "b/bar.scala",
+        text =
+          "object Bar:\n  def plus(a: Double, b: Double): Double =\n    val total = a + b\n    total\n"
+      )
+    )
+  )
+
+  private val root = Paths.get(".")
+
+  // The largest duplicated block's node count for this fixture. minSize=1 is the most permissive
+  // floor, so it surfaces every duplicate — its maximum is the true threshold.
+  private val maxBlockSize: Int =
+    DuplicationAnalyzer.analyze(dupIndex, root, minSize = 1).groups.map(_.astNodeCount).max
+
+  property("analyze(minSize).groups.nonEmpty holds iff minSize <= the largest duplicated block"):
+    forAll(Gen.chooseNum(1, maxBlockSize * 2)) { m =>
+      DuplicationAnalyzer.analyze(dupIndex, root, minSize = m).groups.nonEmpty == (m <= maxBlockSize)
+    }

--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/DuplicationAnalyzerPropertySuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/DuplicationAnalyzerPropertySuite.scala
@@ -10,11 +10,11 @@ import scala.meta.internal.semanticdb as s
 /** Property-based complement to [[DuplicationAnalyzerSuite]] for the `minSize` size guard.
   *
   * [[DuplicationAnalyzerSuite]] pins the "inclusive floor" behaviour at two hand-picked points (an
-  * absurdly high floor admits nothing; a floor equal to the block's own node count still admits it).
-  * This suite generalises that to the full boundary contract: `minSize` only *filters* the fixed set
-  * of duplicate blocks the fixture contains, so `analyze(minSize).groups.nonEmpty` holds exactly
-  * when `minSize` is at most the largest duplicated block's node count. Raising the floor can only
-  * remove blocks (never add larger ones), so the largest block size is a stable threshold.
+  * absurdly high floor admits nothing; a floor equal to the block's own node count still admits
+  * it). This suite generalises that to the full boundary contract: `minSize` only *filters* the
+  * fixed set of duplicate blocks the fixture contains, so `analyze(minSize).groups.nonEmpty` holds
+  * exactly when `minSize` is at most the largest duplicated block's node count. Raising the floor
+  * can only remove blocks (never add larger ones), so the largest block size is a stable threshold.
   */
 class DuplicationAnalyzerPropertySuite extends munit.ScalaCheckSuite:
 
@@ -43,5 +43,8 @@ class DuplicationAnalyzerPropertySuite extends munit.ScalaCheckSuite:
 
   property("analyze(minSize).groups.nonEmpty holds iff minSize <= the largest duplicated block"):
     forAll(Gen.chooseNum(1, maxBlockSize * 2)) { m =>
-      DuplicationAnalyzer.analyze(dupIndex, root, minSize = m).groups.nonEmpty == (m <= maxBlockSize)
+      DuplicationAnalyzer
+        .analyze(dupIndex, root, minSize = m)
+        .groups
+        .nonEmpty == (m <= maxBlockSize)
     }


### PR DESCRIPTION
Closes #149. Executes child 3 of the property-based testing roadmap (#71): convert the highest-value example tests into property-based tests, reusing the shared ScalaCheck patterns.

## Investigation
The `docs/testing/pb-audit.md` ranked-8 candidate list is the source of truth (roadmap doc #147 not yet written). Cross-referencing against already-landed work:
- #1 ConfigMerge idempotency + #3 findSymbol ranking — done in #193.
- #2 ModelsSuite — already deleted (superseded by `ModelsPropertySuite`).
- #5 StructureMetrics pure fns — already fully covered by the existing `GraphMetricsPropertySuite`.

Remaining truly-unconverted high-value candidates: **#4, #6, #7** — converted here.

## Changes
- **#4 linearize** → `AnalyzerHelpersPropertySuite` (+2 props): over any generated class DAG (acyclicity guaranteed by only allowing `c_i extends c_j` for `j > i`), `linearize` returns each ancestor exactly once and yields exactly the transitive parent set of the root — generalizes the fixed diamond example.
- **#6 methodSignature + resolveImplicits** → new `AnalyzerCorePropertySuite` (2 props): a parameter list is flagged implicit iff non-empty AND all params implicit; `resolveImplicits.chosen` is defined iff exactly one candidate produces the type, with candidate count == number of givens.
- **#7 duplication minSize** → new `DuplicationAnalyzerPropertySuite` (1 prop): `analyze(minSize).groups.nonEmpty` iff `minSize <= largest duplicated block` (the floor only filters a fixed block set, so the max block size is a stable threshold).

## Key decisions
- **Additive, zero net loss.** Original concrete tests (diamond, the two Core invariants, the minSize spot-check) are kept as regression anchors; the new properties generalize their sampled points. This mirrors how `AnalyzerHelpersPropertySuite` already coexists with `AnalyzerHelpersSuite`.
- **SemanticDB-dogfood / PC / snapshot suites left untouched** — they stay golden/example per the audit's guidance (non-deterministic or shape-specific, not property-convertible).
- **One PropertySuite per source suite**, matching the existing repo convention.

## Verification
`analysis/testOnly` on the three suites → 21 tests pass (Helpers 18 = 16 existing + 2 new; Core 2; Duplication 1).