### PR TITLE
feat: add idempotent setup subcommand to scalasemantic-mcp.sh/.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,21 @@ sbt mcpClientConfig compile
 
 For other build tools, manual setups, or advanced options, see the [Integration guide](docs/getting-started/integration.md).
 
-If you already have Scala CLI installed and want a build-tool-neutral setup:
+For a build-tool-neutral setup that needs only `java` (no sbt, no Scala CLI), download the launcher
+once and run `setup`. It idempotently enables SemanticDB, writes the agent steering files, and
+merges an MCP server entry into every client config it finds — re-running is always safe:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/MercurieVV/ScalaSemantic/master/scripts/scalasemantic-mcp.sh -o scalasemantic-mcp.sh && chmod +x scalasemantic-mcp.sh
+./scalasemantic-mcp.sh setup
+```
+
+```powershell
+iwr https://raw.githubusercontent.com/MercurieVV/ScalaSemantic/master/scripts/scalasemantic-mcp.ps1 -OutFile scalasemantic-mcp.ps1
+.\scalasemantic-mcp.ps1 setup
+```
+
+If you already have Scala CLI installed, the equivalent `setup` is also available as a script:
 
 ```sh
 scala-cli https://raw.githubusercontent.com/MercurieVV/ScalaSemantic/master/scripts/scalasemantic-mcp.scala setup

--- a/scripts/lib/mcp-config-merge.py
+++ b/scripts/lib/mcp-config-merge.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Idempotently merge one MCP server entry into a client config file.
+
+Ported from the JSON/TOML/YAML merge logic in scalasemantic-mcp.scala so the
+shell (.sh) launcher can reuse it instead of reimplementing bracket-matching
+JSON parsing in POSIX sh. Only touches the one server entry named `server`;
+every other key in the file is left untouched.
+
+Usage:
+    mcp-config-merge.py <json|toml|yaml> <target-file> <server-name> <argv-json> <extra-json>
+
+    argv-json:  JSON array, e.g. '["scalasemantic-mcp.sh","serve","/proj","/cp.txt"]'
+    extra-json: JSON object of extra fields merged into the JSON entry only
+                (ignored for toml/yaml), e.g. '{"timeout": 60000}'
+"""
+import json
+import sys
+from pathlib import Path
+
+
+def merge_json(existing: str, server: str, argv: list[str], extra: dict) -> str:
+    try:
+        doc = json.loads(existing) if existing.strip() else {}
+    except json.JSONDecodeError:
+        doc = {}
+    if not isinstance(doc, dict):
+        doc = {}
+    servers = doc.setdefault("mcpServers", {})
+    entry = {"command": argv[0], "args": argv[1:]}
+    entry.update(extra)
+    servers[server] = entry
+    return json.dumps(doc, indent=2) + "\n"
+
+
+def merge_toml(existing: str, server: str, argv: list[str]) -> str:
+    args_toml = "[" + ", ".join(json.dumps(a) for a in argv[1:]) + "]"
+    fresh = (
+        f'[mcp_servers.{server}]\n'
+        f'command = {json.dumps(argv[0])}\n'
+        f'args = {args_toml}\n'
+        f'startup_timeout_sec = 60\n'
+        f'tool_timeout_sec = 60'
+    )
+    if not existing.strip():
+        return fresh + "\n"
+    header = f"[mcp_servers.{server}]"
+    lines = existing.split("\n")
+    try:
+        idx = next(i for i, l in enumerate(lines) if l.strip() == header)
+    except StopIteration:
+        sep = "" if existing.endswith("\n") else "\n"
+        return existing + sep + "\n" + fresh + "\n"
+    end = next((i for i in range(idx + 1, len(lines)) if lines[i].strip().startswith("[")), len(lines))
+    return "\n".join(lines[:idx] + fresh.split("\n") + lines[end:]).rstrip("\n") + "\n"
+
+
+def continue_item(server: str, argv: list[str]) -> str:
+    command, rest = argv[0], argv[1:]
+    args = ""
+    if rest:
+        args = "\n    args:" + "".join(f"\n      - {json.dumps(a)}" for a in rest)
+    return f'  - name: {json.dumps(server)}\n    command: {json.dumps(command)}{args}\n    connectionTimeout: 60000'
+
+
+def merge_yaml(existing: str, server: str, argv: list[str]) -> str:
+    item = continue_item(server, argv)
+    fresh = (
+        "name: ScalaSemantic MCP\n"
+        "version: 1.0.0\n"
+        "schema: v1\n"
+        "mcpServers:\n" + item + "\n"
+    )
+    if not existing.strip():
+        return fresh
+    lines = existing.split("\n")
+    try:
+        ms_idx = next(i for i, l in enumerate(lines) if l.strip() == "mcpServers:")
+    except StopIteration:
+        sep = "" if existing.endswith("\n") else "\n"
+        return existing + sep + "mcpServers:\n" + item + "\n"
+    block_end = next(
+        (i for i in range(ms_idx + 1, len(lines)) if lines[i].strip() and not lines[i].startswith(" ")),
+        len(lines),
+    )
+    name_line = f"- name: {json.dumps(server)}"
+    item_idx = next(
+        (i for i in range(ms_idx + 1, block_end) if lines[i].strip() == name_line), None
+    )
+    if item_idx is None:
+        out = lines[: ms_idx + 1] + item.split("\n") + lines[ms_idx + 1 :]
+    else:
+        indent = len(lines[item_idx]) - len(lines[item_idx].lstrip(" "))
+        e = next(
+            (
+                i
+                for i in range(item_idx + 1, block_end)
+                if (len(lines[i]) - len(lines[i].lstrip(" "))) == indent and lines[i].strip().startswith("- ")
+            ),
+            block_end,
+        )
+        out = lines[:item_idx] + item.split("\n") + lines[e:]
+    return "\n".join(out).rstrip("\n") + "\n"
+
+
+def main() -> None:
+    if len(sys.argv) != 6:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    fmt, target, server, argv_json, extra_json = sys.argv[1:]
+    argv = json.loads(argv_json)
+    extra = json.loads(extra_json)
+    path = Path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text() if path.exists() else ""
+    if fmt == "json":
+        out = merge_json(existing, server, argv, extra)
+    elif fmt == "toml":
+        out = merge_toml(existing, server, argv)
+    elif fmt == "yaml":
+        out = merge_yaml(existing, server, argv)
+    else:
+        print(f"unknown format: {fmt}", file=sys.stderr)
+        sys.exit(2)
+    path.write_text(out)
+    print(f"scalasemantic-mcp: wrote {path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scalasemantic-mcp.ps1
+++ b/scripts/scalasemantic-mcp.ps1
@@ -1,29 +1,35 @@
-# Auto-download + run the ScalaSemantic MCP server (Windows / PowerShell).
+# Default installer + launcher for the ScalaSemantic MCP server (Windows / PowerShell). Two
+# subcommands:
 #
-# Two paths, picked automatically:
-#   1. if `cs` (coursier) is on PATH — resolve + cache the artifact from Maven Central and run it;
-#   2. otherwise — download the fat jar from the latest GitHub Release once (cached by version) and
-#      run it with `java -jar`.
+#   scalasemantic-mcp.ps1 setup [-Project DIR] [-ClientName all|claude|codex|gemini|cline|roo|continue|antigravity]
+#       Idempotently: enables SemanticDB in the target project's sbt build, writes/updates
+#       SCALA_SEMANTIC_RULES.md + the per-client steering file (CLAUDE.md/AGENTS.md/.cursorrules/...),
+#       prefetches (downloads+caches) the server jar, and merges an MCP server entry into each
+#       client's config file (.mcp.json, .codex/config.toml, .gemini/settings.json, ...) — re-running
+#       is safe, it only ever touches the "scala-semantic" entry.
+#   scalasemantic-mcp.ps1 serve <semanticdb-root> [classpath]   (also the default with no subcommand)
+#       Runs the server. Two paths, picked automatically:
+#         1. if `cs` (coursier) is on PATH — resolve + cache the artifact from Maven Central and run it;
+#         2. otherwise — download the fat jar from the latest GitHub Release once (cached by version)
+#            and run it with `java -jar`.
 # Download progress is suppressed so stdout carries only the JSON-RPC stream.
 #
 # Cold-start strategy (jar path): once ANY version is cached, a launch serves the newest cached jar
 # IMMEDIATELY and forks a detached background updater that fetches the latest release for the NEXT
 # launch. So the download never races the client's connect timeout after the first time. The very
-# first launch (empty cache) still blocks on the download — run `--prefetch` once, or `sbt
-# mcpClientConfig` (which prefetches for you), to warm the cache ahead of the first real connect.
+# first launch (empty cache) still blocks on the download — run `setup` (or plain `-Prefetch`) once
+# to warm the cache ahead of the first real connect.
 #
-# Usage:   powershell -ExecutionPolicy Bypass -File scalasemantic-mcp.ps1 [--prefetch] <semanticdb-root> [classpath]
-#   --prefetch  Download + cache the artifact, then exit WITHOUT serving. Run this once before
-#               adding the server to your MCP config so the first real connect hits a warm cache
-#               instead of racing the client's connection timeout while an ~88 MB jar downloads.
-#   All other arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional
-#   arg 2 = the compile classpath (a path-separated string or a file containing one) that enables
-#   the presentation-compiler backend for live overlay of uncompiled buffers.
+#   -Prefetch  Download + cache the artifact, then exit WITHOUT serving.
+#   All other arguments to `serve` are forwarded verbatim to the server: arg 1 = SemanticDB root,
+#   optional arg 2 = the compile classpath (a path-separated string or a file containing one) that
+#   enables the presentation-compiler backend for live overlay of uncompiled buffers.
 #   --log / --log-output  Forwarded to the server to turn on its (off-by-default) file log:
 #               --log writes a startup line + one line per tool call; --log-output additionally
 #               logs each JSON-RPC response sent to the LLM. (Env equivalents: SCALASEMANTIC_LOG,
 #               SCALASEMANTIC_LOG_OUTPUT; log file path via SCALASEMANTIC_LOG_FILE.)
-# Requires: java on PATH (and optionally coursier). No sbt needed.
+# Requires: java on PATH (and optionally coursier). No sbt, no python — config merging uses only
+# built-in PowerShell JSON/text handling.
 #
 # Pin a version instead of "latest" with:  $env:SCALASEMANTIC_VERSION = "v0.1.4"  (pinned launches
 # skip the background updater — you get exactly that version).
@@ -35,6 +41,7 @@ $Org      = 'io.github.mercurievv'
 $Artifact = 'scalasemantic-mcp_3'
 $Main     = 'com.github.mercurievv.scalasemantic.mcpServer'
 $Cache    = Join-Path $env:LOCALAPPDATA 'scalasemantic-mcp'
+$Self     = $PSCommandPath
 
 New-Item -ItemType Directory -Force -Path $Cache | Out-Null
 
@@ -75,71 +82,353 @@ function Get-Release([string]$Tag) {
   }
 }
 
-$Rest = @($args)
+# ----------------------------------------------------------------------------------------------
+# serve: run the server (coursier or cached fat jar). $Rest is forwarded verbatim to the server.
+# Returns the jar's exit code (or throws on unresolvable/offline-without-cache).
+# ----------------------------------------------------------------------------------------------
+function Serve-Main {
+  param([string[]]$Rest = @())
 
-# --bg-fetch: internal mode forked (detached) by a cached-serve launch to fetch the latest release
-# for the NEXT launch, then exit. A lock file keeps concurrent launches from racing the same `.tmp`.
-if ($Rest.Count -ge 1 -and $Rest[0] -eq '--bg-fetch') {
-  $lock = Join-Path $Cache '.bgfetch.lock'
-  try {
-    $fs = [System.IO.File]::Open($lock, 'CreateNew', 'Write', 'None')
+  # --bg-fetch: internal mode forked (detached) by a cached-serve launch to fetch the latest release
+  # for the NEXT launch, then exit. A lock file keeps concurrent launches from racing the same `.tmp`.
+  if ($Rest.Count -ge 1 -and $Rest[0] -eq '--bg-fetch') {
+    $lock = Join-Path $Cache '.bgfetch.lock'
     try {
-      $tag = Resolve-Tag
-      if ($tag) { [void](Get-Release $tag) }
-    } finally { $fs.Close(); Remove-Item $lock -ErrorAction SilentlyContinue }
-  } catch { } # lock held by another launch — let it do the update
-  exit 0
-}
+      $fs = [System.IO.File]::Open($lock, 'CreateNew', 'Write', 'None')
+      try {
+        $tag = Resolve-Tag
+        if ($tag) { [void](Get-Release $tag) }
+      } finally { $fs.Close(); Remove-Item $lock -ErrorAction SilentlyContinue }
+    } catch { } # lock held by another launch — let it do the update
+    return
+  }
 
-# --prefetch: warm the cache and exit, never serve (decouples the download from the first connect).
-$Prefetch = $false
-if ($Rest.Count -ge 1 -and $Rest[0] -eq '--prefetch') {
-  $Prefetch = $true
-  $Rest = @($Rest[1..($Rest.Count - 1)])
-}
+  # -Prefetch (or legacy --prefetch): warm the cache and return, never serve.
+  $Prefetch = $false
+  if ($Rest.Count -ge 1 -and $Rest[0] -in @('--prefetch', '-Prefetch')) {
+    $Prefetch = $true
+    $Rest = Slice-Array $Rest 1 ($Rest.Count - 1)
+  }
 
-# --- path 1: coursier (preferred) ----------------------------------------------------------------
-if (Get-Command cs -ErrorAction SilentlyContinue) {
-  $ver = if ($env:SCALASEMANTIC_VERSION) { $env:SCALASEMANTIC_VERSION -replace '^v', '' } else { 'latest.release' }
+  # --- path 1: coursier (preferred) --------------------------------------------------------------
+  if (Get-Command cs -ErrorAction SilentlyContinue) {
+    $ver = if ($env:SCALASEMANTIC_VERSION) { $env:SCALASEMANTIC_VERSION -replace '^v', '' } else { 'latest.release' }
+    if ($Prefetch) {
+      [Console]::Error.WriteLine("scalasemantic-mcp: prefetching ${Org}:${Artifact}:$ver via coursier")
+      & cs fetch "${Org}:${Artifact}:$ver"
+      return $LASTEXITCODE
+    }
+    [Console]::Error.WriteLine("scalasemantic-mcp: launching ${Org}:${Artifact}:$ver via coursier")
+    & cs launch "${Org}:${Artifact}:$ver" -M $Main -- @Rest
+    return $LASTEXITCODE
+  }
+
+  # --- path 2: fat jar from GitHub Releases ------------------------------------------------------
+  $Cached = Get-NewestCached
+
+  if (-not $Prefetch -and -not $env:SCALASEMANTIC_VERSION -and $Cached) {
+    # Cached jar present and not pinned: serve it NOW (zero download latency) and fork a detached
+    # updater that pulls the latest release for the next launch. The child runs hidden so it does not
+    # hold the JSON-RPC stdout stream.
+    $Jar = $Cached
+    try {
+      Start-Process -FilePath 'powershell' `
+        -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $Self, 'serve', '--bg-fetch') `
+        -WindowStyle Hidden | Out-Null
+    } catch { } # best-effort updater; serving the cached jar is what matters
+  } else {
+    # No cache (must block once), or pinned (fetch exactly that version), or prefetch (warm fully).
+    $Tag = Resolve-Tag
+    if ($Tag) { [void](Get-Release $Tag) }
+    $Jar = if ($Tag) { Join-Path $Cache "scalasemantic-mcp-$Tag.jar" } else { $null }
+    if (-not $Jar -or -not (Test-Path $Jar)) {
+      $Jar = Get-NewestCached
+      if (-not $Jar) { throw "scalasemantic-mcp: cannot resolve a release and no cached jar found" }
+      [Console]::Error.WriteLine("scalasemantic-mcp: offline — using cached $(Split-Path $Jar -Leaf)")
+    }
+  }
+
   if ($Prefetch) {
-    [Console]::Error.WriteLine("scalasemantic-mcp: prefetching ${Org}:${Artifact}:$ver via coursier")
-    & cs fetch "${Org}:${Artifact}:$ver"
-    exit $LASTEXITCODE
+    [Console]::Error.WriteLine("scalasemantic-mcp: prefetched $(Split-Path $Jar -Leaf)")
+    return 0
   }
-  [Console]::Error.WriteLine("scalasemantic-mcp: launching ${Org}:${Artifact}:$ver via coursier")
-  & cs launch "${Org}:${Artifact}:$ver" -M $Main -- @Rest
-  exit $LASTEXITCODE
+
+  & java -jar $Jar @Rest
+  return $LASTEXITCODE
 }
 
-# --- path 2: fat jar from GitHub Releases --------------------------------------------------------
-$Cached = Get-NewestCached
+# ----------------------------------------------------------------------------------------------
+# setup: idempotently configure a project + its MCP clients to launch this script via `serve`.
+# ----------------------------------------------------------------------------------------------
 
-if (-not $Prefetch -and -not $env:SCALASEMANTIC_VERSION -and $Cached) {
-  # Cached jar present and not pinned: serve it NOW (zero download latency) and fork a detached
-  # updater that pulls the latest release for the next launch. The child runs hidden so it does not
-  # hold the JSON-RPC stdout stream.
-  $Jar = $Cached
-  try {
-    Start-Process -FilePath 'powershell' `
-      -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath, '--bg-fetch') `
-      -WindowStyle Hidden | Out-Null
-  } catch { } # best-effort updater; serving the cached jar is what matters
-} else {
-  # No cache (must block once), or pinned (fetch exactly that version), or prefetch (warm fully).
-  $Tag = Resolve-Tag
-  if ($Tag) { [void](Get-Release $Tag) }
-  $Jar = if ($Tag) { Join-Path $Cache "scalasemantic-mcp-$Tag.jar" } else { $null }
-  if (-not $Jar -or -not (Test-Path $Jar)) {
-    $Jar = Get-NewestCached
-    if (-not $Jar) { throw "scalasemantic-mcp: cannot resolve a release and no cached jar found" }
-    [Console]::Error.WriteLine("scalasemantic-mcp: offline — using cached $(Split-Path $Jar -Leaf)")
+$AllClients = @('claude', 'codex', 'gemini', 'cline', 'roo', 'continue', 'antigravity')
+
+function Get-TargetFor([string]$Client) {
+  switch ($Client.Trim().ToLowerInvariant()) {
+    { $_ -in @('codex', 'openai', 'openai-codex') } { return @{ RelPath = '.codex/config.toml'; Fmt = 'toml' } }
+    { $_ -in @('claude', 'claude-code', 'anthropic') } { return @{ RelPath = '.mcp.json'; Fmt = 'json' } }
+    { $_ -in @('gemini', 'google', 'google-gemini', 'gemini-cli') } {
+      return @{ RelPath = '.gemini/settings.json'; Fmt = 'json'; Extra = @{ timeout = 60000 } }
+    }
+    { $_ -in @('antigravity', 'antigravity-cli', 'agy') } { return @{ RelPath = '.agents/mcp_config.json'; Fmt = 'json' } }
+    { $_ -eq 'cline' } { return @{ RelPath = '.cline/mcp.json'; Fmt = 'json'; Extra = @{ disabled = $false; autoApprove = @() } } }
+    { $_ -in @('roo', 'roo-code') } {
+      return @{ RelPath = '.roo/mcp.json'; Fmt = 'json'; Extra = @{ disabled = $false; alwaysAllow = @(); timeout = 60 } }
+    }
+    { $_ -in @('continue', 'continue-dev') } { return @{ RelPath = '.continue/config.yaml'; Fmt = 'yaml' } }
+    { $_ -in @('generic', 'generic-json', 'json', 'oss', 'open-source', 'free') } { return @{ RelPath = '.mcp.json'; Fmt = 'json' } }
+    default { throw "unsupported client '$Client'; use claude, codex, gemini, cline, roo, continue, antigravity, generic-json, or all" }
   }
 }
 
-if ($Prefetch) {
-  [Console]::Error.WriteLine("scalasemantic-mcp: prefetched $(Split-Path $Jar -Leaf)")
-  exit 0
+function Ensure-SemanticdbConfig([string]$Project) {
+  $sbtFiles = Get-ChildItem -Path $Project -Filter '*.sbt' -File -ErrorAction SilentlyContinue
+  if ($sbtFiles | Where-Object { (Get-Content $_.FullName -Raw) -match 'semanticdbEnabled' }) { return }
+  if (-not $sbtFiles) {
+    [Console]::Error.WriteLine("scalasemantic-mcp: no .sbt files found in $Project; enable SemanticDB in your build tool before using ScalaSemantic")
+    return
+  }
+  $file = Join-Path $Project 'scala-semantic.sbt'
+  if (-not (Test-Path $file)) {
+    Set-Content -Path $file -NoNewline -Value "// Generated by ScalaSemantic MCP setup.`nsemanticdbEnabled := true`n"
+    [Console]::Error.WriteLine("scalasemantic-mcp: created $file")
+  }
 }
 
-& java -jar $Jar @Rest
-exit $LASTEXITCODE
+function Ensure-SteerFile([string]$Project, [string]$Client) {
+  $target = $null; $ref = $null
+  switch ($Client.Trim().ToLowerInvariant()) {
+    { $_ -in @('claude', 'claude-code', 'anthropic') } {
+      $target = Join-Path $Project 'CLAUDE.md'; $ref = '[SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md)'
+    }
+    { $_ -in @('gemini', 'google', 'google-gemini', 'gemini-cli', 'antigravity', 'antigravity-cli', 'agy') } {
+      $target = Join-Path $Project 'AGENTS.md'; $ref = '@SCALA_SEMANTIC_RULES.md'
+    }
+    { $_ -in @('codex', 'openai', 'openai-codex') } {
+      $target = Join-Path $Project '.cursorrules'; $ref = '[SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md)'
+    }
+    { $_ -in @('cline', 'roo', 'roo-code') } {
+      $target = Join-Path $Project '.clinerules'; $ref = '[SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md)'
+    }
+    { $_ -in @('continue', 'continue-dev') } {
+      $target = Join-Path $Project '.continue/rules.txt'; $ref = 'SCALA_SEMANTIC_RULES.md'
+    }
+    default { return }
+  }
+  if (Test-Path $target) {
+    $current = Get-Content $target -Raw
+    if ($current -match 'SCALA_CODE_RULES\.md') {
+      Set-Content -Path $target -NoNewline -Value ($current -replace 'SCALA_CODE_RULES\.md', 'SCALA_SEMANTIC_RULES.md')
+      [Console]::Error.WriteLine("scalasemantic-mcp: updated $target")
+    } elseif ($current -notmatch 'SCALA_SEMANTIC_RULES\.md') {
+      Add-Content -Path $target -Value "`n## Scala Code Rules`nPlease follow the rules in $ref.`n"
+      [Console]::Error.WriteLine("scalasemantic-mcp: updated $target")
+    }
+  } else {
+    New-Item -ItemType Directory -Force -Path (Split-Path $target -Parent) | Out-Null
+    $content = if ((Split-Path $target -Leaf) -eq 'AGENTS.md') {
+      "# AGENTS.md instructions`n`n<INSTRUCTIONS>`n$ref`n</INSTRUCTIONS>`n"
+    } else {
+      "# Project Rules`n`nPlease follow the rules in $ref for working with Scala code.`n"
+    }
+    Set-Content -Path $target -NoNewline -Value $content
+    [Console]::Error.WriteLine("scalasemantic-mcp: created $target")
+  }
+}
+
+function Ensure-Rules([string]$Project, [string]$Client) {
+  $rules = Join-Path $Project 'SCALA_SEMANTIC_RULES.md'
+  if (-not (Test-Path $rules)) {
+    Set-Content -Path $rules -NoNewline -Value @'
+# Scala Semantic Rules
+
+For Scala source questions, use ScalaSemantic MCP tools before shell text tools. Preferably compile code before usage, then more ScalaSemantic functions can be used with better results.
+
+Do not use `cat`, `sed`, `rg`, or similar tools to inspect `.scala` files for symbol, type, signature, hierarchy, implicit, reference, or call-path questions when ScalaSemantic tools are available.
+
+Use shell for builds, tests, git, config, docs, scripts, and non-Scala text work.
+'@
+    [Console]::Error.WriteLine("scalasemantic-mcp: created $rules")
+  }
+  $clients = if ($Client.Trim().ToLowerInvariant() -eq 'all') { $AllClients } else { @($Client) }
+  foreach ($c in $clients) { Ensure-SteerFile $Project $c }
+}
+
+# Safe array slice: PowerShell's `$a[$from..$to]` silently walks BACKWARDS when $from > $to (e.g.
+# empty-args count-1 == -1, or a match at the very first/last line), which corrupts the merge. This
+# always returns the ascending sub-range, or @() when it would be empty/invalid.
+function Slice-Array([array]$Items, [int]$From, [int]$To) {
+  if ($null -eq $Items -or $Items.Count -eq 0 -or $From -gt $To -or $From -ge $Items.Count -or $To -lt 0) { return @() }
+  $From = [Math]::Max($From, 0)
+  $To = [Math]::Min($To, $Items.Count - 1)
+  return @($Items[$From..$To])
+}
+
+# Renders/merges the single "scala-semantic" entry into a JSON MCP config, preserving everything
+# else in the file untouched.
+function Merge-Json([string]$Existing, [string]$Server, [string[]]$Argv, [hashtable]$Extra) {
+  $doc = $null
+  if ($Existing -and $Existing.Trim()) {
+    try { $doc = $Existing | ConvertFrom-Json } catch { $doc = $null }
+  }
+  if (-not $doc) { $doc = [PSCustomObject]@{} }
+  if (-not ($doc.PSObject.Properties.Name -contains 'mcpServers')) {
+    $doc | Add-Member -NotePropertyName mcpServers -NotePropertyValue ([PSCustomObject]@{})
+  }
+  $entry = [ordered]@{ command = $Argv[0]; args = Slice-Array $Argv 1 ($Argv.Count - 1) }
+  foreach ($k in $Extra.Keys) { $entry[$k] = $Extra[$k] }
+  if ($doc.mcpServers.PSObject.Properties.Name -contains $Server) {
+    $doc.mcpServers.PSObject.Properties.Remove($Server)
+  }
+  $doc.mcpServers | Add-Member -NotePropertyName $Server -NotePropertyValue ([PSCustomObject]$entry)
+  return ($doc | ConvertTo-Json -Depth 10) + "`n"
+}
+
+function Render-CodexToml([string]$Server, [string[]]$Argv) {
+  $rest = Slice-Array $Argv 1 ($Argv.Count - 1)
+  $argsToml = '[' + (($rest | ForEach-Object { $_ | ConvertTo-Json -Compress }) -join ', ') + ']'
+  return @"
+[mcp_servers.$Server]
+command = $($Argv[0] | ConvertTo-Json -Compress)
+args = $argsToml
+startup_timeout_sec = 60
+tool_timeout_sec = 60
+"@
+}
+
+function Merge-Toml([string]$Existing, [string]$Server, [string[]]$Argv) {
+  $fresh = Render-CodexToml $Server $Argv
+  if (-not ($Existing -and $Existing.Trim())) { return $fresh + "`n" }
+  $header = "[mcp_servers.$Server]"
+  $lines = $Existing -split "`n"
+  $idx = -1
+  for ($i = 0; $i -lt $lines.Count; $i++) { if ($lines[$i].Trim() -eq $header) { $idx = $i; break } }
+  if ($idx -lt 0) {
+    $sep = if ($Existing.EndsWith("`n")) { '' } else { "`n" }
+    return $Existing + $sep + "`n" + $fresh + "`n"
+  }
+  $end = $lines.Count
+  for ($i = $idx + 1; $i -lt $lines.Count; $i++) { if ($lines[$i].Trim().StartsWith('[')) { $end = $i; break } }
+  $out = ((Slice-Array $lines 0 ($idx - 1)) + @($fresh -split "`n") + (Slice-Array $lines $end ($lines.Count - 1))) -join "`n"
+  return $out.TrimEnd("`n") + "`n"
+}
+
+function Get-ContinueItem([string]$Server, [string[]]$Argv) {
+  $args = ''
+  $rest = Slice-Array $Argv 1 ($Argv.Count - 1)
+  if ($rest.Count -gt 0) {
+    $args = "`n    args:" + (($rest | ForEach-Object { "`n      - $($_ | ConvertTo-Json -Compress)" }) -join '')
+  }
+  return "  - name: $($Server | ConvertTo-Json -Compress)`n    command: $($Argv[0] | ConvertTo-Json -Compress)$args`n    connectionTimeout: 60000"
+}
+
+function Merge-Yaml([string]$Existing, [string]$Server, [string[]]$Argv) {
+  $item = Get-ContinueItem $Server $Argv
+  $fresh = "name: ScalaSemantic MCP`nversion: 1.0.0`nschema: v1`nmcpServers:`n$item`n"
+  if (-not ($Existing -and $Existing.Trim())) { return $fresh }
+  $lines = $Existing -split "`n"
+  $msIdx = -1
+  for ($i = 0; $i -lt $lines.Count; $i++) { if ($lines[$i].Trim() -eq 'mcpServers:') { $msIdx = $i; break } }
+  if ($msIdx -lt 0) {
+    $sep = if ($Existing.EndsWith("`n")) { '' } else { "`n" }
+    return $Existing + $sep + "mcpServers:`n" + $item + "`n"
+  }
+  $blockEnd = $lines.Count
+  for ($i = $msIdx + 1; $i -lt $lines.Count; $i++) {
+    if ($lines[$i].Trim() -and -not $lines[$i].StartsWith(' ')) { $blockEnd = $i; break }
+  }
+  $nameLine = "- name: $($Server | ConvertTo-Json -Compress)"
+  $itemIdx = -1
+  for ($i = $msIdx + 1; $i -lt $blockEnd; $i++) { if ($lines[$i].Trim() -eq $nameLine) { $itemIdx = $i; break } }
+  if ($itemIdx -lt 0) {
+    $out = ((Slice-Array $lines 0 $msIdx) + @($item -split "`n") + (Slice-Array $lines ($msIdx + 1) ($lines.Count - 1))) -join "`n"
+  } else {
+    $indent = $lines[$itemIdx].Length - $lines[$itemIdx].TrimStart(' ').Length
+    $e = $blockEnd
+    for ($i = $itemIdx + 1; $i -lt $blockEnd; $i++) {
+      $li = $lines[$i].Length - $lines[$i].TrimStart(' ').Length
+      if ($li -eq $indent -and $lines[$i].Trim().StartsWith('- ')) { $e = $i; break }
+    }
+    $before = Slice-Array $lines 0 ($itemIdx - 1)
+    $after = Slice-Array $lines $e ($lines.Count - 1)
+    $out = ($before + @($item -split "`n") + $after) -join "`n"
+  }
+  return $out.TrimEnd("`n") + "`n"
+}
+
+function Write-ClientConfigs([string]$Project, [string]$Client, [string[]]$CommandArgv) {
+  $clients = if ($Client.Trim().ToLowerInvariant() -eq 'all') { $AllClients } else { @($Client) }
+  foreach ($c in $clients) {
+    $t = Get-TargetFor $c
+    $out = Join-Path $Project $t.RelPath
+    New-Item -ItemType Directory -Force -Path (Split-Path $out -Parent) | Out-Null
+    $existing = if (Test-Path $out) { Get-Content $out -Raw } else { '' }
+    $extra = if ($t.Extra) { $t.Extra } else { @{} }
+    $merged = switch ($t.Fmt) {
+      'json' { Merge-Json $existing 'scala-semantic' $CommandArgv $extra }
+      'toml' { Merge-Toml $existing 'scala-semantic' $CommandArgv }
+      'yaml' { Merge-Yaml $existing 'scala-semantic' $CommandArgv }
+    }
+    Set-Content -Path $out -NoNewline -Value $merged
+    [Console]::Error.WriteLine("scalasemantic-mcp: wrote $out")
+  }
+}
+
+function Setup-Main {
+  param([string[]]$Rest = @())
+
+  $Project = (Get-Location).Path
+  $Client = 'all'
+  $Command = @('powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $Self)
+  $SkipSemanticdb = $false
+
+  $i = 0
+  while ($i -lt $Rest.Count) {
+    switch ($Rest[$i]) {
+      { $_ -in @('--project', '--root', '-Project') } {
+        New-Item -ItemType Directory -Force -Path $Rest[$i + 1] | Out-Null
+        $Project = (Resolve-Path $Rest[$i + 1]).Path
+        $i += 2
+      }
+      { $_ -in @('--client', '-c', '-ClientName') } { $Client = $Rest[$i + 1]; $i += 2 }
+      { $_ -in @('--command', '-Command') } { $Command = @($Rest[$i + 1]); $i += 2 }
+      { $_ -in @('--skip-semanticdb-config', '-SkipSemanticdbConfig') } { $SkipSemanticdb = $true; $i += 1 }
+      { $_ -in @('--help', '-h') } { Show-Usage; return }
+      default { throw "scalasemantic-mcp: unknown setup argument: $($Rest[$i])" }
+    }
+  }
+
+  if (-not $SkipSemanticdb) { Ensure-SemanticdbConfig $Project }
+  Ensure-Rules $Project $Client
+
+  [Console]::Error.WriteLine("scalasemantic-mcp: prefetching the server jar ...")
+  try { Serve-Main -Rest @('-Prefetch', $Project) | Out-Null }
+  catch { [Console]::Error.WriteLine("scalasemantic-mcp: prefetch skipped (will download on first serve)") }
+
+  $CpFile = Join-Path $Cache 'scalasemantic-mcp-classpath.txt'
+  if (-not (Test-Path $CpFile)) { New-Item -ItemType File -Path $CpFile | Out-Null }
+
+  $argv = @($Command) + @('serve', $Project, $CpFile)
+  Write-ClientConfigs $Project $Client $argv
+}
+
+function Show-Usage {
+  [Console]::Error.WriteLine(@"
+Usage:
+  scalasemantic-mcp.ps1 setup [-ClientName all|claude|codex|gemini|cline|roo|continue|antigravity] [-Project DIR]
+  scalasemantic-mcp.ps1 serve <semanticdb-root> [classpath-file] [--log] [--log-output]
+
+setup writes MCP client config that launches this same script:
+  command = powershell
+  args    = [-NoProfile, -ExecutionPolicy, Bypass, -File, $Self, serve, <project>, <classpath-file>]
+"@)
+}
+
+$AllArgs = @($args)
+$FirstArg = if ($AllArgs.Count -gt 0) { $AllArgs[0] } else { '' }
+switch ($FirstArg) {
+  { $_ -in @('setup', 'configure', 'install') } { Setup-Main -Rest (Slice-Array $AllArgs 1 ($AllArgs.Count - 1)); exit 0 }
+  { $_ -in @('serve', 'run') } { exit (Serve-Main -Rest (Slice-Array $AllArgs 1 ($AllArgs.Count - 1))) }
+  { $_ -in @('--help', '-h', 'help') } { Show-Usage; exit 0 }
+  default { exit (Serve-Main -Rest $AllArgs) }
+}

--- a/scripts/scalasemantic-mcp.sh
+++ b/scripts/scalasemantic-mcp.sh
@@ -1,31 +1,36 @@
 #!/usr/bin/env sh
-# Auto-download + run the ScalaSemantic MCP server (Linux / macOS).
+# Default installer + launcher for the ScalaSemantic MCP server (Linux / macOS). Two subcommands:
 #
-# Two paths, picked automatically:
-#   1. if `cs` (coursier) is on PATH — resolve + cache the artifact from Maven Central and run it
-#      (the JVM-native, npx-style way);
-#   2. otherwise — download the fat jar from the latest GitHub Release once (cached by version) and
-#      run it with `java -jar`.
+#   scalasemantic-mcp.sh setup [--project DIR] [--client all|claude|codex|gemini|cline|roo|continue|antigravity]
+#       Idempotently: enables SemanticDB in the target project's sbt build, writes/updates
+#       SCALA_SEMANTIC_RULES.md + the per-client steering file (CLAUDE.md/AGENTS.md/.cursorrules/...),
+#       prefetches (downloads+caches) the server jar, and merges an MCP server entry into each
+#       client's config file (.mcp.json, .codex/config.toml, .gemini/settings.json, ...) — re-running
+#       is safe, it only ever touches the "scala-semantic" entry.
+#   scalasemantic-mcp.sh serve <semanticdb-root> [classpath]   (also the default with no subcommand)
+#       Runs the server. Two paths, picked automatically:
+#         1. if `cs` (coursier) is on PATH — resolve + cache the artifact from Maven Central and run
+#            it (the JVM-native, npx-style way);
+#         2. otherwise — download the fat jar from the latest GitHub Release once (cached by
+#            version) and run it with `java -jar`.
 # Either way, all progress goes to stderr so stdout carries only the JSON-RPC protocol stream.
 #
 # Cold-start strategy (jar path): once ANY version is cached, a launch serves the newest cached jar
 # IMMEDIATELY and forks a detached background updater that fetches the latest release for the NEXT
 # launch. So the download never races the client's connect timeout after the first time. The very
-# first launch (empty cache) still blocks on the download — run `--prefetch` once, or `sbt
-# mcpClientConfig` (which prefetches for you), to warm the cache ahead of the first real connect.
+# first launch (empty cache) still blocks on the download — run `setup` (or plain `--prefetch`) once
+# to warm the cache ahead of the first real connect.
 #
-# Usage:   scalasemantic-mcp.sh [--prefetch] <semanticdb-root> [classpath]   (root defaults to ".")
-#   --prefetch  Download + cache the artifact, then exit WITHOUT serving. Run this once before
-#               adding the server to your MCP config so the first real connect hits a warm cache
-#               instead of racing the client's connection timeout while an ~88 MB jar downloads.
-#   All other arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional
-#   arg 2 = the compile classpath (a path-separated string or a file containing one) that enables
-#   the presentation-compiler backend for live overlay of uncompiled buffers.
+#   --prefetch  Download + cache the artifact, then exit WITHOUT serving.
+#   serve arguments are forwarded verbatim to the server: arg 1 = SemanticDB root, optional arg 2 =
+#   the compile classpath (a path-separated string or a file containing one) that enables the
+#   presentation-compiler backend for live overlay of uncompiled buffers.
 #   --log / --log-output  Forwarded to the server to turn on its (off-by-default) file log:
 #               --log writes a startup line + one line per tool call; --log-output additionally
 #               logs each JSON-RPC response sent to the LLM. (Env equivalents: SCALASEMANTIC_LOG,
 #               SCALASEMANTIC_LOG_OUTPUT; log file path via SCALASEMANTIC_LOG_FILE.)
-# Requires: java on PATH (and optionally coursier). No sbt needed.
+# Requires: java on PATH (and optionally coursier) for `serve`. `setup`'s config merge additionally
+# needs python3 on PATH (present by default on macOS and most Linux distros).
 #
 # Pin a version instead of "latest" by exporting SCALASEMANTIC_VERSION=v0.1.4 (pinned launches skip
 # the background updater — you get exactly that version).
@@ -36,6 +41,8 @@ ORG="io.github.mercurievv"
 ARTIFACT="scalasemantic-mcp_3"
 MAIN="com.github.mercurievv.scalasemantic.mcpServer"
 CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/scalasemantic-mcp"
+SELF=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")
+SELF_DIR=$(dirname -- "$SELF")
 
 mkdir -p "$CACHE"
 
@@ -108,49 +115,214 @@ if [ "${1:-}" = "--bg-fetch" ]; then
   exit 0
 fi
 
-# --prefetch: warm the cache and exit, never serve (decouples the download from the first connect).
-PREFETCH=0
-if [ "${1:-}" = "--prefetch" ]; then
-  PREFETCH=1
-  shift
-fi
+serve_main() {
+  # --prefetch: warm the cache and exit, never serve (decouples the download from the first connect).
+  PREFETCH=0
+  if [ "${1:-}" = "--prefetch" ]; then
+    PREFETCH=1
+    shift
+  fi
 
-# --- path 1: coursier (preferred) — resolves transitive deps from Central, caches, runs ----------
-if command -v cs >/dev/null 2>&1; then
-  ver="${SCALASEMANTIC_VERSION:-latest.release}"
-  ver="${ver#v}" # coursier wants the Maven version (0.1.4), not the git tag (v0.1.4)
+  # --- path 1: coursier (preferred) — resolves transitive deps from Central, caches, runs --------
+  if command -v cs >/dev/null 2>&1; then
+    ver="${SCALASEMANTIC_VERSION:-latest.release}"
+    ver="${ver#v}" # coursier wants the Maven version (0.1.4), not the git tag (v0.1.4)
+    if [ "$PREFETCH" -eq 1 ]; then
+      echo "scalasemantic-mcp: prefetching $ORG:$ARTIFACT:$ver via coursier" >&2
+      cs fetch "$ORG:$ARTIFACT:$ver"
+      return $?
+    fi
+    echo "scalasemantic-mcp: launching $ORG:$ARTIFACT:$ver via coursier" >&2
+    exec cs launch "$ORG:$ARTIFACT:$ver" -M "$MAIN" -- "$@"
+  fi
+
+  # --- path 2: fat jar from GitHub Releases ------------------------------------------------------
+  CACHED=$(newest_cached)
+
+  if [ "$PREFETCH" -eq 0 ] && [ -z "${SCALASEMANTIC_VERSION:-}" ] && [ -n "$CACHED" ]; then
+    # Cached jar present and not pinned: serve it NOW (zero download latency) and fork a detached
+    # updater that pulls the latest release for the next launch. `( … & )` double-detaches so the
+    # exec below does not wait on it; its fds are redirected away from the JSON-RPC stdout stream.
+    JAR="$CACHED"
+    ( "$SELF" --bg-fetch >/dev/null 2>&1 </dev/null & ) >/dev/null 2>&1 || true
+  else
+    # No cache (must block once), or pinned (fetch exactly that version), or prefetch (warm fully).
+    TAG=$(resolve_tag)
+    if [ -n "$TAG" ]; then download_release "$TAG" || true; fi
+    JAR="$CACHE/scalasemantic-mcp-${TAG:-unknown}.jar"
+    if [ ! -f "$JAR" ]; then
+      JAR=$(newest_cached)
+      [ -n "$JAR" ] || { echo "scalasemantic-mcp: cannot resolve a release and no cached jar found" >&2; exit 1; }
+      echo "scalasemantic-mcp: offline — using cached $(basename "$JAR")" >&2
+    fi
+  fi
+
   if [ "$PREFETCH" -eq 1 ]; then
-    echo "scalasemantic-mcp: prefetching $ORG:$ARTIFACT:$ver via coursier" >&2
-    exec cs fetch "$ORG:$ARTIFACT:$ver"
+    echo "scalasemantic-mcp: prefetched $(basename "$JAR")" >&2
+    return 0
   fi
-  echo "scalasemantic-mcp: launching $ORG:$ARTIFACT:$ver via coursier" >&2
-  exec cs launch "$ORG:$ARTIFACT:$ver" -M "$MAIN" -- "$@"
-fi
 
-# --- path 2: fat jar from GitHub Releases --------------------------------------------------------
-CACHED=$(newest_cached)
+  exec java -jar "$JAR" "$@"
+}
 
-if [ "$PREFETCH" -eq 0 ] && [ -z "${SCALASEMANTIC_VERSION:-}" ] && [ -n "$CACHED" ]; then
-  # Cached jar present and not pinned: serve it NOW (zero download latency) and fork a detached
-  # updater that pulls the latest release for the next launch. `( … & )` double-detaches so the
-  # exec below does not wait on it; its fds are redirected away from the JSON-RPC stdout stream.
-  JAR="$CACHED"
-  ( "$0" --bg-fetch >/dev/null 2>&1 </dev/null & ) >/dev/null 2>&1 || true
-else
-  # No cache (must block once), or pinned (fetch exactly that version), or prefetch (warm fully).
-  TAG=$(resolve_tag)
-  if [ -n "$TAG" ]; then download_release "$TAG" || true; fi
-  JAR="$CACHE/scalasemantic-mcp-${TAG:-unknown}.jar"
-  if [ ! -f "$JAR" ]; then
-    JAR=$(newest_cached)
-    [ -n "$JAR" ] || { echo "scalasemantic-mcp: cannot resolve a release and no cached jar found" >&2; exit 1; }
-    echo "scalasemantic-mcp: offline — using cached $(basename "$JAR")" >&2
+# ---------------------------------------------------------------------------------------------------
+# setup: idempotently configure a project + its MCP clients to launch this script via `serve`.
+# ---------------------------------------------------------------------------------------------------
+
+ALL_CLIENTS="claude codex gemini cline roo continue antigravity"
+
+target_for() {
+  case "$1" in
+    codex|openai|openai-codex) echo ".codex/config.toml toml" ;;
+    claude|claude-code|anthropic) echo ".mcp.json json" ;;
+    gemini|google|google-gemini|gemini-cli) echo ".gemini/settings.json json {\"timeout\":60000}" ;;
+    antigravity|antigravity-cli|agy) echo ".agents/mcp_config.json json" ;;
+    cline) echo ".cline/mcp.json json {\"disabled\":false,\"autoApprove\":[]}" ;;
+    roo|roo-code) echo ".roo/mcp.json json {\"disabled\":false,\"alwaysAllow\":[],\"timeout\":60}" ;;
+    continue|continue-dev) echo ".continue/config.yaml yaml" ;;
+    generic|generic-json|json|oss|open-source|free) echo ".mcp.json json" ;;
+    *) echo "" ;;
+  esac
+}
+
+ensure_semanticdb_config() {
+  local _project _file f
+  _project="$1"
+  for f in "$_project"/*.sbt; do
+    [ -f "$f" ] || continue
+    if grep -q semanticdbEnabled "$f" 2>/dev/null; then return 0; fi
+  done
+  if ! ls "$_project"/*.sbt >/dev/null 2>&1; then
+    echo "scalasemantic-mcp: no .sbt files found in $_project; enable SemanticDB in your build tool before using ScalaSemantic" >&2
+    return 0
   fi
-fi
+  _file="$_project/scala-semantic.sbt"
+  if [ ! -f "$_file" ]; then
+    printf '// Generated by ScalaSemantic MCP setup.\nsemanticdbEnabled := true\n' > "$_file"
+    echo "scalasemantic-mcp: created $_file" >&2
+  fi
+}
 
-if [ "$PREFETCH" -eq 1 ]; then
-  echo "scalasemantic-mcp: prefetched $(basename "$JAR")" >&2
-  exit 0
-fi
+ensure_steer_file() {
+  local _project _client _target _ref sed_bak
+  _project="$1"; _client="$2"
+  case "$_client" in
+    claude|claude-code|anthropic) _target="$_project/CLAUDE.md"; _ref="[SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md)" ;;
+    gemini|google|google-gemini|gemini-cli|antigravity|antigravity-cli|agy) _target="$_project/AGENTS.md"; _ref="@SCALA_SEMANTIC_RULES.md" ;;
+    codex|openai|openai-codex) _target="$_project/.cursorrules"; _ref="[SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md)" ;;
+    cline|roo|roo-code) _target="$_project/.clinerules"; _ref="[SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md)" ;;
+    continue|continue-dev) _target="$_project/.continue/rules.txt"; _ref="SCALA_SEMANTIC_RULES.md" ;;
+    *) return 0 ;;
+  esac
+  if [ -f "$_target" ]; then
+    if grep -q "SCALA_CODE_RULES.md" "$_target" 2>/dev/null; then
+      sed_bak=$(mktemp)
+      sed 's/SCALA_CODE_RULES\.md/SCALA_SEMANTIC_RULES.md/g' "$_target" > "$sed_bak" && mv "$sed_bak" "$_target"
+      echo "scalasemantic-mcp: updated $_target" >&2
+    elif ! grep -q "SCALA_SEMANTIC_RULES.md" "$_target" 2>/dev/null; then
+      printf '\n## Scala Code Rules\nPlease follow the rules in %s.\n' "$_ref" >> "$_target"
+      echo "scalasemantic-mcp: updated $_target" >&2
+    fi
+  else
+    mkdir -p "$(dirname "$_target")"
+    if [ "$(basename "$_target")" = "AGENTS.md" ]; then
+      printf '# AGENTS.md instructions\n\n<INSTRUCTIONS>\n%s\n</INSTRUCTIONS>\n' "$_ref" > "$_target"
+    else
+      printf '# Project Rules\n\nPlease follow the rules in %s for working with Scala code.\n' "$_ref" > "$_target"
+    fi
+    echo "scalasemantic-mcp: created $_target" >&2
+  fi
+}
 
-exec java -jar "$JAR" "$@"
+ensure_rules() {
+  local _project _client _rules c
+  _project="$1"; _client="$2"
+  _rules="$_project/SCALA_SEMANTIC_RULES.md"
+  if [ ! -f "$_rules" ]; then
+    cat > "$_rules" <<'EOF'
+# Scala Semantic Rules
+
+For Scala source questions, use ScalaSemantic MCP tools before shell text tools. Preferably compile code before usage, then more ScalaSemantic functions can be used with better results.
+
+Do not use `cat`, `sed`, `rg`, or similar tools to inspect `.scala` files for symbol, type, signature, hierarchy, implicit, reference, or call-path questions when ScalaSemantic tools are available.
+
+Use shell for builds, tests, git, config, docs, scripts, and non-Scala text work.
+EOF
+    echo "scalasemantic-mcp: created $_rules" >&2
+  fi
+  if [ "$_client" = "all" ]; then
+    for c in $ALL_CLIENTS; do ensure_steer_file "$_project" "$c"; done
+  else
+    ensure_steer_file "$_project" "$_client"
+  fi
+}
+
+write_client_configs() {
+  local _project _client _command _cpfile _merge _clients c _t _relpath _fmt _extra _argv
+  _project="$1"; _client="$2"; _command="$3"; _cpfile="$4"
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "scalasemantic-mcp: python3 not found on PATH — skipping MCP client config merge." >&2
+    echo "scalasemantic-mcp: add this server manually, pointing args at: $_command serve $_project $_cpfile" >&2
+    return 0
+  fi
+  _merge="$SELF_DIR/lib/mcp-config-merge.py"
+  if [ "$_client" = "all" ]; then _clients="$ALL_CLIENTS"; else _clients="$_client"; fi
+  for c in $_clients; do
+    _t=$(target_for "$c")
+    [ -n "$_t" ] || { echo "scalasemantic-mcp: unsupported client '$c'" >&2; continue; }
+    _relpath=$(echo "$_t" | cut -d' ' -f1)
+    _fmt=$(echo "$_t" | cut -d' ' -f2)
+    _extra=$(echo "$_t" | cut -d' ' -f3-)
+    if [ -z "$_extra" ] || [ "$_extra" = "$_fmt" ]; then _extra="{}"; fi
+    _argv=$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$_command" serve "$_project" "$_cpfile")
+    python3 "$_merge" "$_fmt" "$_project/$_relpath" "scala-semantic" "$_argv" "$_extra"
+  done
+}
+
+setup_main() {
+  local _project _client _command _skip_semanticdb _cpfile
+  _project=$(CDPATH= cd -- "." && pwd)
+  _client="all"
+  _command="$SELF"
+  _skip_semanticdb=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --project|--root) _project=$(mkdir -p "$2" && CDPATH= cd -- "$2" && pwd); shift 2 ;;
+      --client|-c) _client="$2"; shift 2 ;;
+      --command) _command="$2"; shift 2 ;;
+      --skip-semanticdb-config) _skip_semanticdb=1; shift ;;
+      --help|-h) usage; exit 0 ;;
+      *) echo "scalasemantic-mcp: unknown setup argument: $1" >&2; usage; exit 2 ;;
+    esac
+  done
+
+  [ "$_skip_semanticdb" -eq 1 ] || ensure_semanticdb_config "$_project"
+  ensure_rules "$_project" "$_client"
+
+  echo "scalasemantic-mcp: prefetching the server jar ..." >&2
+  serve_main --prefetch "$_project" || echo "scalasemantic-mcp: prefetch skipped (will download on first serve)" >&2
+
+  _cpfile="$CACHE/scalasemantic-mcp-classpath.txt"
+  [ -f "$_cpfile" ] || : > "$_cpfile"
+
+  write_client_configs "$_project" "$_client" "$_command" "$_cpfile"
+}
+
+usage() {
+  cat >&2 <<EOF
+Usage:
+  scalasemantic-mcp.sh setup [--client all|claude|codex|gemini|cline|roo|continue|antigravity] [--project DIR]
+  scalasemantic-mcp.sh serve <semanticdb-root> [classpath-file] [--log] [--log-output]
+
+setup writes MCP client config that launches this same script:
+  command = $SELF
+  args    = [serve, <project>, <classpath-file>]
+EOF
+}
+
+case "${1:-}" in
+  setup|configure|install) shift; setup_main "$@" ;;
+  serve|run) shift; serve_main "$@" ;;
+  --help|-h|help) usage; exit 0 ;;
+  *) serve_main "$@" ;;
+esac


### PR DESCRIPTION
## Summary
- Add `setup`/`serve` subcommands to `scripts/scalasemantic-mcp.sh` and `scripts/scalasemantic-mcp.ps1`, bringing them to parity with `scripts/scalasemantic-mcp.scala`'s idempotent setup flow, so they can be the default installer/runner for projects without Scala CLI.
- `setup` enables SemanticDB in the project's `.sbt` files, writes `SCALA_SEMANTIC_RULES.md` + per-client agent steering files, prefetches the fat jar, and merges an MCP server entry into every client config (`.mcp.json`, `.codex/config.toml`, `.gemini/settings.json`, `.cline/mcp.json`, `.roo/mcp.json`, `.continue/config.yaml`, `.agents/mcp_config.json`) without disturbing other keys — re-running is safe.
- `serve` is the prior download+run behavior, now a subcommand (still the default with no args, so existing `.mcp.json` entries keep working unchanged).
- JSON/TOML/YAML merge logic for the `.sh` launcher is shared via new `scripts/lib/mcp-config-merge.py` (uses Python's `json` module — simpler/safer than hand-rolled bracket matching for JSON; line-based port of the scala script's algorithm for TOML/YAML). The `.ps1` launcher does the same merges natively (no Python dependency on Windows).
- README: added the `.sh`/`.ps1` `setup` one-liners as the primary build-tool-neutral install path (only needs `java`), with the Scala CLI script kept as an alternative.

## Key decisions
- Kept `serve` as the default action with no subcommand so nothing breaks for anyone already pointing an MCP client at the bare script.
- Delegated JSON merging on the sh side to Python (present by default on macOS/most Linux) rather than reimplementing bracket-matching JSON parsing in POSIX `sh`.
- Added a `Slice-Array` helper in the `.ps1` script to work around PowerShell's array-slice footgun (`$a[$from..$to]` silently reverses when `$from > $to`), which the empty-args / edge-of-file cases in the merge logic hit constantly.

## Test plan
- [x] `sh -n scripts/scalasemantic-mcp.sh` syntax check
- [x] Ran `setup --client all` end-to-end against a scratch project; verified all 7 client configs are written correctly and re-running produces byte-identical output (idempotent)
- [x] Verified `serve` (default and explicit) answers a real JSON-RPC `initialize` request
- [ ] `.ps1` reviewed carefully but not executed locally (no `pwsh` available in this sandbox without sudo) — flagging as the one unverified piece