### PR TITLE
docs: add claude-cli live token-metrics rerun (42.1% reduction on find-usages-animal)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ build/
 /stainless/
 /.claire/
 /scripts/.scala-build/
+# Local launcher copy referenced by the (ignored) .mcp.json; canonical copy is scripts/scalasemantic-mcp.sh.
+/scalasemantic-mcp.sh
+# scala-cli build cache from running the launcher at repo root.
+/.scala-build/

--- a/docs/research/token-metrics-findings.md
+++ b/docs/research/token-metrics-findings.md
@@ -11,11 +11,13 @@ fully-reproducible result — see
 page is scoped to Part 2 only: real end-to-end agent token usage, captured
 from each engine's own accounting.
 
-**Bottom line: the live run produced exactly one valid, usable comparison** —
-a single query, on a single engine, with 3 repetitions per arm. The
-methodology's full target (5 single-call queries + 2-3 multi-step tasks,
-across claude-cli / codex / agy) was not completed. The gaps and why are
-documented below rather than filled with invented numbers.
+**Bottom line: the live run has produced two valid, usable comparisons** —
+the same single query (`find-usages-animal`) on two engines (codex / o3 and,
+after a 2026-07-03 rerun fixed the login failure, claude-cli /
+claude-sonnet-5), 3 repetitions per arm each. The methodology's full target
+(5 single-call queries + 2-3 multi-step tasks, across claude-cli / codex /
+agy) is still not completed. The gaps and why are documented below rather
+than filled with invented numbers.
 
 ---
 
@@ -24,8 +26,14 @@ documented below rather than filled with invented numbers.
 - Repository: `https://github.com/MercurieVV/ScalaSemantic.git` (this repo,
   per the methodology's fallback rule: "this repository is an acceptable
   fallback if no suitable external project is identified")
-- Commit: `99b17c3981a1fb50ed20587ab92afcfd7fc2d66a`
-- ScalaSemantic MCP server commit under test: same commit (dogfooding)
+- Commit (codex run): `99b17c3981a1fb50ed20587ab92afcfd7fc2d66a`
+- Commit (claude-cli rerun, 2026-07-03):
+  `cf9d6bbd8e310f2794460fa784188072095072a7`, ScalaSemantic MCP server
+  version `0.3.10` (published launcher). Per-measurement commits are recorded
+  in `token-metrics-live-runs.json` as a `targetCommit` field on the
+  measurement, since the file's top-level `source.targetCommit` can only pin
+  one commit.
+- ScalaSemantic MCP server commit under test: same repo (dogfooding)
 
 An earlier attempt (below, [Failed attempt](#failed-attempt-2026-07-02)) used
 a different commit, `00a10cf4e267ce7c6eb5783856e797c5ed6edb7b`, and did not
@@ -34,28 +42,31 @@ produce usable data.
 ## Engine coverage
 
 Per the methodology's [Tools/engines](token-metrics-methodology.md#toolsengines-and-how-to-capture-tokens)
-section, three engines were in scope: claude-cli, codex, agy. Only one
+section, three engines were in scope: claude-cli, codex, agy. Two have now
 produced a valid WITH-vs-WITHOUT comparison:
 
 | Engine | Version | Token accounting source | Outcome |
 | --- | --- | --- | --- |
 | **codex** | `codex-cli 0.142.5` | `turn.completed.usage` (`codex exec --json`) | **Usable** — see [Result](#result-find-usages-animal-codex--o3) below |
-| **claude-cli** | 2.1.197 (Claude Code) | `usage` object in `--output-format json` | Not usable — the CLI was not logged in during the attempt, so no model run occurred and no token data exists for this engine |
-| **agy** (Gemini CLI) | 1.0.15 | none found | Not usable — token usage is not exposed in print-mode stdout or the selected log file, so no per-task figures could be captured; per project memory, agy is also Gemini-only, so it can never substitute for claude-cli/codex coverage even once its token reporting is solved |
+| **claude-cli** | 2.1.199 (Claude Code) | `modelUsage` object in `--output-format json` | **Usable after 2026-07-03 rerun** — the original attempt (v2.1.197) was not logged in and produced zero data; rerun with a logged-in CLI succeeded, see [Result](#result-find-usages-animal-claude-cli--claude-sonnet-5) below |
+| **agy** (Gemini CLI) | 1.0.15 | none found | Not usable — in the original attempt token usage was not exposed in print-mode stdout or the selected log file; in the 2026-07-03 rerun attempt agy was no longer logged in to Antigravity at all ("You are not logged into Antigravity"), so it regressed from "answers without token counts" to "no run at all". Per project memory, agy is also Gemini-only, so it can never substitute for claude-cli/codex coverage even once its auth and token reporting are solved |
 
-Because only codex produced data, **no cross-engine comparison exists**. The
-methodology's explicit warning applies: "cross-engine comparisons of absolute
-token counts are not meaningful" — moot here since there is only one engine's
-data point.
+Two engines now have data on the same task, but the methodology's explicit
+warning still applies: "cross-engine comparisons of absolute token counts are
+not meaningful" — the codex and claude-cli rows below use different models,
+different CLI framing, and were run at different commits, so only each
+engine's own WITH-vs-WITHOUT delta is meaningful, not codex-vs-claude
+absolute numbers.
 
 ## Task coverage
 
 Of the fixed task set (5 single-call queries + 3 multi-step tasks defined in
-the methodology), only **one** single-call query has a valid measurement:
+the methodology), only **one** single-call query has valid measurements
+(now on two engines):
 
 | Task id | Status |
 | --- | --- |
-| `find-usages-animal` | **Valid** — 3 reps/arm, both arms completed through the intended tool path |
+| `find-usages-animal` | **Valid** — codex/o3 and claude-cli/claude-sonnet-5, 3 reps/arm each, both arms completed through the intended tool path |
 | `class-hierarchy-animal` | Not attempted |
 | `method-signature-render` | Not attempted |
 | `trace-implicit-show` | Not attempted |
@@ -127,6 +138,58 @@ works end-to-end (real per-run token accounting captured, aggregated, and
 reported per the schema) and that this first real measurement did not
 replicate Part 1's proxy-derived savings rate.
 
+## Result: `find-usages-animal`, claude-cli / claude-sonnet-5
+
+Rerun on 2026-07-03 after fixing the login failure that gave claude-cli zero
+data in the original attempt. Same task prompt as the codex run, 3
+repetitions per arm, fresh session per run (`claude -p`), commit
+`cf9d6bbd8e310f2794460fa784188072095072a7`, ScalaSemantic server `0.3.10`.
+
+Setup details that differ from codex and matter for reading the numbers:
+
+- **Arm isolation**: with-mcp used `--mcp-config .mcp.json --strict-mcp-config`
+  (ScalaSemantic only); without-mcp used an empty MCP config. Tool
+  allowlists: with-mcp `Read,Grep,Glob` + ScalaSemantic read tools;
+  without-mcp `Read,Grep,Glob` (the engine also used its built-in
+  Bash/Explore agent, which the allowlist mechanism does not remove).
+- **Arm validity was verified from session transcripts** (the trap that
+  invalidated the first codex attempt): each with-mcp run made 6-8
+  `mcp__scala-semantic__*` calls and zero Grep/Read calls; each without-mcp
+  run made zero ScalaSemantic calls.
+- **Accounting source**: `modelUsage` from `--output-format json`, not the
+  top-level `usage` object — the top-level object omits subagent model calls
+  (without-mcp run 3 spawned an Explore subagent that `usage` misses
+  entirely). `inputTokens` below = input + cacheCreation + cacheRead summed
+  over all model calls, so it is total-context-consumed and matches codex
+  semantics where `input_tokens` includes cached tokens; `cacheTokens` is
+  the cache-read subset.
+
+| Run | Arm | Input tokens | Cache tokens | Output tokens | Total tokens |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 1 | with-mcp | 177 329 | 140 374 | 729 | 178 058 |
+| 2 | with-mcp | 141 374 | 119 938 | 887 | 142 261 |
+| 3 | with-mcp | 141 473 | 121 642 | 463 | 141 936 |
+| 1 | without-mcp | 239 103 | 225 652 | 1 474 | 240 577 |
+| 2 | without-mcp | 213 650 | 187 263 | 1 437 | 215 087 |
+| 3 | without-mcp | 338 814 | 281 814 | 4 520 | 343 334 |
+
+| Arm | Mean total tokens | Median | Variance |
+| --- | ---: | ---: | ---: |
+| with-mcp | 154 085.0 | 142 261 | 2.874 × 10⁸ |
+| without-mcp | 266 332.7 | 240 577 | 3.073 × 10⁹ |
+
+**Delta (mean): 112 247.7 tokens, 42.1% reduction.**
+
+Unlike the codex 4.0% result, this delta is larger than the run-to-run
+noise: the with-mcp arm's standard deviation is ~17 000 tokens and the
+without-mcp arm's ~55 000, against a ~112 000-token mean delta (about 2
+standard deviations of the noisier arm). The without-mcp run 3 outlier
+(343 334 total) is the run that spawned an Explore subagent; excluding it,
+the mean reduction is still ~32%. Three repetitions is still too few to
+quote 42.1% as a precise savings rate, but on this engine the direction and
+rough magnitude of the effect are visible above the noise floor, which the
+codex result was not.
+
 ## Token-accounting limitations encountered
 
 - **codex**: nested non-interactive `codex exec` runs, when first attempted,
@@ -136,16 +199,30 @@ replicate Part 1's proxy-derived savings rate.
   underlying cause (why nested non-interactive codex sessions cancel MCP
   calls) was not root-caused as part of this task and may recur.
 - **claude-cli**: session-level `/cost`/summary reporting (per the
-  methodology) requires an authenticated session; the attempt here ran
-  unauthenticated and produced no model run at all, so claude-cli has zero
-  data points, not just missing WITH or WITHOUT arms.
+  methodology) requires an authenticated session; the original attempt ran
+  unauthenticated and produced no model run at all. **Resolved 2026-07-03**
+  by rerunning with a logged-in CLI. One residual accounting subtlety found
+  during the rerun: the top-level `usage` object in `--output-format json`
+  only counts the main conversation thread — when the agent spawns a
+  subagent (as one without-mcp run did), those model calls appear only in
+  `modelUsage`. Use `modelUsage` sums, never top-level `usage`, or
+  subagent-heavy runs are silently undercounted.
 - **agy**: Gemini's `usageMetadata` (promptTokenCount / candidatesTokenCount /
   totalTokenCount) is documented in the methodology as the intended capture
   point, but agy's CLI did not surface it in print-mode stdout, and the log
   file selected for this attempt did not contain it either. The task
   completed (agy produced an answer) but with no attributable token count, so
   this is a tooling gap in agy's observability, not a failure of the task
-  itself.
+  itself. In the 2026-07-03 rerun attempt the situation regressed: agy
+  (still 1.0.15) was no longer logged in to Antigravity, so no run happened
+  at all; fixing it requires an interactive login before any future attempt.
+- **codex model availability**: the o3 model used for the valid codex result
+  is no longer selectable on the ChatGPT-account codex CLI as of 2026-07-03
+  (the account's default is now `gpt-5.5`, and `-m o3` is rejected with
+  "The 'o3' model is not supported when using Codex with a ChatGPT
+  account"). Future codex runs will therefore be a **new dataset**
+  under a different model, not additional repetitions of the o3 rows above —
+  per the methodology's rule that model changes break comparability.
 - **General**: none of the three engines' gaps were about the concept of the
   measurement — each engine's own documented accounting mechanism (per the
   methodology's [Tools/engines table](token-metrics-methodology.md#toolsengines-and-how-to-capture-tokens))
@@ -189,14 +266,20 @@ should be tracked as follow-up work rather than assumed complete:
 
 - 4 of 5 single-call queries (`class-hierarchy-animal`,
   `method-signature-render`, `trace-implicit-show`, `call-path-a-to-c`) have
-  no live measurement.
-- All 3 multi-step tasks (M1–M3) have no live measurement.
-- claude-cli and agy have zero usable data points across any task.
-- The single available result has only 3 reps/arm on one task, with variance
-  larger than the observed mean effect — more repetitions (or a different
-  task less dominated by system-prompt/context overhead) would be needed
-  before drawing any conclusion about real-world savings from end-to-end
-  agent runs.
+  no live measurement on any engine.
+- All 3 multi-step tasks (M1–M3) have no live measurement on any engine.
+- agy has zero usable data points across any task, and as of 2026-07-03 is
+  blocked on an interactive Antigravity login before any rerun is possible.
+- The codex result has only 3 reps/arm with variance larger than the
+  observed mean effect, and cannot be extended: o3 is no longer available on
+  the account, so additional codex data will be a new gpt-5.5 dataset.
+- The claude-cli result (42.1% reduction) is the first live measurement
+  where the delta clearly exceeds run-to-run noise, but it is still one
+  task, one engine, 3 reps/arm — extending claude-cli coverage to the
+  remaining 4 single-call queries and M1–M3 is the highest-value follow-up,
+  since the engine, auth, MCP wiring, and transcript-based arm validation
+  are now all proven to work.
 - The root cause of codex's initial MCP-tool-call cancellation in nested
-  non-interactive sessions was not diagnosed; recurrence risk for future live
-  runs is unknown.
+  non-interactive sessions was not diagnosed (a 2026-07-03 probe ran an MCP
+  call through cleanly, so it did not recur, but why it happened remains
+  unknown); recurrence risk for future live runs is unknown.

--- a/docs/research/token-metrics-live-run.md
+++ b/docs/research/token-metrics-live-run.md
@@ -2,7 +2,8 @@
 
 Issue: #144
 
-Date: 2026-07-02
+Date: 2026-07-02 (codex run); 2026-07-03 (claude-cli rerun, see
+[claude-cli section](#claude-cli-rerun-2026-07-03) below)
 
 ## Target Project
 
@@ -41,3 +42,44 @@ The live run used this repository as the target project:
 ## Conclusion
 
 Using the ScalaSemantic MCP server allows Codex to perform precise definitions and usages analysis using high-signal SemanticDB facts rather than doing full-text grep and reading raw files. This leads to a **4.0%** reduction in total tokens consumed.
+
+## claude-cli rerun (2026-07-03)
+
+The first live run produced no claude-cli data (the CLI was not logged in).
+After fixing authentication, the same task was rerun on claude-cli:
+
+- **Engine**: Claude Code (claude-cli), version `2.1.199`
+- **Model**: `claude-sonnet-5`
+- **Commit**: `cf9d6bbd8e310f2794460fa784188072095072a7`
+- **ScalaSemantic server version**: `0.3.10` (published launcher)
+- Same task prompt, 3 repetitions per arm, fresh session per run.
+- Token accounting: `modelUsage` from `--output-format json` (sums all model
+  calls including subagents); `inputTokens` = input + cacheCreation +
+  cacheRead so it is total-context-consumed, matching codex semantics;
+  `cacheTokens` = the cacheRead subset.
+- Arm validity checked in session transcripts: with-mcp runs made 6-8
+  `mcp__scala-semantic__*` calls and zero Grep/Read; without-mcp runs used
+  Grep/Bash/Explore-agent only and made zero ScalaSemantic calls.
+
+### Results Summary (claude-cli)
+
+- **WITHOUT MCP (Baseline)**: Average total tokens = 266332.7
+- **WITH MCP (ScalaSemantic)**: Average total tokens = 154085.0
+- **Token Savings**: 112247.7 tokens (**42.1%** reduction)
+
+### Detailed Runs (claude-cli)
+
+| Run | Arm | Input Tokens | Cache Tokens | Output Tokens | Total Tokens |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 1 | with-mcp | 177329 | 140374 | 729 | 178058 |
+| 2 | with-mcp | 141374 | 119938 | 887 | 142261 |
+| 3 | with-mcp | 141473 | 121642 | 463 | 141936 |
+| 1 | without-mcp | 239103 | 225652 | 1474 | 240577 |
+| 2 | without-mcp | 213650 | 187263 | 1437 | 215087 |
+| 3 | without-mcp | 338814 | 281814 | 4520 | 343334 |
+
+Unlike the codex 4.0% result, this delta is larger than the run-to-run
+spread: the with-mcp arm's standard deviation is ~17k tokens and the
+without-mcp arm's ~55k, against a 112k mean delta (~2x the noisier arm's
+standard deviation). The without-mcp run 3 outlier (343k) spawned an Explore
+subagent; excluding it, the reduction is still ~32%.

--- a/docs/research/token-metrics-live-runs.json
+++ b/docs/research/token-metrics-live-runs.json
@@ -61,6 +61,62 @@
           "cacheTokens": 128384
         }
       ]
+    },
+    {
+      "id": "find-usages-animal",
+      "query": "Find all definitions and references of the Animal trait.",
+      "tool": "find_usages",
+      "baseline": "Text grep for Animal across fixture source trees.",
+      "engine": "claude-cli",
+      "model": "claude-sonnet-5",
+      "engineVersion": "2.1.199 (Claude Code)",
+      "targetCommit": "cf9d6bbd8e310f2794460fa784188072095072a7",
+      "scalaSemanticVersion": "0.3.10",
+      "note": "Rerun 2026-07-03 after fixing the claude-cli login failure from the first live run. inputTokens = input + cacheCreation + cacheRead summed over modelUsage (includes subagent model calls); cacheTokens = cacheRead subset, matching codex semantics where inputTokens includes cached tokens. with-mcp arm verified via session transcripts: 6-8 mcp__scala-semantic__* calls per run, zero Grep/Read; without-mcp arm used Grep/Bash/Explore-agent only, zero ScalaSemantic MCP calls.",
+      "runs": [
+        {
+          "arm": "with-mcp",
+          "run": 1,
+          "inputTokens": 177329,
+          "outputTokens": 729,
+          "cacheTokens": 140374
+        },
+        {
+          "arm": "with-mcp",
+          "run": 2,
+          "inputTokens": 141374,
+          "outputTokens": 887,
+          "cacheTokens": 119938
+        },
+        {
+          "arm": "with-mcp",
+          "run": 3,
+          "inputTokens": 141473,
+          "outputTokens": 463,
+          "cacheTokens": 121642
+        },
+        {
+          "arm": "without-mcp",
+          "run": 1,
+          "inputTokens": 239103,
+          "outputTokens": 1474,
+          "cacheTokens": 225652
+        },
+        {
+          "arm": "without-mcp",
+          "run": 2,
+          "inputTokens": 213650,
+          "outputTokens": 1437,
+          "cacheTokens": 187263
+        },
+        {
+          "arm": "without-mcp",
+          "run": 3,
+          "inputTokens": 338814,
+          "outputTokens": 4520,
+          "cacheTokens": 281814
+        }
+      ]
     }
   ]
 }

--- a/docs/research/token-metrics-live.json
+++ b/docs/research/token-metrics-live.json
@@ -11,15 +11,87 @@
     "repetitionsRequired": 3
   },
   "summary": {
-    "measurementCount": 1,
+    "measurementCount": 2,
     "taskCount": 1,
-    "engineCount": 1,
-    "toolMeanTokens": 150239.3,
-    "baselineMeanTokens": 156580.3,
-    "tokenDelta": 6341,
-    "savingsPercent": 4
+    "engineCount": 2,
+    "toolMeanTokens": 304324.3,
+    "baselineMeanTokens": 422913,
+    "tokenDelta": 118588.7,
+    "savingsPercent": 28
   },
   "measurements": [
+    {
+      "id": "find-usages-animal",
+      "query": "Find all definitions and references of the Animal trait.",
+      "tool": "find_usages",
+      "baseline": "Text grep for Animal across fixture source trees.",
+      "engine": "claude-cli",
+      "model": "claude-sonnet-5",
+      "withMcp": {
+        "runs": [
+          {
+            "run": 1,
+            "inputTokens": 177329,
+            "outputTokens": 729,
+            "cacheTokens": 140374,
+            "totalTokens": 178058
+          },
+          {
+            "run": 2,
+            "inputTokens": 141374,
+            "outputTokens": 887,
+            "cacheTokens": 119938,
+            "totalTokens": 142261
+          },
+          {
+            "run": 3,
+            "inputTokens": 141473,
+            "outputTokens": 463,
+            "cacheTokens": 121642,
+            "totalTokens": 141936
+          }
+        ],
+        "meanTokens": 154085,
+        "medianTokens": 142261,
+        "variance": 2.873699687E8,
+        "meanInputTokens": 153392,
+        "meanOutputTokens": 693,
+        "meanCacheTokens": 127318
+      },
+      "withoutMcp": {
+        "runs": [
+          {
+            "run": 1,
+            "inputTokens": 239103,
+            "outputTokens": 1474,
+            "cacheTokens": 225652,
+            "totalTokens": 240577
+          },
+          {
+            "run": 2,
+            "inputTokens": 213650,
+            "outputTokens": 1437,
+            "cacheTokens": 187263,
+            "totalTokens": 215087
+          },
+          {
+            "run": 3,
+            "inputTokens": 338814,
+            "outputTokens": 4520,
+            "cacheTokens": 281814,
+            "totalTokens": 343334
+          }
+        ],
+        "meanTokens": 266332.7,
+        "medianTokens": 240577,
+        "variance": 3.0728926842E9,
+        "meanInputTokens": 263855.7,
+        "meanOutputTokens": 2477,
+        "meanCacheTokens": 231576.3
+      },
+      "tokenDelta": 112247.7,
+      "savingsPercent": 42.1
+    },
     {
       "id": "find-usages-animal",
       "query": "Find all definitions and references of the Animal trait.",


### PR DESCRIPTION
## Investigation result

Follow-up on #150's documented live-run failures. Reran the failed engines from the Part 2 live measurement:

- **claude-cli** (the engine with zero data — was not logged in): FIXED and rerun. `find-usages-animal`, 3 reps/arm, fresh session per run, model `claude-sonnet-5`, Claude Code 2.1.199, commit cf9d6bb, server 0.3.10. Result: **42.1% mean token reduction** (154,085 vs 266,333 total tokens), delta ~2x the noisier arm's std dev — first live result where the effect clearly exceeds run-to-run noise (codex/o3 was 4.0%, below noise).
- **codex**: earlier MCP-call cancellation did not recur (probe ran `find_symbol` through cleanly), but o3 is no longer available on the ChatGPT account (`-m o3` rejected; default now gpt-5.5) — documented that future codex runs are a new dataset, per the methodology's model-pinning rule.
- **agy**: regressed — now not logged in to Antigravity at all; blocked on interactive login, documented.

## Key decisions

- **Accounting from `modelUsage`, not top-level `usage`**: one without-mcp run spawned an Explore subagent whose model calls only appear in `modelUsage`; top-level `usage` silently undercounts. Recorded in the findings doc as a capture rule.
- **inputTokens = input + cacheCreation + cacheRead** to match codex semantics (codex `input_tokens` includes cached tokens); `cacheTokens` = cacheRead subset, reported separately per the methodology.
- **Arm validity verified from session transcripts** (the trap that invalidated the first codex attempt): with-mcp runs made 6-8 `mcp__scala-semantic__*` calls, zero Grep/Read; without-mcp runs made zero ScalaSemantic calls.
- Per-measurement `targetCommit`/`engineVersion` fields added to the raw runs JSON (top-level `source.targetCommit` can only pin one commit; the harness ignores unknown fields).
- Aggregate regenerated with `scripts/token-live-metrics.sh` (TokenLiveMetricsSuite passed).
- Gitignored the root-level local launcher copy (`/scalasemantic-mcp.sh`, referenced by the ignored `.mcp.json`) and `/.scala-build/` so local MCP-install artifacts don't leak into commits.

## Rationale

The findings report (#150) explicitly listed claude-cli/agy zero-data and the open task matrix as follow-up work. This closes the claude-cli gap on the one task with an established protocol, keeps agy/codex-o3 honestly documented as blocked/unextendable, and leaves the remaining 4 queries + M1-M3 listed in "What remains open".

🤖 Generated with [Claude Code](https://claude.com/claude-code)