### PR TITLE
feat: add checksum-verified corpus fetch task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/target/vendor-corpus/
 target/
 # Local MCP client registration (machine-specific abs paths). Commit .mcp.json.example instead.
 .mcp.json

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,23 @@
+# Third-Party Source Corpora
+
+The build can fetch these source corpora into `target/vendor-corpus/` for compatibility testing.
+They are downloaded on demand as checksum-verified build artifacts and are not redistributed in
+this repository.
+
+## Scalameta SemanticDB Integration Fixtures
+
+- Upstream: https://github.com/scalameta/scalameta
+- Pinned ref: `v4.13.9`
+- Fetched archive: https://github.com/scalameta/scalameta/archive/refs/tags/v4.13.9.tar.gz
+- Extracted subtree: `tests-semanticdb/src/test/resources/example`
+- Local path: `target/vendor-corpus/scala-2.13/`
+- License: BSD-3-Clause
+
+## Scala 3 SemanticDB Expect Fixtures
+
+- Upstream: https://github.com/scala/scala3
+- Pinned ref: `3.8.4`
+- Fetched archive: https://github.com/scala/scala3/archive/refs/tags/3.8.4.tar.gz
+- Extracted subtree: `tests/semanticdb/expect`
+- Local path: `target/vendor-corpus/scala-3/`
+- License: Apache-2.0

--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,8 @@ lazy val mcpClientConfig =
   inputKey[Unit](
     "Install the launcher + write client config pointing at it (jar auto-updates in bg)"
   )
+lazy val corpusFetch =
+  taskKey[Seq[File]]("Fetch checksum-verified upstream SemanticDB compatibility corpora")
 lazy val proguard = taskKey[File]("Run ProGuard to shrink the assembly JAR")
 lazy val testShrunk = taskKey[Unit]("Run tests using the shrunk ProGuard JAR")
 
@@ -581,6 +583,12 @@ lazy val root = (project in file("."))
     name := "ScalaSemantic",
     publish / skip := true,
     libraryDependencies += slf4jNop,
+    corpusFetch := Def.uncached {
+      _root_.com.github.mercurievv.scalasemantic.sbtplugin.CorpusFetch.fetch(
+        (ThisBuild / baseDirectory).value / "target" / "vendor-corpus",
+        streams.value.log
+      )
+    },
     initialize := {
       val _ = initialize.value
       try {

--- a/project/CorpusFetch.scala
+++ b/project/CorpusFetch.scala
@@ -1,0 +1,127 @@
+package com.github.mercurievv.scalasemantic.sbtplugin
+
+import sbt.*
+
+object CorpusFetch {
+
+  final case class CorpusPin(ref: String, sha256: String)
+
+  final case class VendorCorpus(
+      id: String,
+      owner: String,
+      repo: String,
+      pin: CorpusPin,
+      subtree: String,
+      targetName: String
+  ) {
+    def archiveUrl: String = s"https://github.com/$owner/$repo/archive/${pin.ref}.tar.gz"
+    def archiveRoot: String = s"$repo-${pin.ref.stripPrefix("v")}"
+  }
+
+  val vendorCorpora: Seq[VendorCorpus] = Seq(
+    VendorCorpus(
+      id = "scalameta-semanticdb-integration",
+      owner = "scalameta",
+      repo = "scalameta",
+      pin = CorpusPin("v4.13.9", "4617568610271364a83bba0c61e9ffc8fe77457966d1a95abd7ad7540b322146"),
+      subtree = "tests-semanticdb/src/test/resources/example",
+      targetName = "scala-2.13"
+    ),
+    VendorCorpus(
+      id = "scala3-semanticdb-expect",
+      owner = "scala",
+      repo = "scala3",
+      pin = CorpusPin("3.8.4", "c0b742a933f12c4fce53554bb067c2df176f7b22c3c16c7cd72b12d64cff4d03"),
+      subtree = "tests/semanticdb/expect",
+      targetName = "scala-3"
+    )
+  )
+
+  def fetch(vendorDir: File, log: Logger): Seq[File] = {
+    val archiveDir = vendorDir / "_archives"
+    IO.createDirectory(archiveDir)
+    vendorCorpora.map { corpus =>
+      val archive = archiveDir / s"${corpus.id}-${corpus.pin.ref}.tar.gz"
+      if (archive.exists()) {
+        verifySha256(archive, corpus.pin.sha256)
+        log.info(s"Using cached checksum-verified archive: $archive")
+      } else {
+        downloadArchive(corpus.archiveUrl, archive, log)
+        verifySha256(archive, corpus.pin.sha256)
+      }
+      extractCorpus(archive, corpus, vendorDir, log)
+    }
+  }
+
+  private def sha256Hex(file: File): String = {
+    val digest = java.security.MessageDigest.getInstance("SHA-256")
+    val in = new java.io.BufferedInputStream(new java.io.FileInputStream(file))
+    try {
+      val buffer = new Array[Byte](8192)
+      Iterator
+        .continually(in.read(buffer))
+        .takeWhile(_ != -1)
+        .foreach(read => digest.update(buffer, 0, read))
+    } finally in.close()
+    digest.digest().map("%02x".format(_)).mkString
+  }
+
+  private def verifySha256(file: File, expected: String): Unit = {
+    val actual = sha256Hex(file)
+    if (!actual.equalsIgnoreCase(expected))
+      sys.error(
+        s"Checksum mismatch for ${file.getName}: expected $expected but found $actual. " +
+          "Delete the cached archive and retry only after confirming the pinned upstream ref."
+      )
+  }
+
+  private def downloadArchive(url: String, target: File, log: Logger): Unit = {
+    val tmp = target.getParentFile / s".${target.getName}.download"
+    IO.delete(tmp)
+    log.info(s"Downloading $url")
+    val connection = new java.net.URI(url).toURL.openConnection()
+    connection.setConnectTimeout(15000)
+    connection.setReadTimeout(120000)
+    val in = new java.io.BufferedInputStream(connection.getInputStream)
+    try IO.transfer(in, tmp)
+    finally in.close()
+    IO.move(tmp, target)
+  }
+
+  private def extractCorpus(
+      archive: File,
+      corpus: VendorCorpus,
+      vendorDir: File,
+      log: Logger
+  ): File = {
+    val dest = vendorDir / corpus.targetName
+    val marker = dest / ".corpus-fetch.sha256"
+    if (dest.exists() && marker.exists() && IO.read(marker).trim == corpus.pin.sha256) {
+      log.info(s"${corpus.targetName} corpus is up to date: $dest")
+      dest
+    } else {
+      val tmp = vendorDir / s".${corpus.targetName}.tmp"
+      IO.delete(tmp)
+      IO.createDirectory(tmp)
+      val stripComponents = corpus.subtree.split('/').length + 1
+      val sourcePath = s"${corpus.archiveRoot}/${corpus.subtree}"
+      val rc = scala.sys.process.Process(
+        Seq(
+          "tar",
+          "-xzf",
+          archive.getAbsolutePath,
+          "-C",
+          tmp.getAbsolutePath,
+          s"--strip-components=$stripComponents",
+          sourcePath
+        )
+      ).!
+      if (rc != 0) sys.error(s"Failed to extract $sourcePath from ${archive.getName} (exit $rc)")
+      IO.delete(dest)
+      IO.move(tmp, dest)
+      IO.write(marker, corpus.pin.sha256 + "\n")
+      log.info(s"Extracted ${corpus.id} (${corpus.pin.ref}) to $dest")
+      dest
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a root corpusFetch sbt task for pinned upstream SemanticDB corpora
- cache checksum-verified source archives under target/vendor-corpus/_archives and extract stable scala-2.13 / scala-3 corpus paths
- document third-party attribution and explicitly ignore generated corpus output

## Verification
- rtk sbt --error corpusFetch cold/warm cache
- deliberate cached-archive corruption failed with checksum-mismatch error
- restored cache and reran rtk sbt --error corpusFetch
- rtk sbt --error scalafmtCheckAll
- rtk sbt --error test

Closes #199