### PR TITLE
test: expand CompatSuite with corpus-wide invariants (#201)

### DIFF
--- a/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/CompatSuite.scala
+++ b/analysis/src/test/scala/com/github/mercurievv/scalasemantic/analysis/CompatSuite.scala
@@ -223,3 +223,104 @@ class CompatSuite extends munit.FunSuite:
           }
         }
   }
+
+  // --- Corpus-wide invariants (#201) ------------------------------------------------------------
+  // Golden dirs above are small hand-authored fixtures probed by name (Dog/Animal/Show/...). These
+  // corpus roots hold real third-party sources (scalameta + scala-3 compiler corpora, produced by
+  // `./mill corpusGoldenAll` — build.mill `corpus` cross module — under `target/corpus/scala-
+  // <binVer>/`) — too large and unstable to name individual symbols, so we assert universal
+  // structural invariants over EVERY symbol instead: no exception, no silently empty/blank render.
+  // This surfaces printer/symbol-grammar gaps that named probes would miss.
+  private val corpusRoot: Option[Path] =
+    val rels = List("target/corpus")
+    val start = Paths.get("").toAbsolutePath
+    val bases =
+      Iterator
+        .unfold(start)(path => Option(path).map(current => current -> current.getParent))
+        .take(8)
+        .toList
+    (for base <- bases.iterator; rel <- rels.iterator; p = base.resolve(rel) if Files.isDirectory(p)
+    yield p).nextOption()
+
+  private val corpusVersionDirs: List[Path] =
+    corpusRoot match
+      case None    => Nil
+      case Some(r) =>
+        val s = Files.list(r)
+        try s.iterator.asScala.filter(Files.isDirectory(_)).toList.sortBy(_.getFileName.toString)
+        finally s.close()
+
+  corpusVersionDirs.foreach { dir =>
+    val version = dir.getFileName.toString
+    val idx = SemanticIndex.fromRoots(Seq(dir))
+    val az = Analyzer(idx)
+
+    val isType = (s: String) => s.endsWith("#")
+    val isMethod = (s: String) => s.endsWith(").")
+    val isCtor = (s: String) => s.contains("`<init>`")
+
+    test(s"[corpus $version] golden root has semanticdb symbols"):
+      assert(idx.symbols.nonEmpty, s"[corpus $version] no symbols loaded from $dir")
+
+    // `example/Shadow#*` (scala-3 corpus, `ShadowedParameters.scala`) is a fixture that deliberately
+    // makes every method in the class shadow its own parameters with a same-named local
+    // (`def f(x: Int) = { val x = ... }`) to stress-test shadowed-parameter symbol tracking. This
+    // is a confirmed scalac 3.8.4 SemanticDB-emission quirk, not an Analyzer gap: for each such
+    // method the compiler records its `MethodSignature.parameterLists` scope pointing at the
+    // block-shadowing locals (e.g. `Scope(Vector(local6, local5), Vector())`) instead of the real
+    // parameter symbols, and one of those locals carries a bogus `$anon`/untyped
+    // `SymbolInformation` — verified by dumping the raw info for `shadowInParamBlock`/`multiParams`.
+    // The printer correctly renders the empty type it was given. Excluded by owner prefix (not a
+    // broader filter), so any other real gap in the rest of the corpus still fails this invariant.
+    val knownEmptyTypeExceptionOwner = "example/Shadow#"
+
+    test(s"[corpus $version] no method signature renders an empty type (whole corpus)"):
+      idx.symbols.keys
+        .filter(s => isMethod(s) && !isCtor(s) && !s.startsWith(knownEmptyTypeExceptionOwner))
+        .flatMap(s => MethodSymbol.from(s).toOption)
+        .flatMap(m => az.methodSignature(m))
+        .foreach { sig =>
+          assert(!sig.returnType.isEmpty, s"[corpus $version] empty return type in: ${sig.symbol}")
+          sig.parameterLists.flatMap(_.parameters).foreach { p =>
+            assert(
+              !p.tpe.isEmpty,
+              s"[corpus $version] empty param type for ${p.name} in ${sig.symbol}"
+            )
+          }
+        }
+
+    test(s"[corpus $version] class-hierarchy runs over every type symbol without throwing"):
+      idx.symbols.keys
+        .filter(isType)
+        .flatMap(s => TypeSymbol.from(s).toOption)
+        .foreach { t =>
+          try az.classHierarchy(t)
+          catch case e: Throwable => fail(s"[corpus $version] classHierarchy threw on $t: $e")
+        }
+
+    test(s"[corpus $version] members runs over every type symbol without throwing"):
+      idx.symbols.keys
+        .filter(isType)
+        .flatMap(s => TypeSymbol.from(s).toOption)
+        .foreach { t =>
+          try az.members(t)
+          catch case e: Throwable => fail(s"[corpus $version] members threw on $t: $e")
+        }
+
+    test(s"[corpus $version] resolve-implicits runs over every type symbol without throwing"):
+      idx.symbols.keys
+        .filter(isType)
+        .flatMap(s => TypeSymbol.from(s).toOption)
+        .foreach { t =>
+          try az.resolveImplicits(t)
+          catch case e: Throwable => fail(s"[corpus $version] resolveImplicits threw on $t: $e")
+        }
+
+    test(s"[corpus $version] find-usages runs over every symbol without throwing"):
+      idx.symbols.keys
+        .flatMap(s => SemanticDbSymbol.from(s).toOption)
+        .foreach { sym =>
+          try az.findUsages(sym)
+          catch case e: Throwable => fail(s"[corpus $version] findUsages threw on $sym: $e")
+        }
+  }

--- a/docs/research/token-metrics-methodology.md
+++ b/docs/research/token-metrics-methodology.md
@@ -163,12 +163,12 @@ The auto-generated table below is kept in sync with
 
 | Query | MCP tool | Tool tokens | Baseline tokens | Delta | Savings |
 | --- | --- | ---: | ---: | ---: | ---: |
-| `find-usages-animal` | `find_usages` | 100 | 2810 | 2710 | 96.4% |
+| `find-usages-animal` | `find_usages` | 100 | 2858 | 2758 | 96.5% |
 | `class-hierarchy-animal` | `class_hierarchy` | 111 | 380 | 269 | 70.8% |
 | `method-signature-render` | `method_signature` | 83 | 379 | 296 | 78.1% |
 | `trace-implicit-show` | `trace_implicit_chain` | 56 | 379 | 323 | 85.2% |
 | `call-path-a-to-c` | `call_path` | 65 | 378 | 313 | 82.8% |
-| **Overall (5 queries)** | | **415** | **4326** | **3911** | **90.4%** |
+| **Overall (5 queries)** | | **415** | **4374** | **3959** | **90.5%** |
 
 <!-- END AUTO-GENERATED -->
 

--- a/docs/research/token-metrics.json
+++ b/docs/research/token-metrics.json
@@ -4,9 +4,9 @@
   "summary": {
     "queryCount": 5,
     "toolTokens": 415,
-    "baselineTokens": 4326,
-    "tokenDelta": 3911,
-    "savingsPercent": 90.4
+    "baselineTokens": 4374,
+    "tokenDelta": 3959,
+    "savingsPercent": 90.5
   },
   "queries": [
     {
@@ -15,11 +15,11 @@
       "tool": "find_usages",
       "baseline": "Text grep for Animal across fixture source trees.",
       "toolChars": 399,
-      "baselineChars": 11238,
+      "baselineChars": 11429,
       "toolTokens": 100,
-      "baselineTokens": 2810,
-      "tokenDelta": 2710,
-      "savingsPercent": 96.4
+      "baselineTokens": 2858,
+      "tokenDelta": 2758,
+      "savingsPercent": 96.5
     },
     {
       "id": "class-hierarchy-animal",


### PR DESCRIPTION
## Summary
- Adds a corpus-wide invariant suite to `CompatSuite.scala` (analysis module), running the full
  Analyzer surface over every symbol in the fetched scala-2.13/scala-3 corpora (`target/corpus/`,
  produced by `#200`'s `./mill corpusGoldenAll`), not just the hand-authored named-symbol probes
  already there.
- Invariants added, once per corpus version:
  - golden root loads a non-empty symbol set
  - no global method signature renders an empty return type or empty parameter type
  - class-hierarchy / members / resolve-implicits run over every type symbol without throwing
  - find-usages runs over every symbol without throwing
- Regenerated `docs/research/token-metrics.json` (`UPDATE_TOKEN_METRICS=1`), which drifted because
  growing this repo's own dogfooded SemanticDB shifted the MCP-vs-baseline token counts it snapshots.

## Investigation result
Running the "no empty type" invariant against the real scala-3 corpus surfaced two failures, both
traced to a single fixture: `example/Shadow#shadowInParamBlock()` and `example/Shadow#multiParams()`
in `ShadowedParameters.scala` — a corpus test file that deliberately shadows every method parameter
with a same-named local (`def f(x: Int) = { val x = ... }`), stress-testing symbol tracking under
shadowing.

Dumped the raw `SymbolInformation` for the offending method and confirmed this is a scalac 3.8.4
SemanticDB-emission quirk, not a gap in this repo's Analyzer/printer: the compiler records the
method's own `MethodSignature.parameterLists` scope pointing at the block-shadowing locals
(`Scope(Vector(local6, local5), Vector())`) instead of the real `(x, y)` parameter symbols, and one
of those locals itself carries a bogus `$anon`-named, untyped `SymbolInformation`. The Analyzer
correctly renders the empty type it was handed — there is nothing to fix on our side.

## Key decision
Excluded by owner prefix (`example/Shadow#`) with an inline comment documenting the root cause,
mirroring #200's per-file corpus excludes — narrow and symbol-scoped, so any other real
printer/symbol-grammar gap elsewhere in the corpus still fails the invariant.

## Test plan
- [x] `./mill analysis.test.testForked` — 246/246 green (was 1 failure before the documented
      exclusion; confirmed the invariant genuinely catches a real gap before excluding it)
- [x] `./mill checkFormatFirstParty` — clean
- [x] `./mill __.scalafixCheck` — clean
- [x] local `prePush` (664/664) — green after regenerating token-metrics baseline

Closes #201