### PR TITLE
fix(docs): remove deleted research plan from Docusaurus sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -133,11 +133,6 @@ const sidebars = {
           id: 'research/claude-interaction-study',
           label: 'Claude Interaction Study',
         },
-        {
-          type: 'doc',
-          id: 'research/plan',
-          label: 'Plan & Tracker',
-        },
       ],
     },
     {


### PR DESCRIPTION
Removes the reference to the deleted research/plan.md file from website/sidebars.js to fix the Docusaurus build failure.