### PR TITLE
docs: plain-args request block, side-by-side modified-code diff

### DIFF
--- a/docs/usage/enriching-tools.md
+++ b/docs/usage/enriching-tools.md
@@ -1,8 +1,5 @@
 # Enriching Tools — Compiler View vs. Source Text
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 These tools show the LLM what the compiler sees but the source text does not — inferred types, synthesized implicit arguments and conversions, resolved signatures. Every example below runs against the same source file, executed at docs build time by the real Scala 3.8.4 analyzer.
 
 ## Source under analysis
@@ -167,10 +164,12 @@ Below, the only change to `Enrich.scala` is a new `prefix: String` using-paramet
 +  prefix + sh.show(a)
 ```
 
-The three tabs run `method_signature` on the same `render` symbol: against the committed index, against the unmodified file through the presentation compiler (proving the two agree), and against the edited buffer — which reports the new parameter **without any recompile**.
+`method_signature` on the same `render` symbol, three ways side by side: against the committed index, against the unmodified file through the presentation compiler (proving the two agree), and against the edited buffer — which reports the new parameter **without any recompile**.
 
-<Tabs>
-<TabItem value="db" label="DB (committed)" default>
+<div className="row">
+<div className="col col--4">
+
+**DB (committed)**
 
 ```scala mdoc:passthrough
 println(scalasemantic.docs.ToolRunner.runPretty(
@@ -178,8 +177,10 @@ println(scalasemantic.docs.ToolRunner.runPretty(
   """{"symbol":"com/github/mercurievv/scalasemantic/docexamples/Enrich$package.render()."}"""))
 ```
 
-</TabItem>
-<TabItem value="pc-same" label="PC (same code)">
+</div>
+<div className="col col--4">
+
+**PC (same code)**
 
 ```scala mdoc:passthrough
 println(scalasemantic.docs.ToolRunner.runWithSourcePretty(
@@ -189,8 +190,10 @@ println(scalasemantic.docs.ToolRunner.runWithSourcePretty(
   "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala"))
 ```
 
-</TabItem>
-<TabItem value="pc-mod" label="PC (modified)">
+</div>
+<div className="col col--4">
+
+**PC (modified)**
 
 ```scala mdoc:passthrough
 println(scalasemantic.docs.ToolRunner.runWithSourcePretty(
@@ -200,7 +203,7 @@ println(scalasemantic.docs.ToolRunner.runWithSourcePretty(
   "docExamples/edited/Enrich_modified.scala"))
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</div>
 
 **Replaces:** Recompiling just to ask a question about half-finished code.

--- a/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
+++ b/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
@@ -69,16 +69,25 @@ object ToolRunner:
   def runWithSourcePretty(tool: String, args: String, uri: String, sourcePath: String): String =
     prettyMarkdown(tool, args, runWithSource(tool, args, uri, sourcePath))
 
-  /** `**Request:**` block rendering the tool name and its (pretty-printed) input params, shown
-    * ahead of the output so the reader sees what was asked before what was answered.
+  /** `**Request:**` block listing the tool name and its input params as plain `name: value` bullets
+    * (not a JSON blob — params are data, not code, so a formatted list reads faster), shown ahead
+    * of the output so the reader sees what was asked before what was answered.
     */
   private def requestMarkdown(tool: String, args: String): String =
-    val prettyArgs = scala.util.Try(ujson.write(ujson.read(args), indent = 2)).getOrElse(args)
+    val argLines = scala.util.Try(ujson.read(args)) match
+      case scala.util.Success(obj: ujson.Obj) if obj.obj.nonEmpty =>
+        obj.obj.toSeq
+          .map { case (k, v) =>
+            val value = v match
+              case ujson.Str(s) => s
+              case other        => ujson.write(other)
+            s"- **`$k`**: `$value`"
+          }
+          .mkString("\n")
+      case _ => "*(no parameters)*"
     s"""**Request:** `$tool`
        |
-       |```json
-       |$prettyArgs
-       |```""".stripMargin
+       |$argLines""".stripMargin
 
   private def prettyMarkdown(tool: String, args: String, raw: String): String =
     requestMarkdown(tool, args) + "\n\n" + resultMarkdown(raw)


### PR DESCRIPTION
Request block lists tool args as plain name:value bullets instead of a JSON blob. Tools on modified code now renders as a 3-column side-by-side row instead of tabs.