### PR TITLE
docs: live tool descriptions, single-source diff panels, vertical modified-code view

### DIFF
--- a/docs/usage/enriching-tools.md
+++ b/docs/usage/enriching-tools.md
@@ -4,53 +4,37 @@ These tools show the LLM what the compiler sees but the source text does not —
 
 ## Source under analysis
 
-`Enrich.scala` — a small typeclass (`Show`), two `given` instances, and two calls to a generic `render` method that hides its resolved implicit argument:
+`Enrich.scala` — a small typeclass (`Show`), two `given` instances, and two calls to a generic `render` method that hides its resolved implicit argument. Read straight from the fixture file the tool calls below actually analyze, so this block can never drift from what's shown as "Original" further down.
 
-```scala mdoc:silent
-trait Show[A]:
-  def show(a: A): String
-
-given intShow: Show[Int] with
-  def show(a: Int) = a.toString
-
-given listShow[A](using sh: Show[A]): Show[List[A]] with
-  def show(a: List[A]) = a.map(sh.show).mkString("[", ", ", "]")
-
-def render[A](a: A)(using sh: Show[A]): String =
-  sh.show(a)
-
-val out = render(List(1, 2, 3))
-val num = render(42)
+```scala mdoc:passthrough
+val enrichPath = "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala"
+println(s"```scala\n${scalasemantic.docs.ToolRunner.readSource(enrichPath)}\n```")
 ```
 
 None of the `(using ...)` arguments or inferred return types above are written in the source — the tools below make them visible.
 
 ## annotated_source
 
-> **Answers:** The compiler's exact view of the file: inferred types on every binding, synthesized (using) arguments, implicit conversions.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("annotated_source"))
+```
 
-The compiler injects `(using intShow)` and `(using listShow(...))` into the `render` calls, and infers the return type `: String` on the `out` and `num` bindings — none visible in source text. Side by side:
+The compiler injects `(using intShow)` and `(using listShow(...))` into the `render` calls, and infers the return type `: String` on the `out` and `num` bindings — none visible in source text.
+
+```scala mdoc:passthrough
+val annotatedArgs =
+  s"""{"uri":"$enrichPath","format":"annotated","annotationsOnly":true}"""
+val annotatedRaw = scalasemantic.docs.ToolRunner.run("annotated_source", annotatedArgs)
+println(scalasemantic.docs.ToolRunner.requestMarkdown("annotated_source", annotatedArgs))
+```
 
 <div className="row">
 <div className="col col--6">
 
 **Original**
 
-```scala
-trait Show[A]:
-  def show(a: A): String
-
-given intShow: Show[Int] with
-  def show(a: Int) = a.toString
-
-given listShow[A](using sh: Show[A]): Show[List[A]] with
-  def show(a: List[A]) = a.map(sh.show).mkString("[", ", ", "]")
-
-def render[A](a: A)(using sh: Show[A]): String =
-  sh.show(a)
-
-val out = render(List(1, 2, 3))
-val num = render(42)
+```scala mdoc:passthrough
+println(s"```scala\n${scalasemantic.docs.ToolRunner.readSource(enrichPath)}\n```")
 ```
 
 </div>
@@ -59,13 +43,15 @@ val num = render(42)
 **Enriched (compiler view)**
 
 ```scala mdoc:passthrough
-println(scalasemantic.docs.ToolRunner.runPretty(
-  "annotated_source",
-  """{"uri":"docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala","format":"annotated","annotationsOnly":true}"""))
+println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(annotatedRaw, "source")}\n```")
 ```
 
 </div>
 </div>
+
+```scala mdoc:passthrough
+println(scalasemantic.docs.ToolRunner.detailsMarkdown(annotatedRaw, Seq("source")))
+```
 
 **Replaces:** Reading 15 lines of source → 10 lines with compiler-visible facts.
 
@@ -73,7 +59,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ## method_signature
 
-> **Answers:** The full resolved signature of a method — including the `(using ...)` / implicit parameter lists that are written once at the definition and never at the call sites.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("method_signature"))
+```
 
 The `render` calls in the source read `render(List(1, 2, 3))` — the `Show` instance is invisible there. The signature makes the whole contract explicit.
 
@@ -89,14 +77,14 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ## document_outline
 
-> **Answers:** File outline with compiler-rendered signatures (compiler names, not source text).
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("document_outline"))
+```
 
 The tool returns a tree with compiler-rendered names instead of a text scan. For a 50-line file, the outline is 5–10 lines; for 1000 lines, still manageable.
 
 ```scala mdoc:passthrough
-println(scalasemantic.docs.ToolRunner.runPretty(
-  "document_outline",
-  """{"uri":"docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala"}"""))
+println(scalasemantic.docs.ToolRunner.runPretty("document_outline", s"""{"uri":"$enrichPath"}"""))
 ```
 
 **Replaces:** Scanning files → structured outline.
@@ -105,14 +93,15 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ## type_at_position
 
-> **Answers:** The inferred type at a specific source location.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("type_at_position"))
+```
 
 No inference needed by hand; the tool returns the exact type the compiler assigned. For complex generics and implicit resolution, invaluable.
 
 ```scala mdoc:passthrough
 println(scalasemantic.docs.ToolRunner.runPretty(
-  "type_at_position",
-  """{"uri":"docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala","line":14,"character":6}"""))
+  "type_at_position", s"""{"uri":"$enrichPath","line":14,"character":6}"""))
 ```
 
 **Replaces:** Hand type inference → compiler's answer.
@@ -121,7 +110,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ## resolve_implicits
 
-> **Answers:** Which given/implicit definitions can produce a wanted type — the search the compiler does at every implicit parameter, which text search cannot do.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("resolve_implicits"))
+```
 
 For `Show[_]`, two givens qualify: `intShow` directly and `listShow` (itself parameterized on another `Show`).
 
@@ -137,7 +128,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ## trace_implicit_chain
 
-> **Answers:** The givens that produce a type **and the implicits they transitively pull in** — implicit resolution followed step by step.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("trace_implicit_chain"))
+```
 
 `listShow` produces `Show[List[A]]` only by depending on a `Show[A]`; the chain makes that dependency explicit.
 
@@ -164,46 +157,35 @@ Below, the only change to `Enrich.scala` is a new `prefix: String` using-paramet
 +  prefix + sh.show(a)
 ```
 
-`method_signature` on the same `render` symbol, three ways side by side: against the committed index, against the unmodified file through the presentation compiler (proving the two agree), and against the edited buffer — which reports the new parameter **without any recompile**.
-
-<div className="row">
-<div className="col col--4">
-
-**DB (committed)**
+`method_signature` runs on the same `render` symbol, with the same arguments, three ways: against the committed index, against the unmodified file through the presentation compiler (proving the two agree), and against the edited buffer — which reports the new parameter **without any recompile**.
 
 ```scala mdoc:passthrough
-println(scalasemantic.docs.ToolRunner.runPretty(
-  "method_signature",
-  """{"symbol":"com/github/mercurievv/scalasemantic/docexamples/Enrich$package.render()."}"""))
+val modSigArgs =
+  """{"symbol":"com/github/mercurievv/scalasemantic/docexamples/Enrich$package.render()."}"""
+println(scalasemantic.docs.ToolRunner.requestMarkdown("method_signature", modSigArgs))
 ```
 
-</div>
-<div className="col col--4">
-
-**PC (same code)**
+### DB (committed)
 
 ```scala mdoc:passthrough
-println(scalasemantic.docs.ToolRunner.runWithSourcePretty(
-  "method_signature",
-  """{"symbol":"com/github/mercurievv/scalasemantic/docexamples/Enrich$package.render()."}""",
-  "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
-  "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala"))
+val dbRaw = scalasemantic.docs.ToolRunner.run("method_signature", modSigArgs)
+println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(dbRaw, "signature")}\n```")
 ```
 
-</div>
-<div className="col col--4">
-
-**PC (modified)**
+### PC (same code)
 
 ```scala mdoc:passthrough
-println(scalasemantic.docs.ToolRunner.runWithSourcePretty(
-  "method_signature",
-  """{"symbol":"com/github/mercurievv/scalasemantic/docexamples/Enrich$package.render()."}""",
-  "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
-  "docExamples/edited/Enrich_modified.scala"))
+val pcSameRaw = scalasemantic.docs.ToolRunner.runWithSource(
+  "method_signature", modSigArgs, enrichPath, enrichPath)
+println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(pcSameRaw, "signature")}\n```")
 ```
 
-</div>
-</div>
+### PC (modified)
+
+```scala mdoc:passthrough
+val pcModRaw = scalasemantic.docs.ToolRunner.runWithSource(
+  "method_signature", modSigArgs, enrichPath, "docExamples/edited/Enrich_modified.scala")
+println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(pcModRaw, "signature")}\n```")
+```
 
 **Replaces:** Recompiling just to ask a question about half-finished code.

--- a/docs/usage/tool-examples.md
+++ b/docs/usage/tool-examples.md
@@ -36,7 +36,9 @@ These tools return precise semantic answers — a symbol, a usage set, a hierarc
 
 ### find_symbol
 
-> **Answers:** The symbol (definition and fully qualified name) for a plain name in code.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("find_symbol"))
+```
 
 Grep `transform` returns 5+ matches across comments and strings. `find_symbol` returns 1 definition.
 
@@ -52,7 +54,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ### class_hierarchy
 
-> **Answers:** The supertypes and subtypes of a class or trait.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("class_hierarchy"))
+```
 
 ```scala mdoc:passthrough
 val procSym = scalasemantic.docs.ToolRunner.run("find_symbol", """{"query":"Processor"}""")
@@ -67,7 +71,9 @@ println(scalasemantic.docs.ToolRunner.runPretty("class_hierarchy", s"""{"symbol"
 
 ### find_overloads
 
-> **Answers:** All overloads of a method.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("find_overloads"))
+```
 
 ```scala mdoc:passthrough
 val fmtSym = scalasemantic.docs.ToolRunner.run("find_symbol", """{"query":"format"}""")
@@ -82,7 +88,9 @@ println(scalasemantic.docs.ToolRunner.runPretty("find_overloads", s"""{"symbol":
 
 ### find_usages
 
-> **Answers:** All references to a symbol (exact, no over-matching comments or strings).
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("find_usages"))
+```
 
 ```scala mdoc:passthrough
 val useSym = scalasemantic.docs.ToolRunner.run("find_symbol", """{"query":"transform"}""")
@@ -97,7 +105,9 @@ println(scalasemantic.docs.ToolRunner.runPretty("find_usages", s"""{"symbol":"$u
 
 ### members
 
-> **Answers:** All declared and inherited members of a class or trait.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("members"))
+```
 
 ```scala mdoc:passthrough
 val memSym = scalasemantic.docs.ToolRunner.run("find_symbol", """{"query":"UpperProcessor"}""")
@@ -112,7 +122,9 @@ println(scalasemantic.docs.ToolRunner.runPretty("members", s"""{"symbol":"$memSy
 
 ### call_path
 
-> **Answers:** Whether method A reaches method B, and the exact call chain that connects them.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("call_path"))
+```
 
 `pipeline` never calls `process` directly, but reaches it through `compose` and `transform`. The tool returns the shortest path and the call-site of every edge.
 
@@ -128,7 +140,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ### method_call_hierarchy
 
-> **Answers:** The transitive callers (incoming) or callees (outgoing) of a method, as a tree.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("method_call_hierarchy"))
+```
 
 Outgoing from `pipeline`: `compose`, then the two `transform` calls, then `process` — the whole fan-out in one call.
 
@@ -144,7 +158,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ### value_flow
 
-> **Answers:** How a value propagates through the code — following it across method boundaries into renamed parameters, and classifying where it ends up.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("value_flow"))
+```
 
 The `input` parameter of `pipeline` flows into `compose`'s `input`, then `transform`'s `input`, then `process`'s `x` — a rename at every hop that text search cannot follow.
 
@@ -160,7 +176,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ### rename_plan
 
-> **Answers:** Exact character ranges to rewrite for a safe rename.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("rename_plan"))
+```
 
 The tool returns exact line and character ranges for every reference. No over-matching strings or comments.
 
@@ -177,7 +195,9 @@ println(scalasemantic.docs.ToolRunner.runPretty("rename_plan", s"""{"symbol":"$r
 
 ### move_plan
 
-> **Answers:** Exact edits to move a top-level symbol to a different package.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("move_plan"))
+```
 
 ```scala mdoc:passthrough
 val movSym = scalasemantic.docs.ToolRunner.run("find_symbol", """{"query":"calculateTotal"}""")
@@ -192,7 +212,9 @@ println(scalasemantic.docs.ToolRunner.runPretty("move_plan", s"""{"symbol":"$mov
 
 ### extract_method_plan
 
-> **Answers:** Edits to extract a code range into a new method.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("extract_method_plan"))
+```
 
 The tool analyzes the range, identifies local variables and scope, returns exact edits.
 
@@ -208,7 +230,9 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 ### structure
 
-> **Answers:** Project-wide dependency graph, metrics, and cycles.
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("structure"))
+```
 
 A snapshot of entire dependency structure in one call.
 
@@ -222,7 +246,9 @@ println(scalasemantic.docs.ToolRunner.runPretty("structure", "{}"))
 
 ### smart_code_duplications
 
-> **Answers:** Structurally identical code blocks (not text-matched).
+```scala mdoc:passthrough
+println("> **Answers:** " + scalasemantic.docs.ToolRunner.describe("smart_code_duplications"))
+```
 
 The tool finds structural duplicates (same pattern, different names), ignoring syntactic noise.
 

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/ToolCli.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/ToolCli.scala
@@ -28,19 +28,29 @@ object ToolCli:
         .getOrElse(sys.error(s"unknown tool: $toolName (have: ${tools.map(_.name).mkString(",")})"))
       ujson.write(tool.run(args), indent = 2)
 
-    val output = m.get("source") match
-      case Some(sourcePath) =>
-        val uri = m("uri")
-        val sourceText = new String(Files.readAllBytes(Paths.get(sourcePath)))
-        argsJson("source") = sourceText
-        argsJson("uri") = uri
-        PresentationCompilerBackend.useCurrentJvm(workspace = Some(root)) { backend =>
-          runTool(Analyzer(index, Some(backend)), argsJson)
-        }
-      case None =>
-        runTool(Analyzer(index), argsJson)
+    // `--describe` short-circuits before running the tool: callers pull each tool's live
+    // `description` (the same string an MCP client sees via `tools/list`) instead of a
+    // hand-maintained blurb that can drift from what the server actually reports.
+    if m.contains("describe") then
+      val tools = McpTools.all(Analyzer(index), root)
+      val tool = tools
+        .find(_.name == toolName)
+        .getOrElse(sys.error(s"unknown tool: $toolName (have: ${tools.map(_.name).mkString(",")})"))
+      println(tool.description)
+    else
+      val output = m.get("source") match
+        case Some(sourcePath) =>
+          val uri = m("uri")
+          val sourceText = new String(Files.readAllBytes(Paths.get(sourcePath)))
+          argsJson("source") = sourceText
+          argsJson("uri") = uri
+          PresentationCompilerBackend.useCurrentJvm(workspace = Some(root)) { backend =>
+            runTool(Analyzer(index, Some(backend)), argsJson)
+          }
+        case None =>
+          runTool(Analyzer(index), argsJson)
 
-    println(output)
+      println(output)
 
   private def parse(args: Array[String]): Map[String, String] =
     def loop(idx: Int, acc: Map[String, String]): Map[String, String] =

--- a/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
+++ b/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
@@ -10,6 +10,12 @@ object ToolRunner:
   private def index = sys.props("scalasemantic.docs.indexDir")
   private def root = sys.props.getOrElse("scalasemantic.docs.root", ".")
 
+  /** Field names whose value is source-code-shaped even on a single line (no embedded `\n`), so
+    * they're always pulled into their own fenced `scala` block by [[resultMarkdown]] instead of
+    * being left to plain (unhighlighted) JSON.
+    */
+  private val codeFields = Set("source", "signature")
+
   def run(tool: String, args: String): String =
     os
       .proc(
@@ -57,23 +63,56 @@ object ToolRunner:
       .text()
       .trim
 
-  /** Markdown for a tool's JSON result: any top-level string field that carries embedded newlines
-    * (e.g. `annotated_source`'s `source`) is pulled into its own fenced Scala block — multi-line
-    * and readable — instead of sitting escaped as `\n` inside one JSON line. The full JSON (with
-    * those fields elided, since they're already shown above) follows in a collapsed `<details>` so
-    * the extracted code stays the visually primary content.
+  /** The tool's own `description` field — the same string an MCP client sees via `tools/list` —
+    * instead of a hand-maintained doc blurb that can drift from what the server actually reports.
+    */
+  def describe(tool: String): String =
+    os
+      .proc(
+        "java",
+        "-cp",
+        jar,
+        "com.github.mercurievv.scalasemantic.mcp.ToolCli",
+        "--index",
+        index,
+        "--root",
+        root,
+        "--tool",
+        tool,
+        "--describe"
+      )
+      .call(check = true)
+      .out
+      .text()
+      .trim
+
+  /** Reads a fixture file relative to the docs root — the same file a tool call's `uri`/`source`
+    * argument points at, so a "source under analysis" block and a tool's own output are always
+    * printing the exact same bytes, never a hand-copied (and driftable) duplicate.
+    */
+  def readSource(relativePath: String): String =
+    os.read(os.Path(root, os.pwd) / os.RelPath(relativePath)).stripLineEnd
+
+  /** Markdown for a tool's JSON result: any top-level field that's source-code-shaped (either it
+    * carries embedded newlines, e.g. `annotated_source`'s `source`, or its name is in
+    * [[codeFields]], e.g. `method_signature`'s `signature`) is pulled into its own fenced Scala
+    * block — highlighted, readable — instead of sitting escaped/unhighlighted inside JSON. The
+    * remaining fields (references, symbols, counts — plain data, not code) stay as formatted JSON
+    * in a collapsed `<details>` so the extracted code stays the visually primary content.
     */
   def runPretty(tool: String, args: String): String =
-    prettyMarkdown(tool, args, run(tool, args))
+    requestMarkdown(tool, args) + "\n\n" + resultMarkdown(run(tool, args))
 
   def runWithSourcePretty(tool: String, args: String, uri: String, sourcePath: String): String =
-    prettyMarkdown(tool, args, runWithSource(tool, args, uri, sourcePath))
+    requestMarkdown(tool, args) + "\n\n" + resultMarkdown(
+      runWithSource(tool, args, uri, sourcePath)
+    )
 
   /** `**Request:**` block listing the tool name and its input params as plain `name: value` bullets
     * (not a JSON blob — params are data, not code, so a formatted list reads faster), shown ahead
     * of the output so the reader sees what was asked before what was answered.
     */
-  private def requestMarkdown(tool: String, args: String): String =
+  def requestMarkdown(tool: String, args: String): String =
     val argLines = scala.util.Try(ujson.read(args)) match
       case scala.util.Success(obj: ujson.Obj) if obj.obj.nonEmpty =>
         obj.obj.toSeq
@@ -91,31 +130,39 @@ object ToolRunner:
        |
        |$argLines""".stripMargin
 
-  private def prettyMarkdown(tool: String, args: String, raw: String): String =
-    requestMarkdown(tool, args) + "\n\n" + resultMarkdown(raw)
+  /** Pulls a single field's value out of a tool's raw JSON, unwrapped (no markdown fencing) so the
+    * caller can place it inside a custom layout (e.g. a diff panel).
+    */
+  def extractField(raw: String, field: String): String =
+    ujson.read(raw).obj(field).str
+
+  /** Collapsed `<details>` block with the raw JSON, eliding fields already shown elsewhere (e.g. as
+    * an extracted code block via [[extractField]]) so nothing is printed twice.
+    */
+  def detailsMarkdown(raw: String, elideFields: Seq[String] = Nil): String =
+    val parsed = ujson.read(raw)
+    val elided = ujson.Obj.from(parsed.obj.toSeq.map { case (k, v) =>
+      if elideFields.contains(k) then k -> ujson.Str("(shown above)") else k -> v
+    })
+    val redactedJson = ujson.write(elided, indent = 2)
+    s"""<details>
+       |<summary>Raw JSON</summary>
+       |
+       |```json
+       |$redactedJson
+       |```
+       |
+       |</details>""".stripMargin
 
   private def resultMarkdown(raw: String): String =
     val parsed = ujson.read(raw)
-    val multilineFields = parsed.obj.toSeq.collect {
-      case (k, ujson.Str(v)) if v.contains("\n") =>
+    val codeLikeFields = parsed.obj.toSeq.collect {
+      case (k, ujson.Str(v)) if v.contains("\n") || codeFields.contains(k) =>
         k -> v
     }
-    if multilineFields.isEmpty then s"```json\n$raw\n```"
+    if codeLikeFields.isEmpty then s"```json\n$raw\n```"
     else
-      val codeBlocks = multilineFields
+      val codeBlocks = codeLikeFields
         .map { case (k, v) => s"**`$k`:**\n\n```scala\n$v\n```" }
         .mkString("\n\n")
-      val elided = ujson.Obj.from(parsed.obj.toSeq.map { case (k, v) =>
-        if multilineFields.exists(_._1 == k) then k -> ujson.Str("(shown above)") else k -> v
-      })
-      val redactedJson = ujson.write(elided, indent = 2)
-      s"""$codeBlocks
-         |
-         |<details>
-         |<summary>Raw JSON</summary>
-         |
-         |```json
-         |$redactedJson
-         |```
-         |
-         |</details>""".stripMargin
+      s"$codeBlocks\n\n${detailsMarkdown(raw, codeLikeFields.map(_._1))}"


### PR DESCRIPTION
Addresses layout/content feedback on the enriching-tools diff page:

- ToolCli gains a `--describe` flag that prints a tool's live `description` field (the same string
  an MCP client sees via `tools/list`). Docs no longer hand-maintain "Answers:" blurbs that can
  drift from what the server actually reports — every tool section now pulls its description live.
- `annotated_source`'s diff panel: Request+Arguments now render once, above the Original/Enriched
  row (previously nested only under the right column). The right-hand label changed from a raw
  `source:` field to "Enriched (compiler view)" to match the left column's "Original" heading.
- Both columns read from `ToolRunner.readSource`, which loads the real fixture file straight off
  disk — the same file the tool call's `uri` points at — so "Original" can never drift from a
  hand-copied duplicate.
- `resultMarkdown` now force-extracts known code-shaped fields (`signature`, in addition to
  `source`) into their own highlighted `scala` fence even when the value has no embedded newline,
  so `method_signature`/`extract_method_plan` output highlights just the signature, not the
  surrounding JSON.
- "Tools on modified code": the three `method_signature` calls share one Request+Arguments block
  (they use identical args) instead of repeating it 3x, and render as three vertical sections
  instead of a 3-column side-by-side row (too cramped at that width).
- Added `docusaurus.config.js` Prism config: Scala isn't in Docusaurus's default language bundle,
  so `.scala` fences rendered unhighlighted; `additionalLanguages: ['java','scala','diff','json']`
  fixes that (java must precede scala — the scala grammar extends it).

Verified: `mill mcp.compile`/`docs.compile` clean, `mill docs.checkFormat`/`docs.run` clean,
`npm run build` clean (only preexisting unrelated broken-link warnings), and `mill prePush` full
suite green via tree2m.