### PR TITLE
fix: batch tool-description lookups into one subprocess call

### DIFF
--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/ToolCli.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/ToolCli.scala
@@ -28,15 +28,15 @@ object ToolCli:
         .getOrElse(sys.error(s"unknown tool: $toolName (have: ${tools.map(_.name).mkString(",")})"))
       ujson.write(tool.run(args), indent = 2)
 
-    // `--describe` short-circuits before running the tool: callers pull each tool's live
-    // `description` (the same string an MCP client sees via `tools/list`) instead of a
-    // hand-maintained blurb that can drift from what the server actually reports.
+    // `--describe` short-circuits before running any tool and dumps EVERY tool's live
+    // `description` (the same string an MCP client sees via `tools/list`) as one JSON array, in one
+    // subprocess call — instead of a hand-maintained blurb that can drift from what the server
+    // actually reports, and instead of one JVM spin-up per tool (multiplies badly across a doc
+    // build with dozens of tool sections).
     if m.contains("describe") then
       val tools = McpTools.all(Analyzer(index), root)
-      val tool = tools
-        .find(_.name == toolName)
-        .getOrElse(sys.error(s"unknown tool: $toolName (have: ${tools.map(_.name).mkString(",")})"))
-      println(tool.description)
+      val descriptions = tools.map(t => ujson.Obj("name" -> t.name, "description" -> t.description))
+      println(ujson.write(ujson.Arr(descriptions*), indent = 2))
     else
       val output = m.get("source") match
         case Some(sourcePath) =>

--- a/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
+++ b/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
@@ -63,11 +63,13 @@ object ToolRunner:
       .text()
       .trim
 
-  /** The tool's own `description` field — the same string an MCP client sees via `tools/list` —
-    * instead of a hand-maintained doc blurb that can drift from what the server actually reports.
+  /** Every tool's own `description` field — the same string an MCP client sees via `tools/list` —
+    * fetched with ONE subprocess call and cached for the life of the doc build, instead of a
+    * hand-maintained blurb that can drift, and instead of spawning a fresh JVM per tool (this doc
+    * set alone has ~20 tool sections; that many extra JVM spin-ups per build is unnecessary load).
     */
-  def describe(tool: String): String =
-    os
+  private lazy val descriptions: Map[String, String] =
+    val raw = os
       .proc(
         "java",
         "-cp",
@@ -78,13 +80,16 @@ object ToolRunner:
         "--root",
         root,
         "--tool",
-        tool,
+        "*",
         "--describe"
       )
       .call(check = true)
       .out
       .text()
       .trim
+    ujson.read(raw).arr.map(o => o("name").str -> o("description").str).toMap
+
+  def describe(tool: String): String = descriptions(tool)
 
   /** Reads a fixture file relative to the docs root — the same file a tool call's `uri`/`source`
     * argument points at, so a "source under analysis" block and a tool's own output are always


### PR DESCRIPTION
docs-deploy.yml failed on the previous PR's merge (run 29198095224, "Render docs with mdoc" step)
with mdoc reporting "0 errors" yet the mill task still exiting 1 — a runtime failure inside a
fence, not a compile error. Reproduced fine on a clean local clone, so the likely cause is
CI-resource-specific: the prior change added a `ToolRunner.describe(tool)` call per tool section
(~20 across the two docs pages), each shelling out to a brand-new JVM that rebuilds the full
SemanticIndex + tool list just to read one `description` string — on a constrained CI runner that's
a lot of extra JVM spin-up pressure on top of the existing per-example tool-call subprocesses.

Fix: `ToolCli --describe` now dumps every tool's `name`/`description` as one JSON array in a single
call (ignoring `--tool`), and `ToolRunner.descriptions` fetches + caches it once (lazy val) for the
whole doc build instead of once per tool. Cuts ~19 subprocess spawns down to 1.

Verified: mill mcp.compile/docs.compile clean, mill docs.checkFormat/docs.run clean locally AND on
a fresh clone (16s, down from ~20-30s), npm run build clean, output content unchanged (checked
Answers lines in both docs pages still populate correctly).