### PR TITLE
fix(mcp): anchor annotated_source terse notes to the call, name summoned givens by type

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -186,9 +186,21 @@ final class Analyzer(
       detail: SourceDetail = SourceDetail.Terse
   ): Option[List[SourceAnnotation]] =
     index.document(uri.value).map { doc =>
-      val synthetic = detail match
-        case SourceDetail.Terse => doc.synthetics.iterator.flatMap(h.syntheticAnnotation).toList
-        case SourceDetail.Full  => fullAnnotations(doc, sourceLines)
+      val synthetic0 = detail match
+        case SourceDetail.Terse =>
+          doc.synthetics.iterator.flatMap(h.syntheticAnnotation(_, sourceLines)).toList
+        case SourceDetail.Full => fullAnnotations(doc, sourceLines)
+      // Drop the redundant `(using …)` a given/def forwards into its OWN construction: the note
+      // lands on the definition's header (at or before its name), and that using-param is already
+      // written in the signature. A genuine call-site using in the body sits AFTER the name.
+      val defStarts = doc.occurrences.iterator
+        .filter(_.role == s.SymbolOccurrence.Role.DEFINITION)
+        .flatMap(_.range)
+        .map(r => (r.startLine, r.startCharacter))
+        .toList
+      val synthetic = synthetic0.filterNot(a =>
+        a.kind == "implicit" && defStarts.exists((dl, dc) => dl == a.line && dc >= a.character)
+      )
       val defTypes = doc.occurrences.iterator.flatMap(h.defTypeAnnotation(_, sourceLines)).toList
       (synthetic ++ defTypes).distinct.sortBy(a => (a.line, a.character, a.kind))
     }

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
@@ -40,24 +40,30 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
     * zero-width enclosing point and so carries no trustworthy column. `None` for synthetics we do
     * not surface.
     */
-  def syntheticAnnotation(syn: s.Synthetic): Option[SourceAnnotation] =
+  def syntheticAnnotation(
+      syn: s.Synthetic,
+      sourceLines: IndexedSeq[String]
+  ): Option[SourceAnnotation] =
     val r = syn.range.getOrElse(s.Range.defaultInstance)
     syn.tree match
       case t: s.TypeApplyTree if t.typeArguments.nonEmpty =>
+        // Anchor the inferred type-args to the CALL they apply to (`a.map[String]`), not the token
+        // at the range start — which is the receiver (`a`), reading as `a[String]`.
+        val targs = t.typeArguments.map(renderType).mkString("[", ", ", "]")
+        val anchor = functionAnchor(t.function, sourceLines)
         Some(
           SourceAnnotation(
             r.startLine,
             r.startCharacter,
             "inferred-type-args",
-            t.typeArguments.map(renderType).mkString("[", ", ", "]")
+            if anchor.isEmpty then targs else s"$anchor$targs"
           )
         )
       case app: s.ApplyTree =>
         app.function match
-          // using-args appended to a visible call: the function IS the original expression, so the
-          // range is the enclosing point, not where the args belong — no reliable column.
+          // using-args appended to a visible call: the function IS the original expression.
           case _: s.OriginalTree =>
-            val args = app.arguments.iterator.flatMap(insertedName).toList
+            val args = app.arguments.iterator.flatMap(insertedSymbol).map(givenDisplay).toList
             Option.when(args.nonEmpty)(
               SourceAnnotation(
                 r.startLine,
@@ -66,22 +72,74 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
                 args.mkString("(using ", ", ", ")")
               )
             )
-          // an implicit conversion wraps the original expression: the range pins the converted
-          // expression, so the column is meaningful.
+          // an implicit conversion wraps the original expression: show `conv(convertedExpr)`.
+          // `apply` is the compiler's `.apply` insertion, not a real conversion — the type-args
+          // note already covers that call, so drop it here.
           case fn =>
-            insertedName(fn).map(c =>
-              SourceAnnotation(r.startLine, r.startCharacter, "implicit-conversion", s"$c(…)")
-            )
+            insertedName(fn).filter(_ != "apply").map { c =>
+              val arg =
+                app.arguments.headOption.flatMap(convertedText(_, sourceLines)).getOrElse("…")
+              SourceAnnotation(r.startLine, r.startCharacter, "implicit-conversion", s"$c($arg)")
+            }
       case _ => None
 
-  /** Best-effort display name of an inserted implicit tree (a given/implicit reference). */
-  def insertedName(tree: s.Tree): Option[String] =
+  /** The symbol an inserted implicit tree (a given/implicit/conversion reference) resolves to. */
+  def insertedSymbol(tree: s.Tree): Option[String] =
     tree match
-      case t: s.IdTree        => Some(index.displayName(t.symbol))
-      case t: s.SelectTree    => t.id.flatMap(insertedName)
-      case t: s.TypeApplyTree => insertedName(t.function)
-      case t: s.ApplyTree     => insertedName(t.function)
+      case t: s.IdTree        => Some(t.symbol)
+      case t: s.SelectTree    => t.id.flatMap(insertedSymbol)
+      case t: s.TypeApplyTree => insertedSymbol(t.function)
+      case t: s.ApplyTree     => insertedSymbol(t.function)
       case _                  => None
+
+  /** Plain display name of an inserted implicit tree (used for conversion names — NOT type-ified).
+    */
+  def insertedName(tree: s.Tree): Option[String] =
+    insertedSymbol(tree).map(index.displayName)
+
+  /** How to name a summoned given: its identifier when informative, else its TYPE. A synthetic
+    * evidence/`x$` parameter (`evidence$1`) or a type-like capitalised standard given (`Int`, the
+    * `Ordering.Int` val) tells the reader nothing — render `Show[A]` / `Ordering[Int]` instead.
+    */
+  private def givenDisplay(symbol: String): String =
+    val name = index.displayName(symbol)
+    val uninformative = name.isEmpty || name.contains('$') || name.headOption.exists(_.isUpper)
+    if !uninformative then name
+    else
+      val tpe = renderType(index.info(symbol).map(valueType).getOrElse(s.Type.Empty))
+      if tpe.nonEmpty then tpe
+      else
+        // stdlib givens (`Ordering.Int`) carry no indexed signature — synthesize `Owner[Name]`.
+        val owner = index.displayName(index.owner(symbol))
+        if owner.nonEmpty && name.nonEmpty then s"$owner[$name]" else name
+
+  /** The call a synthetic's function applies to, for anchoring a type-args note: `render`, `a.map`,
+    * `List.apply`. Reuses [[renderTree]] to render the function expression, then collapses a
+    * complex receiver (one containing a nested call) to just its trailing `.method`, so the note
+    * never re-inlines a whole sub-expression.
+    */
+  def functionAnchor(tree: s.Tree, sourceLines: IndexedSeq[String]): String =
+    val full = renderTree(tree, sourceLines)
+    if full.nonEmpty && !full.contains('(') && full.length <= 24 then full
+    else
+      tree match
+        case t: s.TypeApplyTree => functionAnchor(t.function, sourceLines)
+        case t: s.SelectTree    => t.id.map(id => s".${renderTree(id, sourceLines)}").getOrElse("…")
+        case _ if full.isEmpty  => ""
+        case _                  =>
+          // complex `OriginalTree` (e.g. `List(...).sortBy`): keep only the trailing `.member`.
+          val dot = full.lastIndexOf('.')
+          if dot >= 0 && dot < full.length - 1 && !full.substring(dot + 1).exists("([".contains(_))
+          then s".${full.substring(dot + 1)}"
+          else "…"
+
+  /** Source text of the expression an implicit conversion wrapped, if recoverable. */
+  private def convertedText(tree: s.Tree, sourceLines: IndexedSeq[String]): Option[String] =
+    tree match
+      case o: s.OriginalTree =>
+        val src = originalText(o.range, sourceLines, Map.empty)
+        Option.when(src.nonEmpty)(src)
+      case _ => None
 
   /** Render one synthetic tree as a compact elaborated expression. */
   def renderTree(

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -168,42 +168,15 @@ private[mcp] object McpToolsSupport:
             val base = if gutter then f"${i + 1}%5d  $src" else src
             if notes.isEmpty || fmt == SourceFormat.Plain then Some(base)
             else
-              val joined = notes.map(n => noteText(src, n)).mkString("; ")
+              // Each note is self-anchored by the analysis layer (e.g. `a.map[String]`,
+              // `(using Show[A])`) — the renderer just joins them, no column arithmetic.
+              val joined = notes.map(_.text).mkString("; ")
               Some(
                 if fmt == SourceFormat.Compilable then s"$base  // ⟹ $joined"
                 else s"$base   ⟹ $joined"
               )
         }
         .mkString("\n")
-
-    /** Kinds whose `character` is a precise call site, so the note can be anchored to the token it
-      * applies to (vs. the using-arg note, whose range is only the enclosing point).
-      */
-    private val preciseColKinds = Set("inferred-type-args", "implicit-conversion")
-
-    /** The identifier at 0-based `col` in `src` (letters/digits/`_`/`$`), or "" if none. */
-    private def identifierAt(src: String, col: Int): String =
-      if col < 0 || col >= src.length then ""
-      else
-        def isIdChar(c: Char) = c.isLetterOrDigit || c == '_' || c == '$'
-        if !isIdChar(src.charAt(col)) then ""
-        else
-          @annotation.tailrec
-          def scan(end: Int): Int =
-            if end < src.length && isIdChar(src.charAt(end)) then scan(end + 1) else end
-          val end = scan(col)
-          src.substring(col, end)
-
-    /** An annotation's display text. Positional kinds are anchored to the identifier at their
-      * column (e.g. `render[List[Int]]`, `List.apply(…)`) instead of a `col N` prefix.
-      */
-    private def noteText(src: String, n: SourceAnnotation): String =
-      if !preciseColKinds.contains(n.kind) then n.text
-      else
-        val tok = identifierAt(src, n.character)
-        if tok.isEmpty then n.text
-        else if n.kind == "inferred-type-args" then s"$tok${n.text}"
-        else s"$tok.${n.text}"
 
     private def legend(fmt: SourceFormat): String =
       val markers =
@@ -1006,7 +979,8 @@ private[mcp] object McpToolsGroupC:
             "source with the compiler's invisible insertions made explicit inline: the implicit " +
             "arguments & conversions it synthesised, the type arguments it inferred, and the inferred " +
             "result/value type of every definition the source left unascribed. Each note is appended to " +
-            "its line after `⟹` (anchored to the identifier it applies to); lines are 1-based. " +
+            "its line after `⟹`, self-anchored to the call it applies to (e.g. `a.map[String]`, " +
+            "`(using Show[A])`); lines are 1-based. " +
             "A plain text read MISSES all of this — this shows what the compiler actually sees. Pass " +
             "`annotationsOnly` to get just the annotated lines. Pick the `format` for your need: " +
             "`annotated` (default, densest — gutter + `⟹` notes, NOT valid Scala), `compilable` (notes as " +

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich.json
@@ -8,7 +8,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 45,
+    "annotationCount": 42,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich.scala
@@ -20,22 +20,22 @@ object Show:
     def show(a: String) = a  // ⟹ : String
 
   // context bound `A: Show` desugars to a `(using Show[A])` parameter the source never writes
-  given listShow[A: Show]: Show[List[A]] with  // ⟹ (using evidence$1); : Show[A]
+  given listShow[A: Show]: Show[List[A]] with  // ⟹ : Show[A]
     def show(a: List[A]) =  // ⟹ : String
-      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ a[String]; (using evidence$1)
+      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ a.map[String]; (using Show[A])
 
 // `[A: Show]` again — the using-param and the `Show[A]` summon are both invisible in the text
-def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using evidence$1)
+def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using Show[A])
 
-extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using x$2); render[Int]
+extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using Show[Int]); render[Int]
 
-val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply(…); List[Int]
+val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int]
 val out = render(nums)  // ⟹ : String; (using listShow); render[List[Int]]; (using intShow)
-val sorted = nums.sorted  // ⟹ : List[Int]; (using Int); nums[Int]
-val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using String); List.apply(…); List[String]; List[Tuple2[String, Int]]; ArrowAssoc(…); [Int]; ArrowAssoc(…); [Int]
-val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; nums[Tuple2[Int, String]]; n.ArrowAssoc(…); n[String]; (using intShow); render[Int]
-val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int; nums[Int]
-val ratio: Double = nums.size  // ⟹ nums.int2double(…)
+val sorted = nums.sorted  // ⟹ : List[Int]; (using Ordering[Int]); nums.sorted[Int]
+val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using Ordering[String]); .sortBy[String]; List.apply[Tuple2[String, Int]]; ArrowAssoc("b"); "b" ->[Int]; ArrowAssoc("a"); "a" ->[Int]
+val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; nums.map[Tuple2[Int, String]]; ArrowAssoc(n); n ->[String]; (using intShow); render[Int]
+val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int; nums.foldLeft[Int]
+val ratio: Double = nums.size  // ⟹ int2double(nums.size)
 val shownFive = 5.shown  // ⟹ : String; (using intShow)
 val firstTwo =  // ⟹ : Option[String]
   for

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.json
@@ -9,7 +9,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 45,
+    "annotationCount": 42,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.scala
@@ -20,22 +20,22 @@ object Show:
     def show(a: String) = a  // ⟹ : String
 
                                                                                               
-  given listShow[A: Show]: Show[List[A]] with  // ⟹ (using evidence$1); : Show[A]
+  given listShow[A: Show]: Show[List[A]] with  // ⟹ : Show[A]
     def show(a: List[A]) =  // ⟹ : String
-      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ a[String]; (using evidence$1)
+      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ a.map[String]; (using Show[A])
 
                                                                                               
-def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using evidence$1)
+def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using Show[A])
 
-extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using x$2); render[Int]
+extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using Show[Int]); render[Int]
 
-val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply(…); List[Int]
+val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int]
 val out = render(nums)  // ⟹ : String; (using listShow); render[List[Int]]; (using intShow)
-val sorted = nums.sorted  // ⟹ : List[Int]; (using Int); nums[Int]
-val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using String); List.apply(…); List[String]; List[Tuple2[String, Int]]; ArrowAssoc(…); [Int]; ArrowAssoc(…); [Int]
-val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; nums[Tuple2[Int, String]]; n.ArrowAssoc(…); n[String]; (using intShow); render[Int]
-val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int; nums[Int]
-val ratio: Double = nums.size  // ⟹ nums.int2double(…)
+val sorted = nums.sorted  // ⟹ : List[Int]; (using Ordering[Int]); nums.sorted[Int]
+val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using Ordering[String]); .sortBy[String]; List.apply[Tuple2[String, Int]]; ArrowAssoc("b"); "b" ->[Int]; ArrowAssoc("a"); "a" ->[Int]
+val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; nums.map[Tuple2[Int, String]]; ArrowAssoc(n); n ->[String]; (using intShow); render[Int]
+val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int; nums.foldLeft[Int]
+val ratio: Double = nums.size  // ⟹ int2double(nums.size)
 val shownFive = 5.shown  // ⟹ : String; (using intShow)
 val firstTwo =  // ⟹ : Option[String]
   for

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.json
@@ -9,7 +9,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 45,
+    "annotationCount": 42,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.scala
@@ -20,22 +20,22 @@ object Show:
     def show(a: String) = a  // ⟹ : String
 
   // context bound `A: Show` desugars to a `(using Show[A])` parameter the source never writes
-  given listShow[A: Show]: Show[List[A]] with  // ⟹ (using evidence$1); : Show[A]
+  given listShow[A: Show]: Show[List[A]] with  // ⟹ : Show[A]
     def show(a: List[A]) =  // ⟹ : String
-      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ a[String]; (using evidence$1)
+      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ a.map[String]; (using Show[A])
 
 // `[A: Show]` again — the using-param and the `Show[A]` summon are both invisible in the text
-def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using evidence$1)
+def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using Show[A])
 
-extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using x$2); render[Int]
+extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using Show[Int]); render[Int]
 
-val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply(…); List[Int]
+val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int]
 val out = render(nums)  // ⟹ : String; (using listShow); render[List[Int]]; (using intShow)
-val sorted = nums.sorted  // ⟹ : List[Int]; (using Int); nums[Int]
-val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using String); List.apply(…); List[String]; List[Tuple2[String, Int]]; ArrowAssoc(…); [Int]; ArrowAssoc(…); [Int]
-val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; nums[Tuple2[Int, String]]; n.ArrowAssoc(…); n[String]; (using intShow); render[Int]
-val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int; nums[Int]
-val ratio: Double = nums.size  // ⟹ nums.int2double(…)
+val sorted = nums.sorted  // ⟹ : List[Int]; (using Ordering[Int]); nums.sorted[Int]
+val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using Ordering[String]); .sortBy[String]; List.apply[Tuple2[String, Int]]; ArrowAssoc("b"); "b" ->[Int]; ArrowAssoc("a"); "a" ->[Int]
+val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; nums.map[Tuple2[Int, String]]; ArrowAssoc(n); n ->[String]; (using intShow); render[Int]
+val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int; nums.foldLeft[Int]
+val ratio: Double = nums.size  // ⟹ int2double(nums.size)
 val shownFive = 5.shown  // ⟹ : String; (using intShow)
 val firstTwo =  // ⟹ : Option[String]
   for


### PR DESCRIPTION
Fixes six rendering defects in the terse/compilable annotated_source output, surfaced by the broadened Enrich fixture (#239). Moves all note anchoring into the analysis layer so each note is self-contained; the renderer just joins them (deleting the fragile identifierAt/column logic).

## Defects fixed
- **D1 receiver-anchored type-args** — `a[String]` -> `a.map[String]`, `nums[Int]` -> `nums.sorted[Int]`. Type-args now anchor to the CALL (via renderTree on the synthetic's function), collapsing a complex receiver to its trailing `.method` (`.sortBy[String]`).
- **D2 opaque compiler names** — `(using evidence$1)`/`(using x$2)` -> `(using Show[A])`/`(using Show[Int])`. A synthetic evidence/`x$` given is named by its TYPE.
- **D3 redundant self-forward** — the `(using …)` a given/def forwards into its own construction (on the declaration header) is dropped; genuine call-site usings in the body are kept.
- **D4 bare-type ordering summon** — `(using Int)` -> `(using Ordering[Int])`. Stdlib givens carry no indexed signature, so the type is synthesized as `Owner[Name]` from the symbol.
- **D5 orphan type-args** — no more bare `[Int]`; every type-arg note carries its call.
- **D6 split apply note** — `List.apply(…); List[Int]` -> `List.apply[Int]`; the `.apply` insertion no longer misrenders as a conversion.

## Key decisions
- Anchoring lives in AnalyzerHelpers (shared, testable), not the renderer — noteText is now just `_.text`.
- Conversion names stay plain (`ArrowAssoc(n)`, `int2double(nums.size)`); only using-args are type-ified — insertedName was split into insertedSymbol (raw) + givenDisplay (type-ify).

## Scope / follow-up
- Only the terse/compilable path is fixed (the default, and where the defects were raised). `detail=full` uses a separate renderTree path and is UNCHANGED (verified: its golden did not move) — the same evidence$/ordering polish there is a noted follow-up.
- Golden diff reads buggy->fixed against the #239 baseline.