### PR TITLE
fix(mcp): name summoned givens by type in annotated_source detail=full

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -199,7 +199,8 @@ final class Analyzer(
         .map(r => (r.startLine, r.startCharacter))
         .toList
       val synthetic = synthetic0.filterNot(a =>
-        a.kind == "implicit" && defStarts.exists((dl, dc) => dl == a.line && dc >= a.character)
+        (a.kind == "implicit" || a.kind == "full") &&
+          defStarts.exists((dl, dc) => dl == a.line && dc >= a.character)
       )
       val defTypes = doc.occurrences.iterator.flatMap(h.defTypeAnnotation(_, sourceLines)).toList
       (synthetic ++ defTypes).distinct.sortBy(a => (a.line, a.character, a.kind))

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
@@ -34,11 +34,9 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
 
   // --- annotated source -----------------------------------------------------
 
-  /** An implicit-insertion or inferred-type-argument annotation for one synthetic, anchored at the
-    * synthetic's source range. The `kind` distinguishes notes whose range is a precise call site
-    * (`inferred-type-args`, `implicit-conversion`) from the using-argument note, whose range is the
-    * zero-width enclosing point and so carries no trustworthy column. `None` for synthetics we do
-    * not surface.
+  /** An implicit-insertion or inferred-type-argument annotation for one synthetic. Each note's text
+    * is self-anchored to the call it applies to (`a.map[String]`, `(using Show[A])`) rather than a
+    * column, so the renderer prints it verbatim. `None` for synthetics we do not surface.
     */
   def syntheticAnnotation(
       syn: s.Synthetic,
@@ -156,7 +154,11 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
           case _                 => false
         if args.isEmpty then base
         else if originalFunction || t.arguments.forall(insertedName(_).nonEmpty) then
-          s"$base${args.mkString("(using ", ", ", ")")}"
+          // using-args: name each summoned given by identifier-or-type (so `evidence$1` -> `Show[A]`,
+          // `Ordering.Int` -> `Ordering[Int]`), same rule the terse path uses.
+          val usingArgs =
+            t.arguments.map(renderUsingArg(_, sourceLines, typeApps)).filter(_.nonEmpty)
+          s"$base${usingArgs.mkString("(using ", ", ", ")")}"
         else
           val renderedArgs = t.arguments match
             case Seq(orig: s.OriginalTree) =>
@@ -177,6 +179,28 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
       case t: s.OriginalTree =>
         originalText(t.range, sourceLines, typeApps)
       case _ => ""
+
+  /** Render a summoned given in using-argument position: a bare given by [[givenDisplay]] (so an
+    * evidence/`Ordering.Int` name becomes its type), a nested given-application recursively (so
+    * `listShow(using intShow)` keeps its shape), otherwise defer to [[renderTree]].
+    */
+  private def renderUsingArg(
+      tree: s.Tree,
+      sourceLines: IndexedSeq[String],
+      typeApps: Map[(Int, Int, Int), String]
+  ): String =
+    tree match
+      case t: s.IdTree     => givenDisplay(t.symbol)
+      case t: s.SelectTree => t.id.flatMap(insertedSymbol).map(givenDisplay).getOrElse("")
+      case t: s.ApplyTree  =>
+        val base = renderUsingArg(t.function, sourceLines, typeApps)
+        val nested = t.arguments.map(renderUsingArg(_, sourceLines, typeApps)).filter(_.nonEmpty)
+        if nested.isEmpty then base else s"$base${nested.mkString("(using ", ", ", ")")}"
+      case t: s.TypeApplyTree =>
+        val base = renderUsingArg(t.function, sourceLines, typeApps)
+        val targs = t.typeArguments.map(renderType).filter(_.nonEmpty)
+        if targs.isEmpty then base else targs.mkString(s"$base[", ", ", "]")
+      case other => renderTree(other, sourceLines, typeApps)
 
   def typeApplyOriginalRange(tree: s.Tree): Option[s.Range] =
     tree match

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.json
@@ -9,7 +9,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 26,
+    "annotationCount": 25,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.scala
@@ -20,19 +20,19 @@ object Show:
     def show(a: String) = a  // ⟹ : String
 
   // context bound `A: Show` desugars to a `(using Show[A])` parameter the source never writes
-  given listShow[A: Show]: Show[List[A]] with  // ⟹ (using evidence$1); : Show[A]
+  given listShow[A: Show]: Show[List[A]] with  // ⟹ : Show[A]
     def show(a: List[A]) =  // ⟹ : String
-      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ Show[A](using evidence$1)
+      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ Show[A](using Show[A])
 
 // `[A: Show]` again — the using-param and the `Show[A]` summon are both invisible in the text
-def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ Show[A](using evidence$1)
+def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ Show[A](using Show[A])
 
-extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ render[Int](n)(using x$2)
+extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ render[Int](n)(using Show[Int])
 
 val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int](1, 2, 3)
 val out = render(nums)  // ⟹ : String; render[List[Int]](nums)(using listShow(using intShow))
-val sorted = nums.sorted  // ⟹ : List[Int]; nums.sorted[Int](using Int)
-val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; List.apply[Tuple2[String, Int]][String]("b" ->[Int] 2, "a" ->[Int] 1).sortBy(_._1)(using String)
+val sorted = nums.sorted  // ⟹ : List[Int]; nums.sorted[Int](using Ordering[Int])
+val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; List.apply[Tuple2[String, Int]][String]("b" ->[Int] 2, "a" ->[Int] 1).sortBy(_._1)(using Ordering[String])
 val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; ArrowAssoc[Int](n); render[Int](n)(using intShow)
 val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int
 val ratio: Double = nums.size  // ⟹ int2double(nums.size)


### PR DESCRIPTION
Follow-up to #240, applying the same given-naming polish to the `detail=full` renderer (a separate `renderTree` path #240 left untouched).

## Changes
- **Typed given names in full mode** — using-args in the elaborated expression now name each summoned given by identifier-or-type via a new `renderUsingArg` (mirrors terse's `givenDisplay`): `(using evidence$1)` -> `(using Show[A])`, `(using x$2)` -> `(using Show[Int])`, `(using Int)` -> `(using Ordering[Int])`. Nested givens keep their shape (`(using listShow(using intShow))`).
- **D3 self-forward in full mode** — the redundant `(using …)` a given forwards into its own construction is now dropped for `full`-kind notes too (the filter previously covered only terse `implicit` notes), so `given listShow[A: Show]` shows just `: Show[A]`.
- Tidies the now-stale `syntheticAnnotation` doc-comment (dropped the obsolete 'no trustworthy column' note).

## Scope
- Only `annotated_source_enrich_full` golden moves; terse/compilable goldens are unchanged (verified).
- Still OUT of scope, unchanged: full mode's co-ranged-synthetic double type-args on the dense `ranked` line (`List.apply[..][String](...)`) — the merge/dedup caveat documented in docs/explanation/annotated-source-enrichment.md §5.