### PR TITLE
feat(mcp): name summoned givens and explode wildcard imports in annotated_source

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -235,6 +235,74 @@ final class Analyzer(
         .sortBy(_._1)
     }
 
+  /** Desugar wildcard / `given` imports into explicit ones — the `format=compilable` rendering of
+    * `symbols=on`. Each `import X.*` / `import X.given` line is replaced by a single-line
+    * `import X.member` (or braced `import X.{a, b}` for several) naming exactly the members of `X`
+    * the file actually uses, so no name enters scope invisibly. The braced form stays on ONE
+    * physical line, so annotation line offsets are preserved.
+    *
+    * "Used" is drawn from BOTH occurrences and synthetics: an implicitly-summoned given
+    * (`render(3.14)` picking `doubleShow`) has no textual occurrence — only a synthetic `IdTree` —
+    * so occurrences alone would miss it. A line is left untouched when its prefix or its used
+    * members cannot be resolved. Limits (per the design doc): only names that entered scope THROUGH
+    * the import are covered — same-package, inherited, and `export`ed names need no import and are
+    * left to the `symbols` legend.
+    */
+  def explodeImports(uri: DocumentUri, lines: IndexedSeq[String]): IndexedSeq[String] =
+    index
+      .document(uri.value)
+      .map { doc =>
+        val used: Set[String] =
+          (doc.occurrences.iterator
+            .filter(_.role == s.SymbolOccurrence.Role.REFERENCE)
+            .map(_.symbol) ++
+            doc.synthetics.iterator.flatMap(syn => h.treeSymbols(syn.tree)))
+            .filter(index.isGlobal)
+            .toSet
+        val membersByOwner: Map[String, List[String]] =
+          used
+            .groupBy(index.owner)
+            .map((owner, syms) =>
+              owner -> syms.iterator
+                .map(index.displayName)
+                .filter(_.nonEmpty)
+                .toList
+                .distinct
+                .sorted
+            )
+        val importRe = """^(\s*)import\s+(.+)\.(?:\*|given)\s*$""".r
+        // Resolve the import prefix TEXT to its symbol: prefer an occurrence on the import line
+        // (SemanticDB records the prefix reference), else match an owner by its last name segment.
+        def prefixSymbol(lineIdx: Int, prefixText: String): Option[String] =
+          doc.occurrences.iterator
+            .filter(o => o.role == s.SymbolOccurrence.Role.REFERENCE)
+            .filter(o => o.range.exists(_.startLine == lineIdx))
+            .map(_.symbol)
+            .filter(sym => index.isGlobal(sym) && (sym.endsWith(".") || sym.endsWith("/")))
+            .toList
+            .sortBy(sym => -sym.length)
+            .headOption
+            .orElse:
+              val last = prefixText.split('.').last
+              membersByOwner.keys.find(o => index.displayName(o) == last)
+        lines.iterator.zipWithIndex.map { (line, i) =>
+          line match
+            case importRe(indent, prefixText) =>
+              val exploded =
+                for
+                  pfx <- prefixSymbol(i, prefixText)
+                  members <- membersByOwner.get(pfx).filter(_.nonEmpty)
+                yield
+                  val sel = members match
+                    case single :: Nil => single
+                    case many          => many.mkString("{", ", ", "}")
+                  s"${indent}import $prefixText.$sel"
+              exploded.getOrElse(line)
+            case _ => line
+        }.toIndexedSeq
+      }
+      .getOrElse(lines)
+
   def stripComments(lines: IndexedSeq[String]): IndexedSeq[String] =
     h.stripComments(lines)
 

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/Analyzer.scala
@@ -199,7 +199,8 @@ final class Analyzer(
         .map(r => (r.startLine, r.startCharacter))
         .toList
       val synthetic = synthetic0.filterNot(a =>
-        a.kind == "implicit" && defStarts.exists((dl, dc) => dl == a.line && dc >= a.character)
+        (a.kind == "implicit" || a.kind == "full") &&
+          defStarts.exists((dl, dc) => dl == a.line && dc >= a.character)
       )
       val defTypes = doc.occurrences.iterator.flatMap(h.defTypeAnnotation(_, sourceLines)).toList
       (synthetic ++ defTypes).distinct.sortBy(a => (a.line, a.character, a.kind))

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
@@ -34,11 +34,9 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
 
   // --- annotated source -----------------------------------------------------
 
-  /** An implicit-insertion or inferred-type-argument annotation for one synthetic, anchored at the
-    * synthetic's source range. The `kind` distinguishes notes whose range is a precise call site
-    * (`inferred-type-args`, `implicit-conversion`) from the using-argument note, whose range is the
-    * zero-width enclosing point and so carries no trustworthy column. `None` for synthetics we do
-    * not surface.
+  /** An implicit-insertion or inferred-type-argument annotation for one synthetic. Each note's text
+    * is self-anchored to the call it applies to (`a.map[String]`, `(using Show[A])`) rather than a
+    * column, so the renderer prints it verbatim. `None` for synthetics we do not surface.
     */
   def syntheticAnnotation(
       syn: s.Synthetic,
@@ -156,7 +154,11 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
           case _                 => false
         if args.isEmpty then base
         else if originalFunction || t.arguments.forall(insertedName(_).nonEmpty) then
-          s"$base${args.mkString("(using ", ", ", ")")}"
+          // using-args: name each summoned given by identifier-or-type (so `evidence$1` -> `Show[A]`,
+          // `Ordering.Int` -> `Ordering[Int]`), same rule the terse path uses.
+          val usingArgs =
+            t.arguments.map(renderUsingArg(_, sourceLines, typeApps)).filter(_.nonEmpty)
+          s"$base${usingArgs.mkString("(using ", ", ", ")")}"
         else
           val renderedArgs = t.arguments match
             case Seq(orig: s.OriginalTree) =>
@@ -177,6 +179,28 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
       case t: s.OriginalTree =>
         originalText(t.range, sourceLines, typeApps)
       case _ => ""
+
+  /** Render a summoned given in using-argument position: a bare given by [[givenDisplay]] (so an
+    * evidence/`Ordering.Int` name becomes its type), a nested given-application recursively (so
+    * `listShow(using intShow)` keeps its shape), otherwise defer to [[renderTree]].
+    */
+  private def renderUsingArg(
+      tree: s.Tree,
+      sourceLines: IndexedSeq[String],
+      typeApps: Map[(Int, Int, Int), String]
+  ): String =
+    tree match
+      case t: s.IdTree     => givenDisplay(t.symbol)
+      case t: s.SelectTree => t.id.flatMap(insertedSymbol).map(givenDisplay).getOrElse("")
+      case t: s.ApplyTree  =>
+        val base = renderUsingArg(t.function, sourceLines, typeApps)
+        val nested = t.arguments.map(renderUsingArg(_, sourceLines, typeApps)).filter(_.nonEmpty)
+        if nested.isEmpty then base else s"$base${nested.mkString("(using ", ", ", ")")}"
+      case t: s.TypeApplyTree =>
+        val base = renderUsingArg(t.function, sourceLines, typeApps)
+        val targs = t.typeArguments.map(renderType).filter(_.nonEmpty)
+        if targs.isEmpty then base else targs.mkString(s"$base[", ", ", "]")
+      case other => renderTree(other, sourceLines, typeApps)
 
   def typeApplyOriginalRange(tree: s.Tree): Option[s.Range] =
     tree match

--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/analysis/AnalyzerHelpers.scala
@@ -95,6 +95,22 @@ private[analysis] final class AnalyzerHelpers(index: SemanticIndex):
   def insertedName(tree: s.Tree): Option[String] =
     insertedSymbol(tree).map(index.displayName)
 
+  /** Every global symbol referenced anywhere inside a synthetic tree — function AND arguments,
+    * recursively. Unlike [[insertedSymbol]] (which follows only the applied function) this reaches
+    * the summoned givens carried as arguments (`ApplyTree(render, [IdTree(doubleShow)])`), the very
+    * names an implicit summon inserts with no textual occurrence. Used by import-explosion to learn
+    * which members of an imported prefix are actually used.
+    */
+  def treeSymbols(tree: s.Tree): List[String] =
+    tree match
+      case t: s.IdTree        => List(t.symbol)
+      case t: s.SelectTree    => treeSymbols(t.qualifier) ++ t.id.toList.flatMap(treeSymbols)
+      case t: s.ApplyTree     => treeSymbols(t.function) ++ t.arguments.flatMap(treeSymbols)
+      case t: s.TypeApplyTree => treeSymbols(t.function)
+      case t: s.FunctionTree  => t.parameters.toList.flatMap(treeSymbols) ++ treeSymbols(t.body)
+      case t: s.MacroExpansionTree => treeSymbols(t.beforeExpansion)
+      case _                       => Nil
+
   /** How to name a summoned given: its identifier when informative, else its TYPE. A synthetic
     * evidence/`x$` parameter (`evidence$1`) or a type-like capitalised standard given (`Int`, the
     * `Ordering.Int` val) tells the reader nothing — render `Show[A]` / `Ordering[Int]` instead.

--- a/docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala
+++ b/docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala
@@ -29,7 +29,20 @@ def render[A: Show](a: A): String = Show[A].show(a)
 
 extension (n: Int) def shown(using Show[Int]): String = render(n)
 
+object Instances:
+  given doubleShow: Show[Double] with
+    def show(a: Double) = a.toString
+  given floatShow: Show[Float] with
+    def show(a: Float) = a.toString
+
+// wildcard `given` import: the givens enter scope with NO written name at the summon site — only
+// the symbols legend can say which given `render(3.14)` picked, and format=compilable explodes this
+// line to the explicit `import Instances.{doubleShow, floatShow}` of just the givens actually used
+import Instances.given
+
 val nums = List(1, 2, 3)
+val pi = render(3.14)
+val flo = render(1.0f)
 val out = render(nums)
 val sorted = nums.sorted
 val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)

--- a/docs/explanation/annotated-source-enrichment.md
+++ b/docs/explanation/annotated-source-enrichment.md
@@ -98,6 +98,15 @@ Why a legend and not inline FQN or exploded imports:
   `format=compilable` rendering of `symbols=on`**, restricted to imported entities, with its limits
   documented — never the default.
 
+  *Implemented* (`Analyzer.explodeImports`): with `format=compilable` + `symbols=on`, each
+  `import X.*` / `import X.given` line is rewritten to an explicit `import X.member` (or braced
+  `import X.{a, b}` for several) naming just the members of `X` the file actually uses. Used members
+  are collected from **both** occurrences and synthetics — an implicitly-summoned given
+  (`render(3.14)` → `doubleShow`) has no textual occurrence, only a synthetic `IdTree`, so
+  occurrences alone would miss it. The braced form stays on one physical line, preserving annotation
+  offsets. A line is left untouched when its prefix or used members cannot be resolved. See the
+  `annotated_source_enrich_symbols.scala` golden for the worked example.
+
 | Name origin | exploded imports resolve? | occurrence legend resolves? |
 |-------------|:-:|:-:|
 | imported type/def | ✅ | ✅ |

--- a/docs/usage/tool-examples.md
+++ b/docs/usage/tool-examples.md
@@ -22,6 +22,7 @@ Every tool example on this page is **executed at docs build time** by the real S
 | `smart_code_duplications` | Structurally identical blocks |
 | **Enriching tools** | |
 | `annotated_source` | Compiler-visible facts and inferred types |
+| `annotated_source` (`symbols=on`) | Name→package legend + explicit imports |
 | `method_signature` | Full signature with implicit/using params |
 | `document_outline` | File structure with compiler-rendered names |
 | `resolve_implicits` | Which givens/implicits apply |
@@ -240,7 +241,7 @@ These tools show the LLM what the compiler sees but the source text does not —
 
 ### Source under analysis
 
-`Enrich.scala` — a small typeclass (`Show`), two `given` instances, and two calls to a generic `render` method that hides its resolved implicit argument. Read straight from the fixture file the tool calls below actually analyze, so this block can never drift from what's shown as "Original" further down.
+`Enrich.scala` — a `Show` typeclass with several `given` instances (for `Int`, `String`, `List`, and two more brought in by a wildcard `given` import), a context-bound `render`, an extension method, and a spread of call sites (`map`, `sortBy`, `foldLeft`, a `for`-comprehension, numeric widening) that each hide a different compiler insertion: summoned implicits, inferred type arguments, inferred result/value types, and implicit conversions. Read straight from the fixture file the tool calls below actually analyze, so this block can never drift from what's shown as "Original" further down.
 
 ```scala mdoc:passthrough
 val enrichPath = "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala"
@@ -253,7 +254,7 @@ None of the `(using ...)` arguments or inferred return types above are written i
 
 **Answers:** compiler-visible facts and inferred types.
 
-The compiler injects `(using intShow)` and `(using listShow(...))` into the `render` calls, and infers the return type `: String` on the `out` and `num` bindings — none visible in source text.
+The compiler injects `(using intShow)` and `(using listShow(...))` into the `render` calls, infers the return type `: String` on the `out` binding and `: List[Int]` on `nums`, and adds the inferred type arguments (`List.apply[Int]`, `render[List[Int]]`) — none visible in source text.
 
 ```scala mdoc:passthrough
 val annotatedArgs =
@@ -287,7 +288,34 @@ println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(annotatedRaw, "
 println(scalasemantic.docs.ToolRunner.detailsMarkdown(annotatedRaw, annotatedArgs))
 ```
 
-**Replaces:** Reading 15 lines of source → 10 lines with compiler-visible facts.
+**Replaces:** Reading the source and hand-tracing every implicit/inferred insertion → one compiler-visible view.
+
+---
+
+### annotated_source with `symbols=on` — name origins & explicit imports
+
+**Answers:** which package each mid-code type belongs to, and which given a wildcard import actually brought into scope.
+
+`symbols=on` appends a `type → package` legend at the end. Under `format=compilable` it additionally **explodes** wildcard / `given` imports into the exact names used: `import Instances.given` becomes `import Instances.{doubleShow, floatShow}` — naming just the givens the compiler summoned at the `render(3.14)` / `render(1.0f)` call sites, none of which is written at the summon site. Names that need no import (same-package, inherited, `export`ed) stay in the legend; only imported names are exploded.
+
+```scala mdoc:passthrough
+val symbolsArgs =
+  s"""{"uri":"$enrichPath","format":"compilable","annotationsOnly":false,"symbols":true}"""
+val symbolsRaw = scalasemantic.docs.ToolRunner.run("annotated_source", symbolsArgs)
+println(scalasemantic.docs.ToolRunner.requestMarkdown("annotated_source", symbolsArgs))
+```
+
+**Enriched (compiler view, `symbols=on`)**
+
+```scala mdoc:passthrough
+println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(symbolsRaw, "source")}\n```")
+```
+
+```scala mdoc:passthrough
+println(scalasemantic.docs.ToolRunner.detailsMarkdown(symbolsRaw, symbolsArgs))
+```
+
+**Replaces:** guessing where a mid-code `Show` / `List` comes from, and hand-resolving which given a wildcard import supplies → a legend plus explicit imports.
 
 ---
 

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -110,7 +110,8 @@ private[mcp] object McpToolsSupport:
       (
         "symbols",
         "boolean",
-        "append a legend mapping each type used to its full package path (default false)"
+        "append a legend mapping each type used to its full package path (default false); with " +
+          "format=compilable it also explodes wildcard/`given` imports into the explicit names used"
       ),
       (
         "docs",
@@ -1006,12 +1007,19 @@ private[mcp] object McpToolsGroupC:
             az.sourceAnnotations(uri, lines, detail) match
               case None       => notFoundUri(uri.value)
               case Some(anns) =>
-                val symbols = if argBool(a, "symbols", false) then az.symbolLegend(uri) else Nil
+                val symbolsOn = argBool(a, "symbols", false)
+                val symbols = if symbolsOn then az.symbolLegend(uri) else Nil
+                val fmt = argFormat(a, "format")
+                // import-explosion is the compilable rendering of symbols=on: desugar wildcard /
+                // `given` imports into explicit ones so no name enters scope invisibly.
+                val displayLines =
+                  if symbolsOn && fmt == SourceFormat.Compilable then az.explodeImports(uri, lines)
+                  else lines
                 SourceView.result(
                   uri.value,
-                  lines,
+                  displayLines,
                   anns,
-                  argFormat(a, "format"),
+                  fmt,
                   argBool(a, "annotationsOnly", false),
                   symbols
                 )

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich.json
@@ -8,7 +8,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 42,
+    "annotationCount": 50,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich.scala
@@ -29,7 +29,20 @@ def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using Show[A])
 
 extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using Show[Int]); render[Int]
 
+object Instances:
+  given doubleShow: Show[Double] with
+    def show(a: Double) = a.toString  // ⟹ : String
+  given floatShow: Show[Float] with
+    def show(a: Float) = a.toString  // ⟹ : String
+
+// wildcard `given` import: the givens enter scope with NO written name at the summon site — only
+// the symbols legend can say which given `render(3.14)` picked, and format=compilable explodes this
+// line to the explicit `import Instances.{doubleShow, floatShow}` of just the givens actually used
+import Instances.given
+
 val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int]
+val pi = render(3.14)  // ⟹ : String; (using doubleShow); render[Double]
+val flo = render(1.0f)  // ⟹ : String; (using floatShow); render[Float]
 val out = render(nums)  // ⟹ : String; (using listShow); render[List[Int]]; (using intShow)
 val sorted = nums.sorted  // ⟹ : List[Int]; (using Ordering[Int]); nums.sorted[Int]
 val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using Ordering[String]); .sortBy[String]; List.apply[Tuple2[String, Int]]; ArrowAssoc("b"); "b" ->[Int]; ArrowAssoc("a"); "a" ->[Int]

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.json
@@ -9,7 +9,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 42,
+    "annotationCount": 50,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_docs.scala
@@ -29,7 +29,20 @@ def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using Show[A])
 
 extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using Show[Int]); render[Int]
 
+object Instances:
+  given doubleShow: Show[Double] with
+    def show(a: Double) = a.toString  // ⟹ : String
+  given floatShow: Show[Float] with
+    def show(a: Float) = a.toString  // ⟹ : String
+
+                                                                                                 
+                                                                                                    
+                                                                                                   
+import Instances.given
+
 val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int]
+val pi = render(3.14)  // ⟹ : String; (using doubleShow); render[Double]
+val flo = render(1.0f)  // ⟹ : String; (using floatShow); render[Float]
 val out = render(nums)  // ⟹ : String; (using listShow); render[List[Int]]; (using intShow)
 val sorted = nums.sorted  // ⟹ : List[Int]; (using Ordering[Int]); nums.sorted[Int]
 val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using Ordering[String]); .sortBy[String]; List.apply[Tuple2[String, Int]]; ArrowAssoc("b"); "b" ->[Int]; ArrowAssoc("a"); "a" ->[Int]

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.json
@@ -9,7 +9,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 26,
+    "annotationCount": 25,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.json
@@ -9,7 +9,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 25,
+    "annotationCount": 31,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.scala
@@ -20,19 +20,19 @@ object Show:
     def show(a: String) = a  // ⟹ : String
 
   // context bound `A: Show` desugars to a `(using Show[A])` parameter the source never writes
-  given listShow[A: Show]: Show[List[A]] with  // ⟹ (using evidence$1); : Show[A]
+  given listShow[A: Show]: Show[List[A]] with  // ⟹ : Show[A]
     def show(a: List[A]) =  // ⟹ : String
-      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ Show[A](using evidence$1)
+      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ Show[A](using Show[A])
 
 // `[A: Show]` again — the using-param and the `Show[A]` summon are both invisible in the text
-def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ Show[A](using evidence$1)
+def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ Show[A](using Show[A])
 
-extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ render[Int](n)(using x$2)
+extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ render[Int](n)(using Show[Int])
 
 val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int](1, 2, 3)
 val out = render(nums)  // ⟹ : String; render[List[Int]](nums)(using listShow(using intShow))
-val sorted = nums.sorted  // ⟹ : List[Int]; nums.sorted[Int](using Int)
-val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; List.apply[Tuple2[String, Int]][String]("b" ->[Int] 2, "a" ->[Int] 1).sortBy(_._1)(using String)
+val sorted = nums.sorted  // ⟹ : List[Int]; nums.sorted[Int](using Ordering[Int])
+val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; List.apply[Tuple2[String, Int]][String]("b" ->[Int] 2, "a" ->[Int] 1).sortBy(_._1)(using Ordering[String])
 val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; ArrowAssoc[Int](n); render[Int](n)(using intShow)
 val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int
 val ratio: Double = nums.size  // ⟹ int2double(nums.size)

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_full.scala
@@ -29,10 +29,23 @@ def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ Show[A](using Show[A
 
 extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ render[Int](n)(using Show[Int])
 
+object Instances:
+  given doubleShow: Show[Double] with
+    def show(a: Double) = a.toString  // ⟹ : String
+  given floatShow: Show[Float] with
+    def show(a: Float) = a.toString  // ⟹ : String
+
+// wildcard `given` import: the givens enter scope with NO written name at the summon site — only
+// the symbols legend can say which given `render(3.14)` picked, and format=compilable explodes this
+// line to the explicit `import Instances.{doubleShow, floatShow}` of just the givens actually used
+import Instances.given
+
 val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int](1, 2, 3)
+val pi = render(3.14)  // ⟹ : String; render[Double](3.14)(using doubleShow)
+val flo = render(1.0f)  // ⟹ : String; render[Float](1.0f)(using floatShow)
 val out = render(nums)  // ⟹ : String; render[List[Int]](nums)(using listShow(using intShow))
 val sorted = nums.sorted  // ⟹ : List[Int]; nums.sorted[Int](using Ordering[Int])
-val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; List.apply[Tuple2[String, Int]][String]("b" ->[Int] 2, "a" ->[Int] 1).sortBy(_._1)(using Ordering[String])
+val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; List.apply[Tuple2[String, Int]]("b" ->[Int] 2, "a" ->[Int][String] 1).sortBy(_._1)(using Ordering[String])
 val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; ArrowAssoc[Int](n); render[Int](n)(using intShow)
 val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int
 val ratio: Double = nums.size  // ⟹ int2double(nums.size)

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.json
@@ -9,7 +9,7 @@
   "result": {
     "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
     "format": "compilable",
-    "annotationCount": 42,
+    "annotationCount": 50,
     "legend": "Valid Scala: each note is a trailing `// ⟹` comment, no line-number gutter. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
     "source": "<<see companion .scala golden file>>"
   }

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_symbols.scala
@@ -29,7 +29,20 @@ def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using Show[A])
 
 extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using Show[Int]); render[Int]
 
+object Instances:
+  given doubleShow: Show[Double] with
+    def show(a: Double) = a.toString  // ⟹ : String
+  given floatShow: Show[Float] with
+    def show(a: Float) = a.toString  // ⟹ : String
+
+// wildcard `given` import: the givens enter scope with NO written name at the summon site — only
+// the symbols legend can say which given `render(3.14)` picked, and format=compilable explodes this
+// line to the explicit `import Instances.{doubleShow, floatShow}` of just the givens actually used
+import Instances.{doubleShow, floatShow}
+
 val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int]
+val pi = render(3.14)  // ⟹ : String; (using doubleShow); render[Double]
+val flo = render(1.0f)  // ⟹ : String; (using floatShow); render[Float]
 val out = render(nums)  // ⟹ : String; (using listShow); render[List[Int]]; (using intShow)
 val sorted = nums.sorted  // ⟹ : List[Int]; (using Ordering[Int]); nums.sorted[Int]
 val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using Ordering[String]); .sortBy[String]; List.apply[Tuple2[String, Int]]; ArrowAssoc("b"); "b" ->[Int]; ArrowAssoc("a"); "a" ->[Int]

--- a/mcp/src/test/resources/docs-golden/document_outline_enrich.json
+++ b/mcp/src/test/resources/docs-golden/document_outline_enrich.json
@@ -102,65 +102,117 @@
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.shown()."
       },
       {
+        "name": "Instances",
+        "kind": "OBJECT",
+        "line": 31,
+        "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.",
+        "children": [
+          {
+            "name": "doubleShow",
+            "kind": "OBJECT",
+            "line": 32,
+            "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.doubleShow.",
+            "children": [
+              {
+                "name": "show",
+                "kind": "METHOD",
+                "line": 33,
+                "signature": "def show(a: Double): String",
+                "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.doubleShow.show()."
+              }
+            ]
+          },
+          {
+            "name": "floatShow",
+            "kind": "OBJECT",
+            "line": 34,
+            "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.floatShow.",
+            "children": [
+              {
+                "name": "show",
+                "kind": "METHOD",
+                "line": 35,
+                "signature": "def show(a: Float): String",
+                "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.floatShow.show()."
+              }
+            ]
+          }
+        ]
+      },
+      {
         "name": "nums",
         "kind": "METHOD",
-        "line": 31,
+        "line": 42,
         "signature": ": List[Int]",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.nums."
       },
       {
+        "name": "pi",
+        "kind": "METHOD",
+        "line": 43,
+        "signature": ": String",
+        "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.pi."
+      },
+      {
+        "name": "flo",
+        "kind": "METHOD",
+        "line": 44,
+        "signature": ": String",
+        "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.flo."
+      },
+      {
         "name": "out",
         "kind": "METHOD",
-        "line": 32,
+        "line": 45,
         "signature": ": String",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.out."
       },
       {
         "name": "sorted",
         "kind": "METHOD",
-        "line": 33,
+        "line": 46,
         "signature": ": List[Int]",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.sorted."
       },
       {
         "name": "ranked",
         "kind": "METHOD",
-        "line": 34,
+        "line": 47,
         "signature": ": List[Tuple2[String, Int]]",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.ranked."
       },
       {
         "name": "labeled",
         "kind": "METHOD",
-        "line": 35,
+        "line": 48,
         "signature": ": List[Tuple2[Int, String]]",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.labeled."
       },
       {
         "name": "total",
         "kind": "METHOD",
-        "line": 36,
+        "line": 49,
         "signature": ": Int",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.total."
       },
       {
         "name": "ratio",
         "kind": "METHOD",
-        "line": 37,
+        "line": 50,
         "signature": ": Double",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.ratio."
       },
       {
         "name": "shownFive",
         "kind": "METHOD",
-        "line": 38,
+        "line": 51,
         "signature": ": String",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.shownFive."
       },
       {
         "name": "firstTwo",
         "kind": "METHOD",
-        "line": 39,
+        "line": 52,
         "signature": ": Option[String]",
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Enrich$package.firstTwo."
       }

--- a/mcp/src/test/resources/docs-golden/resolve_implicits_show.json
+++ b/mcp/src/test/resources/docs-golden/resolve_implicits_show.json
@@ -7,6 +7,14 @@
     "type": "com/github/mercurievv/scalasemantic/docexamples/Show#",
     "candidates": [
       {
+        "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.doubleShow.",
+        "type": "Show[Double]"
+      },
+      {
+        "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.floatShow.",
+        "type": "Show[Float]"
+      },
+      {
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Show.intShow.",
         "type": "Show[Int]"
       },

--- a/mcp/src/test/resources/docs-golden/structure_all.json
+++ b/mcp/src/test/resources/docs-golden/structure_all.json
@@ -7,7 +7,7 @@
     "modules": [
       {
         "module": "docExamples",
-        "types": 6,
+        "types": 7,
         "layer": 0,
         "ca": 0,
         "ce": 0,
@@ -23,7 +23,7 @@
         "ca": 2,
         "ce": 0,
         "instability": 0,
-        "centrality": 0.068
+        "centrality": 0.058
       },
       {
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Show#",
@@ -33,7 +33,17 @@
         "ca": 1,
         "ce": 0,
         "instability": 0,
-        "centrality": 0.046
+        "centrality": 0.04
+      },
+      {
+        "symbol": "com/github/mercurievv/scalasemantic/docexamples/Instances.",
+        "name": "Instances",
+        "module": "docExamples",
+        "layer": 0,
+        "ca": 0,
+        "ce": 0,
+        "instability": 0,
+        "centrality": 0.021
       },
       {
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Invoice#",
@@ -43,7 +53,7 @@
         "ca": 0,
         "ce": 0,
         "instability": 0,
-        "centrality": 0.025
+        "centrality": 0.021
       },
       {
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/ReverseProcessor#",
@@ -53,7 +63,7 @@
         "ca": 0,
         "ce": 1,
         "instability": 1,
-        "centrality": 0.025
+        "centrality": 0.021
       },
       {
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/Show.",
@@ -63,7 +73,7 @@
         "ca": 0,
         "ce": 1,
         "instability": 1,
-        "centrality": 0.025
+        "centrality": 0.021
       },
       {
         "symbol": "com/github/mercurievv/scalasemantic/docexamples/UpperProcessor#",
@@ -73,7 +83,7 @@
         "ca": 0,
         "ce": 1,
         "instability": 1,
-        "centrality": 0.025
+        "centrality": 0.021
       }
     ]
   }

--- a/mcp/src/test/resources/docs-golden/trace_implicit_chain_show.json
+++ b/mcp/src/test/resources/docs-golden/trace_implicit_chain_show.json
@@ -7,6 +7,14 @@
     "type": "com/github/mercurievv/scalasemantic/docexamples/Show#",
     "steps": [
       {
+        "given": "doubleShow",
+        "type": "Show[Double]"
+      },
+      {
+        "given": "floatShow",
+        "type": "Show[Float]"
+      },
+      {
         "given": "intShow",
         "type": "Show[Int]"
       },


### PR DESCRIPTION
## What

Two related `annotated_source` enrichments, plus the fixture/doc coverage for both.

1. **Name summoned givens by type in `detail=full`** — the elaborated expression now renders `render[Double](3.14)(using doubleShow)` / `(using Ordering[Int])` / nested `listShow(using intShow)` instead of opaque `evidence$1`, and drops the redundant `(using …)` a given/def forwards into its own construction (same rule the terse path already used).

2. **Explode wildcard / `given` imports** (`Analyzer.explodeImports`) — the `format=compilable` rendering of `symbols=on`. Each `import X.*` / `import X.given` line is rewritten to the explicit names actually used: `import Instances.given` → `import Instances.{doubleShow, floatShow}`. Single-line braced form keeps line count stable, so annotation offsets are preserved.

## Investigation

- Verified against the design doc's line-177 decision: the occurrence-derived symbol legend strictly dominates import-explosion on coverage (it also resolves same-package / inherited / implicitly-summoned names), so the legend stays primary and explosion is offered **only** as the compilable rendering of `symbols=on`, restricted to imported entities.
- "Used members" must be drawn from **both** occurrences **and** synthetics: an implicitly-summoned given (`render(3.14)` picking `doubleShow`) has no textual occurrence — only a synthetic `IdTree` carried as a using-argument — so occurrences alone miss it. Added `AnalyzerHelpers.treeSymbols` to walk the full synthetic tree (function + arguments).

## Key decisions

- **Gate explosion on `format=compilable` AND `symbols=on`** — every other view keeps the wildcard untouched. Confirmed by golden: the plain compilable view still shows `import Instances.given`.
- **Braced single-line output** (`import X.{a, b}`) rather than one line per name — avoids shifting every downstream annotation's line offset.
- **Leave a line untouched** when its prefix or used members cannot be resolved (never emit broken Scala).
- **No dedicated golden file** for explosion — it is exactly the existing `annotated_source(Enrich.scala, symbols=on)` case, so it rides `annotated_source_enrich_symbols.{scala,json}`; a second imported given exercises the braced multi-member branch.

## Rationale

Names that enter scope through a wildcard `given` import are invisible at the summon site — an agent reading the source cannot tell which given the compiler picked. Explosion makes the compilable view self-contained and pasteable; the legend covers everything else. Limits (same-package / inherited / `export`ed need no import) are documented in `docs/explanation/annotated-source-enrichment.md` §3.3.

## Docs / coverage

- New executed example in `docs/usage/tool-examples.md` (`annotated_source` with `symbols=on`) demonstrating the legend + import explosion; summary-table row added; stale prose refreshed for the grown fixture.
- Design doc §3.3 marked implemented.
- `checkFormatFirstParty` ✅, `mcp.compile` ✅, full `mcp.test` ✅ (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)