### PR TITLE
feat(mcp): add format=diff to annotated_source (green/red compiler-insertion diff)

### DIFF
--- a/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
+++ b/analysis/src/main/scala/com/github/mercurievv/scalasemantic/model/InputTypes.scala
@@ -289,12 +289,14 @@ object InputTypes:
     case Annotated extends SourceFormat("annotated")
     case Compilable extends SourceFormat("compilable")
     case Plain extends SourceFormat("plain")
+    case Diff extends SourceFormat("diff")
 
   object SourceFormat:
     def from(value: String): SourceFormat =
       value.trim match
         case "compilable" => Compilable
         case "plain"      => Plain
+        case "diff"       => Diff
         case _            => Annotated
 
   enum SourceDetail(val value: String):

--- a/docs/explanation/annotated-source-enrichment.md
+++ b/docs/explanation/annotated-source-enrichment.md
@@ -125,12 +125,20 @@ Why a legend and not inline FQN or exploded imports:
 
 ```
 annotated_source(uri,
-  format         = annotated | compilable | plain   // default annotated
-  detail         = terse | full                      // default terse
-  symbols        = off | on                          // default off
-  docs           = keep | strip                      // default keep
-  annotationsOnly = false)                            // default false
+  format         = annotated | compilable | plain | diff   // default annotated
+  detail         = terse | full                            // default terse
+  symbols        = off | on                                // default off
+  docs           = keep | strip                            // default keep
+  annotationsOnly = false)                                  // default false
 ```
+
+`format=diff` emits a unified diff from the source as written (`-`) to the enriched compilable view
+(`+`): the inline `// ⟹` notes and (with `symbols=on`) the exploded imports appear as added lines,
+so any diff viewer colours the compiler's insertions green and the shadowed originals red. The two
+sides are line-for-line aligned by construction (each enriched line derives from one raw line;
+import-explosion preserves the line count), so it hunks with 3 lines of context and needs no diff
+algorithm. Modified lines are emitted as paired `-`/`+` — a legal, appliable patch, chosen for
+line-by-line green/red rendering.
 
 Defaults reproduce today's behavior minus `col N` (which `terse` replaces token-anchored). Tool
 description must guide the agent to escalate terse→full and flip `symbols=on` before an edit or

--- a/docs/usage/tool-examples.md
+++ b/docs/usage/tool-examples.md
@@ -23,6 +23,7 @@ Every tool example on this page is **executed at docs build time** by the real S
 | **Enriching tools** | |
 | `annotated_source` | Compiler-visible facts and inferred types |
 | `annotated_source` (`symbols=on`) | Name→package legend + explicit imports |
+| `annotated_source` (`format=diff`) | Unified diff of the compiler's insertions |
 | `method_signature` | Full signature with implicit/using params |
 | `document_outline` | File structure with compiler-rendered names |
 | `resolve_implicits` | Which givens/implicits apply |
@@ -316,6 +317,27 @@ println(scalasemantic.docs.ToolRunner.detailsMarkdown(symbolsRaw, symbolsArgs))
 ```
 
 **Replaces:** guessing where a mid-code `Show` / `List` comes from, and hand-resolving which given a wildcard import supplies → a legend plus explicit imports.
+
+---
+
+### annotated_source with `format=diff` — see exactly what the compiler added
+
+**Answers:** which parts of a file are the compiler's, not yours.
+
+`format=diff` returns a unified diff from the source as written to the enriched view: `-` lines are the original, `+` lines carry the inline `// ⟹` insertions and (with `symbols=on`) the exploded imports. Any diff viewer renders it green/red, so the compiler's contribution is visible at a glance — no side-by-side reading.
+
+```scala mdoc:passthrough
+val diffArgs =
+  s"""{"uri":"$enrichPath","format":"diff","annotationsOnly":false,"symbols":true}"""
+val diffRaw = scalasemantic.docs.ToolRunner.run("annotated_source", diffArgs)
+println(scalasemantic.docs.ToolRunner.requestMarkdown("annotated_source", diffArgs))
+```
+
+```scala mdoc:passthrough
+println(s"```diff\n${scalasemantic.docs.ToolRunner.extractField(diffRaw, "source")}\n```")
+```
+
+**Replaces:** eyeballing two source blocks to spot the difference → one colourised diff.
 
 ---
 

--- a/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
+++ b/mcp/src/main/scala/com/github/mercurievv/scalasemantic/mcp/McpTools.scala
@@ -100,7 +100,8 @@ private[mcp] object McpToolsSupport:
       (
         "format",
         "string",
-        "annotated (default, gutter + ⟹ notes) | compilable (// ⟹ comments, valid Scala) | plain"
+        "annotated (default, gutter + ⟹ notes) | compilable (// ⟹ comments, valid Scala) | plain " +
+          "| diff (unified diff, source → enriched, for green/red rendering)"
       ),
       (
         "annotationsOnly",
@@ -132,23 +133,91 @@ private[mcp] object McpToolsSupport:
       */
     def result(
         uri: String,
-        lines: IndexedSeq[String],
+        rawLines: IndexedSeq[String],
+        displayLines: IndexedSeq[String],
         anns: List[SourceAnnotation],
         format: SourceFormat,
         annotationsOnly: Boolean,
         symbols: List[(String, String)] = Nil
     ): ujson.Value =
-      val rendered = render(lines, anns, format, annotationsOnly)
       val legendBlock =
         if symbols.isEmpty then ""
         else symbols.map((n, fqn) => s"//   $n → $fqn").mkString("\n// symbols:\n", "\n", "")
+      val rendered = format match
+        case SourceFormat.Diff => renderDiff(uri, rawLines, displayLines, anns, symbols)
+        case _                 => render(displayLines, anns, format, annotationsOnly) + legendBlock
       ujson.Obj(
         "uri" -> ujson.Str(uri),
         "format" -> ujson.Str(format.value),
         "annotationCount" -> ujson.Num(anns.size),
         "legend" -> ujson.Str(legend(format)),
-        "source" -> ujson.Str(rendered + legendBlock)
+        "source" -> ujson.Str(rendered)
       )
+
+    /** A unified diff from the source as written (`-`) to the enriched compilable view (`+`): every
+      * inline `// ⟹` note and every exploded wildcard/`given` import appears as an added line, so
+      * any diff viewer colours the compiler's insertions green and the shadowed originals red. The
+      * two sides are line-for-line aligned by construction (each enriched line derives from one raw
+      * line; import-explosion keeps the line count), with the `symbols` legend appended as further
+      * additions — so no diff algorithm is needed, only hunking with 3 lines of context.
+      */
+    private def renderDiff(
+        uri: String,
+        rawLines: IndexedSeq[String],
+        displayLines: IndexedSeq[String],
+        anns: List[SourceAnnotation],
+        symbols: List[(String, String)]
+    ): String =
+      val byLine = anns.groupBy(_.line)
+      val legendLines: List[String] =
+        if symbols.isEmpty then Nil
+        else "" :: "// symbols:" :: symbols.map((n, fqn) => s"//   $n → $fqn")
+      // Op = (oldLine?, newLine?): a context line has old == new; a modified line differs; a legend
+      // line is a pure addition (None, Some). Zip raw with display so no positional indexing is
+      // needed (wartremover forbids Seq.apply).
+      val body: List[(Option[String], Option[String])] =
+        rawLines
+          .zip(displayLines)
+          .zipWithIndex
+          .map { case ((raw, disp), i) =>
+            val notes = byLine.getOrElse(i, Nil)
+            val enriched =
+              if notes.isEmpty then disp else s"$disp  // ⟹ ${notes.map(_.text).mkString("; ")}"
+            (Some(raw), Some(enriched))
+          }
+          .toList
+      val ops = body ++ legendLines.map(l => (Option.empty[String], Some(l)))
+      val changed = ops.zipWithIndex.collect { case (op, i) if op._1 != op._2 => i }
+      if changed.isEmpty then ""
+      else
+        val context = 3
+        val n = ops.size
+        val merged = changed
+          .map(i => (math.max(0, i - context), math.min(n - 1, i + context)))
+          .foldLeft(List.empty[(Int, Int)]) { (acc, r) =>
+            acc match
+              case (s0, e0) :: tail if r._1 <= e0 + 1 => (s0, math.max(e0, r._2)) :: tail
+              case _                                  => r :: acc
+          }
+          .reverse
+        val header = s"--- $uri (original)\n+++ $uri (enriched)"
+        val hunks = merged.map { (s, e) =>
+          val before = ops.take(s)
+          val slice = ops.slice(s, e + 1)
+          val oldBefore = before.count(_._1.isDefined)
+          val newBefore = before.count(_._2.isDefined)
+          val oldCount = slice.count(_._1.isDefined)
+          val newCount = slice.count(_._2.isDefined)
+          val oldStart = if oldCount == 0 then oldBefore else oldBefore + 1
+          val newStart = if newCount == 0 then newBefore else newBefore + 1
+          val hunkHeader = s"@@ -$oldStart,$oldCount +$newStart,$newCount @@"
+          val lines = slice.flatMap { (o, nw) =>
+            if o == nw then o.toList.map(l => s" $l")
+            else o.toList.map(l => s"-$l") ++ nw.toList.map(l => s"+$l")
+          }
+          (hunkHeader :: lines).mkString("\n")
+        }
+        (header :: hunks).mkString("\n")
 
     /** Weave source lines and annotations into one string per the chosen format. */
     private def render(
@@ -193,6 +262,10 @@ private[mcp] object McpToolsSupport:
         case SourceFormat.Annotated =>
           "READ-ONLY view, NOT valid Scala — do NOT paste into code; edit the real file at uri " +
             s"(gutter line numbers map 1:1). ⟹ marks each note. $markers"
+        case SourceFormat.Diff =>
+          "Unified diff, source-as-written → enriched: `-` lines are the original, `+` lines add " +
+            "the compiler's inline `// ⟹` insertions and explode wildcard/`given` imports (with " +
+            s"symbols=on). Render in any diff viewer for green/red. $markers"
 
   private[mcp] def round2(d: Double): Double = math.round(d * 100.0) / 100.0
   private[mcp] def round3(d: Double): Double = math.round(d * 1000.0) / 1000.0
@@ -985,7 +1058,9 @@ private[mcp] object McpToolsGroupC:
             "A plain text read MISSES all of this — this shows what the compiler actually sees. Pass " +
             "`annotationsOnly` to get just the annotated lines. Pick the `format` for your need: " +
             "`annotated` (default, densest — gutter + `⟹` notes, NOT valid Scala), `compilable` (notes as " +
-            "`// ⟹` comments, no gutter — valid pasteable Scala), or `plain` (the raw file, no notes). In " +
+            "`// ⟹` comments, no gutter — valid pasteable Scala), `plain` (the raw file, no notes), or " +
+            "`diff` (a unified diff from the source as written to the enriched view — `+` lines are the " +
+            "compiler's insertions, render green/red in any diff viewer). In " +
             "`annotated`/`plain` the gutter is a READ-ONLY view: never paste it into code; edit the real " +
             "file at `uri` (gutter numbers map 1:1).",
           (
@@ -1010,13 +1085,14 @@ private[mcp] object McpToolsGroupC:
                 val symbolsOn = argBool(a, "symbols", false)
                 val symbols = if symbolsOn then az.symbolLegend(uri) else Nil
                 val fmt = argFormat(a, "format")
-                // import-explosion is the compilable rendering of symbols=on: desugar wildcard /
-                // `given` imports into explicit ones so no name enters scope invisibly.
-                val displayLines =
-                  if symbolsOn && fmt == SourceFormat.Compilable then az.explodeImports(uri, lines)
-                  else lines
+                // import-explosion is the compilable rendering of symbols=on (and its diff): desugar
+                // wildcard / `given` imports into explicit ones so no name enters scope invisibly.
+                val explode =
+                  symbolsOn && (fmt == SourceFormat.Compilable || fmt == SourceFormat.Diff)
+                val displayLines = if explode then az.explodeImports(uri, lines) else lines
                 SourceView.result(
                   uri.value,
+                  lines,
                   displayLines,
                   anns,
                   fmt,

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_diff.json
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_diff.json
@@ -1,0 +1,16 @@
+{
+  "tool": "annotated_source",
+  "args": {
+    "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
+    "format": "diff",
+    "annotationsOnly": false,
+    "symbols": true
+  },
+  "result": {
+    "uri": "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala",
+    "format": "diff",
+    "annotationCount": 50,
+    "legend": "Unified diff, source-as-written → enriched: `-` lines are the original, `+` lines add the compiler's inline `// ⟹` insertions and explode wildcard/`given` imports (with symbols=on). Render in any diff viewer for green/red. Notes show compiler insertions invisible in the source: `(using …)` implicit args, `name(…)` implicit conversion, `[…]` inferred type args, `: T` inferred type. symbols=on adds a type→package legend.",
+    "source": "<<see companion .scala golden file>>"
+  }
+}

--- a/mcp/src/test/resources/docs-golden/annotated_source_enrich_diff.scala
+++ b/mcp/src/test/resources/docs-golden/annotated_source_enrich_diff.scala
@@ -1,0 +1,74 @@
+--- docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala (original)
++++ docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala (enriched)
+@@ -14,45 +14,49 @@
+   def apply[A](using s: Show[A]): Show[A] = s
+ 
+   given intShow: Show[Int] with
+-    def show(a: Int) = a.toString
++    def show(a: Int) = a.toString  // ⟹ : String
+ 
+   given stringShow: Show[String] with
+-    def show(a: String) = a
++    def show(a: String) = a  // ⟹ : String
+ 
+   // context bound `A: Show` desugars to a `(using Show[A])` parameter the source never writes
+-  given listShow[A: Show]: Show[List[A]] with
++  given listShow[A: Show]: Show[List[A]] with  // ⟹ : Show[A]
+-    def show(a: List[A]) =
++    def show(a: List[A]) =  // ⟹ : String
+-      a.map(Show[A].show).mkString("[", ", ", "]")
++      a.map(Show[A].show).mkString("[", ", ", "]")  // ⟹ a.map[String]; (using Show[A])
+ 
+ // `[A: Show]` again — the using-param and the `Show[A]` summon are both invisible in the text
+-def render[A: Show](a: A): String = Show[A].show(a)
++def render[A: Show](a: A): String = Show[A].show(a)  // ⟹ (using Show[A])
+ 
+-extension (n: Int) def shown(using Show[Int]): String = render(n)
++extension (n: Int) def shown(using Show[Int]): String = render(n)  // ⟹ (using Show[Int]); render[Int]
+ 
+ object Instances:
+   given doubleShow: Show[Double] with
+-    def show(a: Double) = a.toString
++    def show(a: Double) = a.toString  // ⟹ : String
+   given floatShow: Show[Float] with
+-    def show(a: Float) = a.toString
++    def show(a: Float) = a.toString  // ⟹ : String
+ 
+ // wildcard `given` import: the givens enter scope with NO written name at the summon site — only
+ // the symbols legend can say which given `render(3.14)` picked, and format=compilable explodes this
+ // line to the explicit `import Instances.{doubleShow, floatShow}` of just the givens actually used
+-import Instances.given
++import Instances.{doubleShow, floatShow}
+ 
+-val nums = List(1, 2, 3)
++val nums = List(1, 2, 3)  // ⟹ : List[Int]; List.apply[Int]
+-val pi = render(3.14)
++val pi = render(3.14)  // ⟹ : String; (using doubleShow); render[Double]
+-val flo = render(1.0f)
++val flo = render(1.0f)  // ⟹ : String; (using floatShow); render[Float]
+-val out = render(nums)
++val out = render(nums)  // ⟹ : String; (using listShow); render[List[Int]]; (using intShow)
+-val sorted = nums.sorted
++val sorted = nums.sorted  // ⟹ : List[Int]; (using Ordering[Int]); nums.sorted[Int]
+-val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)
++val ranked = List("b" -> 2, "a" -> 1).sortBy(_._1)  // ⟹ : List[Tuple2[String, Int]]; (using Ordering[String]); .sortBy[String]; List.apply[Tuple2[String, Int]]; ArrowAssoc("b"); "b" ->[Int]; ArrowAssoc("a"); "a" ->[Int]
+-val labeled = nums.map(n => n -> render(n))
++val labeled = nums.map(n => n -> render(n))  // ⟹ : List[Tuple2[Int, String]]; nums.map[Tuple2[Int, String]]; ArrowAssoc(n); n ->[String]; (using intShow); render[Int]
+-val total = nums.foldLeft(0)(_ + _)
++val total = nums.foldLeft(0)(_ + _)  // ⟹ : Int; nums.foldLeft[Int]
+-val ratio: Double = nums.size
++val ratio: Double = nums.size  // ⟹ int2double(nums.size)
+-val shownFive = 5.shown
++val shownFive = 5.shown  // ⟹ : String; (using intShow)
+-val firstTwo =
++val firstTwo =  // ⟹ : Option[String]
+   for
+     a <- nums.headOption
+     b <- sorted.headOption
+-  yield render(a) + render(b)
++  yield render(a) + render(b)  // ⟹ (using intShow); render[Int]; (using intShow); render[Int]
+ 
++
++// symbols:
++//   List → scala.collection.immutable.List
++//   Show → com.github.mercurievv.scalasemantic.docexamples.Show

--- a/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/DocsEnrichingExamplesGoldenSuite.scala
+++ b/mcp/src/test/scala/com/github/mercurievv/scalasemantic/mcp/DocsEnrichingExamplesGoldenSuite.scala
@@ -93,6 +93,18 @@ class DocsEnrichingExamplesGoldenSuite extends munit.FunSuite:
       )
     )
 
+  test("annotated_source(Enrich.scala, format=diff, symbols=on)"):
+    assertGolden(
+      "annotated_source_enrich_diff",
+      "annotated_source",
+      ujson.Obj(
+        "uri" -> EnrichPath,
+        "format" -> "diff",
+        "annotationsOnly" -> false,
+        "symbols" -> true
+      )
+    )
+
   test("annotated_source(Enrich.scala, docs=strip)"):
     assertGolden(
       "annotated_source_enrich_docs",


### PR DESCRIPTION
## What

Add `format=diff` to `annotated_source`: a unified diff from the source as written (`-`) to the enriched compilable view (`+`). The inline `// ⟹` insertions — and, with `symbols=on`, the exploded wildcard/`given` imports — appear as added lines, so any diff viewer (GitHub, Docusaurus ```diff, a terminal pager) colours the compiler's contribution green and the shadowed originals red at a glance.

Example (`format=diff, symbols=on`):

```diff
-import Instances.given
+import Instances.{doubleShow, floatShow}
...
-val pi = render(3.14)
+val pi = render(3.14)  // ⟹ : String; (using doubleShow); render[Double]
```

## Design

- **No diff algorithm needed.** The enriched view is a known line-for-line transform of the source — each enriched line derives from exactly one raw line, and import-explosion uses the braced single-line form so the line count never changes. So the two sides are aligned by construction; `renderDiff` just hunks them with 3 lines of context (the `symbols` legend is appended as trailing additions).
- **Modified lines emit paired `-old`/`+new`.** That is a legal, appliable unified-diff patch, chosen so every renderer colours line-by-line — the goal here is green/red display, not canonical git grouping.
- **Explosion gate broadened** to `symbols=on && (format ∈ {compilable, diff})`, so the diff shows the exploded import as a real change; every other view is untouched.
- `SourceView.result` now takes both the raw and the display (exploded) lines; only the diff path uses both. Implemented without positional indexing (zip/slice/count) to satisfy wartremover's `SeqApply`.

## Rationale

The previous side-by-side "Original | Enriched" doc view made the reader eyeball two blocks to find what the compiler added. A diff makes the compiler's contribution the *only* thing highlighted — the most direct answer to "which parts of this file are mine vs synthesised".

## Coverage

- Golden test `annotated_source(Enrich.scala, format=diff, symbols=on)` in `DocsEnrichingExamplesGoldenSuite` (new `annotated_source_enrich_diff.{scala,json}`).
- Executed doc example in `docs/usage/tool-examples.md` rendering the diff in a ```diff fence; summary-table row added.
- Design doc §4 documents the format and the alignment/paired-line decisions.
- `tool` + `format`/`symbols` param descriptions updated.

## Verification

`./mill docs.run` (mdoc) ✅ 0 errors · `checkFormatFirstParty` ✅ · `mcp.compile` ✅ · full `mcp.test` ✅ (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)