### PR TITLE
feat(docs): tabbed annotated_source examples with intra-line insert highlighting

### DIFF
--- a/docs/usage/tool-examples.md
+++ b/docs/usage/tool-examples.md
@@ -1,3 +1,7 @@
+---
+format: mdx
+---
+
 # Tool Examples — Real Output, Self-Verifying
 
 Every tool example on this page is **executed at docs build time** by the real Scala 3.8.4 analyzer — no hand-written JSON. If a tool call fails, the docs build fails, so this page cannot rot. Each example's exact tool/args/result triple is also pinned as a golden-file test in the `mcp` module (`DocsToolExamplesGoldenSuite` / `DocsEnrichingExamplesGoldenSuite`), so a change to tool output shows up as a reviewable diff there too, not just a silent docs rebuild.
@@ -21,9 +25,7 @@ Every tool example on this page is **executed at docs build time** by the real S
 | `structure` | Dependency graph and cycles |
 | `smart_code_duplications` | Structurally identical blocks |
 | **Enriching tools** | |
-| `annotated_source` | Compiler-visible facts and inferred types |
-| `annotated_source` (`symbols=on`) | Name→package legend + explicit imports |
-| `annotated_source` (`format=diff`) | Unified diff of the compiler's insertions |
+| `annotated_source` | Compiler view — inferred types, implicits, exploded imports, diff (tabbed) |
 | `method_signature` | Full signature with implicit/using params |
 | `document_outline` | File structure with compiler-rendered names |
 | `resolve_implicits` | Which givens/implicits apply |
@@ -240,96 +242,71 @@ println(scalasemantic.docs.ToolRunner.runPretty(
 
 These tools show the LLM what the compiler sees but the source text does not — inferred types, synthesized implicit arguments and conversions, resolved signatures. Every example below runs against the same source file, executed at docs build time by the real Scala 3.8.4 analyzer.
 
-### Source under analysis
+### annotated_source
 
-`Enrich.scala` — a `Show` typeclass with several `given` instances (for `Int`, `String`, `List`, and two more brought in by a wildcard `given` import), a context-bound `render`, an extension method, and a spread of call sites (`map`, `sortBy`, `foldLeft`, a `for`-comprehension, numeric widening) that each hide a different compiler insertion: summoned implicits, inferred type arguments, inferred result/value types, and implicit conversions. Read straight from the fixture file the tool calls below actually analyze, so this block can never drift from what's shown as "Original" further down.
+**Answers:** compiler-visible facts and inferred types — everything the compiler sees that the source text does not.
+
+`Enrich.scala` — a `Show` typeclass with several `given` instances (for `Int`, `String`, `List`, and two more brought in by a wildcard `given` import), a context-bound `render`, an extension method, and a spread of call sites (`map`, `sortBy`, `foldLeft`, a `for`-comprehension, numeric widening) that each hide a different compiler insertion. The tabs run the real analyzer against it at build time: **Original** is the raw file; **compilable** and **symbols=on** show the compiler's view with the inserted `// ⟹` notes tinted green **in place** (only what the compiler added is highlighted — no whole-line diff); **diff** is the literal `format=diff` patch.
 
 ```scala mdoc:passthrough
 val enrichPath = "docExamples/src/main/scala/com/github/mercurievv/scalasemantic/docexamples/Enrich.scala"
+val annotatedArgs = s"""{"uri":"$enrichPath","format":"compilable","annotationsOnly":false}"""
+val symbolsArgs = s"""{"uri":"$enrichPath","format":"compilable","annotationsOnly":false,"symbols":true}"""
+val diffArgs = s"""{"uri":"$enrichPath","format":"diff","annotationsOnly":false,"symbols":true}"""
+val annotatedRaw = scalasemantic.docs.ToolRunner.run("annotated_source", annotatedArgs)
+val symbolsRaw = scalasemantic.docs.ToolRunner.run("annotated_source", symbolsArgs)
+val diffRaw = scalasemantic.docs.ToolRunner.run("annotated_source", diffArgs)
+```
+
+<Tabs groupId="annotated-source">
+<TabItem value="original" label="Original">
+
+The source exactly as written — none of the `(using …)` arguments or inferred types below are visible here.
+
+```scala mdoc:passthrough
 println(s"```scala\n${scalasemantic.docs.ToolRunner.readSource(enrichPath)}\n```")
 ```
 
-None of the `(using ...)` arguments or inferred return types above are written in the source — the tools below make them visible.
+</TabItem>
+<TabItem value="compilable" label="compilable" default>
 
-### annotated_source
-
-**Answers:** compiler-visible facts and inferred types.
-
-The compiler injects `(using intShow)` and `(using listShow(...))` into the `render` calls, infers the return type `: String` on the `out` binding and `: List[Int]` on `nums`, and adds the inferred type arguments (`List.apply[Int]`, `render[List[Int]]`) — none visible in source text.
+The compiler injects `(using intShow)` / `(using listShow(...))` into the `render` calls, infers `: String` on `out` and `: List[Int]` on `nums`, and adds the inferred type arguments — each tinted green inline.
 
 ```scala mdoc:passthrough
-val annotatedArgs =
-  s"""{"uri":"$enrichPath","format":"compilable","annotationsOnly":false}"""
-val annotatedRaw = scalasemantic.docs.ToolRunner.run("annotated_source", annotatedArgs)
 println(scalasemantic.docs.ToolRunner.requestMarkdown("annotated_source", annotatedArgs))
 ```
 
-<div className="row">
-<div className="col col--6">
-
-**Original**
-
 ```scala mdoc:passthrough
-println(s"```scala\n${scalasemantic.docs.ToolRunner.readSource(enrichPath)}\n```")
+println(scalasemantic.docs.ToolRunner.enrichedComponent(annotatedRaw))
 ```
 
-</div>
-<div className="col col--6">
-
-**Enriched (compiler view)**
-
 ```scala mdoc:passthrough
-println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(annotatedRaw, "source")}\n```")
+println(scalasemantic.docs.ToolRunner.detailsMarkdown(annotatedArgs, annotatedRaw))
 ```
 
-</div>
-</div>
+</TabItem>
+<TabItem value="symbols" label="symbols=on">
+
+Appends a `type → package` legend and, under `compilable`, **explodes** the wildcard `import Instances.given` into `import Instances.{doubleShow, floatShow}` — the exact givens summoned at `render(3.14)` / `render(1.0f)`. Names that need no import (same-package, inherited, `export`ed) stay in the legend.
 
 ```scala mdoc:passthrough
-println(scalasemantic.docs.ToolRunner.detailsMarkdown(annotatedRaw, annotatedArgs))
-```
-
-**Replaces:** Reading the source and hand-tracing every implicit/inferred insertion → one compiler-visible view.
-
----
-
-### annotated_source with `symbols=on` — name origins & explicit imports
-
-**Answers:** which package each mid-code type belongs to, and which given a wildcard import actually brought into scope.
-
-`symbols=on` appends a `type → package` legend at the end. Under `format=compilable` it additionally **explodes** wildcard / `given` imports into the exact names used: `import Instances.given` becomes `import Instances.{doubleShow, floatShow}` — naming just the givens the compiler summoned at the `render(3.14)` / `render(1.0f)` call sites, none of which is written at the summon site. Names that need no import (same-package, inherited, `export`ed) stay in the legend; only imported names are exploded.
-
-```scala mdoc:passthrough
-val symbolsArgs =
-  s"""{"uri":"$enrichPath","format":"compilable","annotationsOnly":false,"symbols":true}"""
-val symbolsRaw = scalasemantic.docs.ToolRunner.run("annotated_source", symbolsArgs)
 println(scalasemantic.docs.ToolRunner.requestMarkdown("annotated_source", symbolsArgs))
 ```
 
-**Enriched (compiler view, `symbols=on`)**
-
 ```scala mdoc:passthrough
-println(s"```scala\n${scalasemantic.docs.ToolRunner.extractField(symbolsRaw, "source")}\n```")
+println(scalasemantic.docs.ToolRunner.enrichedComponent(symbolsRaw))
 ```
 
 ```scala mdoc:passthrough
-println(scalasemantic.docs.ToolRunner.detailsMarkdown(symbolsRaw, symbolsArgs))
+println(scalasemantic.docs.ToolRunner.detailsMarkdown(symbolsArgs, symbolsRaw))
 ```
 
-**Replaces:** guessing where a mid-code `Show` / `List` comes from, and hand-resolving which given a wildcard import supplies → a legend plus explicit imports.
+</TabItem>
+<TabItem value="diff" label="diff (patch)">
 
----
-
-### annotated_source with `format=diff` — see exactly what the compiler added
-
-**Answers:** which parts of a file are the compiler's, not yours.
-
-`format=diff` returns a unified diff from the source as written to the enriched view: `-` lines are the original, `+` lines carry the inline `// ⟹` insertions and (with `symbols=on`) the exploded imports. Any diff viewer renders it green/red, so the compiler's contribution is visible at a glance — no side-by-side reading.
+`format=diff` returns a unified diff from source → enriched: `-` lines are the original, `+` lines carry the insertions and exploded imports. A literal, appliable patch — coloured whole-line green/red by any diff viewer.
 
 ```scala mdoc:passthrough
-val diffArgs =
-  s"""{"uri":"$enrichPath","format":"diff","annotationsOnly":false,"symbols":true}"""
-val diffRaw = scalasemantic.docs.ToolRunner.run("annotated_source", diffArgs)
 println(scalasemantic.docs.ToolRunner.requestMarkdown("annotated_source", diffArgs))
 ```
 
@@ -337,7 +314,10 @@ println(scalasemantic.docs.ToolRunner.requestMarkdown("annotated_source", diffAr
 println(s"```diff\n${scalasemantic.docs.ToolRunner.extractField(diffRaw, "source")}\n```")
 ```
 
-**Replaces:** eyeballing two source blocks to spot the difference → one colourised diff.
+</TabItem>
+</Tabs>
+
+**Replaces:** reading the source and hand-tracing every implicit/inferred insertion → one compiler-visible view where green marks exactly what the compiler added.
 
 ---
 

--- a/mdoc-docs/src/main/scala/DocsMain.scala
+++ b/mdoc-docs/src/main/scala/DocsMain.scala
@@ -21,3 +21,27 @@ object DocsMain:
       .withArgs(args.toList)
     val exitCode = mdoc.Main.process(settings)
     if exitCode != 0 then sys.exit(exitCode)
+
+    // Opt-in MDX: mdoc only EXECUTES `*.md` (it copies `*.mdx` verbatim, unrendered), while
+    // Docusaurus's `detect` only PARSES `*.mdx` as MDX (our `*.md` pages are CommonMark on purpose —
+    // they contain `<root>`, `List[A]`, `{...}` MDX would choke on). A page that needs MDX (JSX
+    // components like <Tabs>/<EnrichedCode>) therefore declares `format: mdx` in its front matter;
+    // here — after rendering — we rename those generated outputs to `*.mdx` so Docusaurus treats
+    // them as MDX. Bridges the two tools' opposite extension conventions.
+    val outDir = java.nio.file.Paths.get("website", "docs")
+    val generated = java.nio.file.Files.walk(outDir)
+    try
+      generated
+        .filter((p: java.nio.file.Path) => p.toString.endsWith(".md"))
+        .filter((p: java.nio.file.Path) =>
+          java.nio.file.Files.readString(p).linesIterator.take(6).contains("format: mdx")
+        )
+        .forEach { (p: java.nio.file.Path) =>
+          val target = java.nio.file.Paths.get(p.toString.stripSuffix(".md") + ".mdx")
+          val _ = java.nio.file.Files.move(
+            p,
+            target,
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING
+          )
+        }
+    finally generated.close()

--- a/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
+++ b/mdoc-docs/src/main/scala/scalasemantic/docs/ToolRunner.scala
@@ -101,6 +101,14 @@ object ToolRunner:
   def extractField(raw: String, field: String): String =
     ujson.read(raw).obj(field).str
 
+  /** A `<EnrichedCode>` MDX element wrapping a tool result's `source` field — the intra-line
+    * insert-tinting component (see `website/src/components/EnrichedCode.js`), which highlights only
+    * the compiler's `// ⟹` insertions rather than diffing whole lines. The source is passed as a
+    * JSON-encoded string prop so backticks, braces, and the `⟹` glyph survive MDX parsing intact.
+    */
+  def enrichedComponent(raw: String): String =
+    s"<EnrichedCode code={${ujson.write(extractField(raw, "source"))}} />"
+
   /** Collapsed `<details>` block with the raw JSON, eliding fields already shown elsewhere (e.g. as
     * an extracted code block via [[extractField]]) so nothing is printed twice.
     */

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,7 +76,9 @@ const config = {
           priority: 0.5,
           filename: 'sitemap.xml',
         },
-        theme: {},
+        theme: {
+          customCss: require.resolve('./src/css/custom.css'),
+        },
       }),
     ],
   ],

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "^3.6.0",
         "@docusaurus/preset-classic": "^3.6.0",
+        "prism-react-renderer": "^2.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.6.0",
     "@docusaurus/preset-classic": "^3.6.0",
+    "prism-react-renderer": "^2.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/website/src/components/EnrichedCode.js
+++ b/website/src/components/EnrichedCode.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Highlight, themes } from 'prism-react-renderer';
+import { useColorMode } from '@docusaurus/theme-common';
+
+// The delimiter the analysis layer uses for every inserted note in the `compilable` format.
+// Everything from this marker to end-of-line is a compiler insertion (not in the source as written),
+// so we tint only that span — the "intra-line diff" that avoids re-printing whole `+`/`-` lines.
+const NOTE_MARKER = '// ⟹';
+
+/**
+ * Renders enriched Scala from `annotated_source` (compilable format) with Prism syntax colours,
+ * background-tinting ONLY the inserted `// ⟹ …` notes green — so the reader sees exactly what the
+ * compiler added, in place, without a whole-line diff. `code` arrives as a plain string prop.
+ */
+export default function EnrichedCode({ code, language = 'scala' }) {
+  const { colorMode } = useColorMode();
+  const theme = colorMode === 'dark' ? themes.dracula : themes.github;
+  const src = (code ?? '').replace(/\n+$/, '');
+  return (
+    <Highlight theme={theme} code={src} language={language}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={`${className} ss-enriched`} style={style}>
+          <code>
+            {tokens.map((line, i) => {
+              const lineStr = line.map((t) => t.content).join('');
+              const marker = lineStr.indexOf(NOTE_MARKER);
+              let pos = 0;
+              return (
+                <span {...getLineProps({ line })} key={i} style={{ display: 'block' }}>
+                  {line.map((token, k) => {
+                    const start = pos;
+                    pos += token.content.length;
+                    const props = getTokenProps({ token });
+                    if (marker >= 0 && start >= marker) {
+                      props.className = `${props.className || ''} ss-ins`;
+                    }
+                    return <span {...props} key={k} />;
+                  })}
+                </span>
+              );
+            })}
+          </code>
+        </pre>
+      )}
+    </Highlight>
+  );
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,0 +1,11 @@
+/* Intra-line insert tint for <EnrichedCode>: only the compiler's `// ⟹ …` insertions are
+   highlighted green, in place, so the reader sees what was added without a whole-line diff. */
+.ss-enriched .ss-ins {
+  background-color: rgba(46, 160, 67, 0.18);
+  border-radius: 3px;
+  padding: 0 1px;
+}
+
+[data-theme='dark'] .ss-enriched .ss-ins {
+  background-color: rgba(63, 185, 80, 0.25);
+}

--- a/website/src/theme/MDXComponents.js
+++ b/website/src/theme/MDXComponents.js
@@ -1,0 +1,13 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import EnrichedCode from '@site/src/components/EnrichedCode';
+
+// Registered globally so the mdoc-generated Markdown can use <Tabs>/<TabItem>/<EnrichedCode>
+// without per-file import statements (mdoc passes these tags through verbatim into website/docs).
+export default {
+  ...MDXComponents,
+  Tabs,
+  TabItem,
+  EnrichedCode,
+};


### PR DESCRIPTION
## What

Rework the `annotated_source` examples on the docs "Tool Examples" page into a single tabbed widget with **intra-line** insert highlighting, instead of three stacked sections and whole-line diffs.

- **Tabs** (`Original` | `compilable` | `symbols=on` | `diff`) collapse the four variants of the same tool into one widget — the raw source now lives in an **Original** tab rather than a separate page-header block.
- **Intra-line green tint**: a new `<EnrichedCode>` MDX component renders the enriched Scala with full Prism syntax colours and background-tints **only** the compiler's inserted `// ⟹ …` notes — so the reader sees exactly what was added, in place, without re-printing whole `+`/`-` lines. The literal unified-diff patch stays available in the `diff` tab.

## How

- `website/src/components/EnrichedCode.js` — `prism-react-renderer` (already a transitive dep, now explicit) highlights the code; tokens at/after the `// ⟹` marker on each line get a `.ss-ins` class. `website/src/css/custom.css` gives `.ss-ins` a green background (light + dark). Registered globally via `website/src/theme/MDXComponents.js` so mdoc-generated Markdown can use `<Tabs>`/`<TabItem>`/`<EnrichedCode>` with no per-file imports.
- `ToolRunner.enrichedComponent` emits `<EnrichedCode code={…}/>` with the source JSON-encoded as the prop, so backticks / braces / the `⟹` glyph survive MDX parsing.

## The `.md` ↔ `.mdx` bridge (the fiddly bit)

Two tools disagree on extensions:
- **mdoc** only *executes* `*.md` (it copies `*.mdx` through verbatim, unrendered).
- **Docusaurus** `markdown.format: 'detect'` only *parses* `*.mdx` as MDX — our `*.md` pages are deliberately CommonMark (they contain `<root>`, `List[A]`, `{…}` that MDX would choke on), so a `*.md` page can't use JSX components.

So a page needing MDX declares `format: mdx` in its front matter, and `DocsMain` — after mdoc renders — renames those opted-in outputs `*.md` → `*.mdx`. Docusaurus then treats just that page as MDX; every other page stays CommonMark. This keeps the global `detect` setting (flipping it to `mdx` breaks other pages: `stryker4s-research.md`'s bare `<br>`, etc.).

## Verification

- `./mill docs.run` (mdoc) ✅ 0 errors — generates `tool-examples.mdx` with fences executed.
- `npm run build` ✅ — rendered HTML shows `role="tablist"` (tabs), two `.ss-enriched` blocks, and `.ss-ins` spans wrapping exactly the `// ⟹ …` notes; bundled CSS carries the green `.ss-ins` background (light `#2ea0432e` / dark `#3fb95040`).
- `checkFormatFirstParty` ✅.
- No tool/analyzer code changed → golden suites untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)