### PR TITLE
ci: validate docs site in prePush when docs are changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ build/
 # ScalaSemantic generated classpath metadata is project-local but machine-specific.
 /.scala-semantic/
 .aider*
+/plans/
+/.gh-tasks-llm-executor/
+

--- a/build.mill
+++ b/build.mill
@@ -667,6 +667,72 @@ def smokeTest() = Task.Command {
   }
 }
 
+def docsSiteRelevantPath(path: String): Boolean =
+  path.startsWith("docs/") ||
+    path.startsWith("mdoc-docs/") ||
+    path.startsWith("website/") ||
+    path == "scripts/gen-release-notes.sh"
+
+def gitLines(args: String*): Seq[String] =
+  scala.util
+    .Try {
+      os.proc("git", args).call(cwd = build.moduleDir, check = false) match {
+        case res if res.exitCode == 0 =>
+          res.out.lines().map(_.trim).filter(_.nonEmpty)
+        case _ => Seq.empty
+      }
+    }
+    .getOrElse(Seq.empty)
+
+def changedPathsForPrePush: T[Seq[String]] = Task.Input {
+  val worktreeChanges =
+    gitLines("diff", "--name-only", "--cached", "--") ++
+      gitLines("diff", "--name-only", "--") ++
+      gitLines("ls-files", "--others", "--exclude-standard")
+
+  val branchBase =
+    gitLines("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}").headOption
+      .filter(_.nonEmpty)
+      .orElse(gitLines("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD").headOption)
+      .getOrElse("origin/master")
+
+  val pushedChanges =
+    gitLines("merge-base", "HEAD", branchBase).headOption match {
+      case Some(base) => gitLines("diff", "--name-only", s"$base..HEAD", "--")
+      case None       => Seq.empty
+    }
+
+  (worktreeChanges ++ pushedChanges).distinct.sorted
+}
+
+def docsSiteChanged: T[Boolean] = Task {
+  val relevant = changedPathsForPrePush().filter(docsSiteRelevantPath)
+  if (relevant.nonEmpty) {
+    Task.log.info(
+      "Docs-site changes detected; validating docs build:\n" +
+        relevant.map(path => s"  - $path").mkString("\n")
+    )
+    true
+  } else {
+    Task.log.info("No docs-site changes detected; skipping docs build.")
+    false
+  }
+}
+
+def docsSiteBuild() = Task.Command {
+  os.proc("bash", (build.moduleDir / "scripts" / "gen-release-notes.sh").toString)
+    .call(cwd = build.moduleDir, stdout = os.Inherit, stderr = os.Inherit)
+  docs.run()
+  val docusaurusBin = build.moduleDir / "website" / "node_modules" / ".bin" / "docusaurus"
+  if (!os.exists(docusaurusBin)) {
+    sys.error(
+      "Docs site dependencies are missing; run `cd website && npm ci` before building docs."
+    )
+  }
+  os.proc("npm", "run", "build")
+    .call(cwd = build.moduleDir / "website", stdout = os.Inherit, stderr = os.Inherit)
+}
+
 def prePush() = Task.Command {
   checkFormatFirstParty()()
   checkScalafixFirstParty()()
@@ -676,6 +742,7 @@ def prePush() = Task.Command {
   )(_.testForked())()
   analysis.stainlessVerify()()
   smokeTest()()
+  if (docsSiteChanged()) docsSiteBuild()()
 
   Task.log.info("Checking unit and E2E regression consistency...")
   val res = os

--- a/docs/project/development.md
+++ b/docs/project/development.md
@@ -19,7 +19,7 @@ Each module emits its own SemanticDB (`def semanticDbEnabled = true`), so tests 
 ```sh
 ./mill __.compile              # also (re)emits SemanticDB for every module
 ./mill __.test                 # dogfooded on core, analysis (incl. CompatSuite), mcp
-./mill prePush                 # clean; checkFormatAll; compatGoldenAll; test all modules; stainlessVerify
+./mill prePush                 # format/scalafix checks; compat goldens; tests; stainless/smoke/regression; docs site when docs changed
 ./mill mcpClientConfig --client all   # generate/merge configs and rules for all clients (dogfooding)
 ```
 
@@ -46,8 +46,12 @@ Add a version by appending to `compatFixtures`'s cross versions in `build.mill` 
 
 ```sh
 ./mill docs.run                              # mdoc renders docs → website/docs (executes Scala fences)
-cd website && npm install && npm run build   # Docusaurus static site (Node 18+)
+cd website && npm ci && npm run build        # Docusaurus static site (Node 18+)
 ```
+
+`./mill prePush` runs the docs-site build automatically when changes touch `docs/`, `mdoc-docs/`,
+`website/`, or `scripts/gen-release-notes.sh`. It expects `website/node_modules` to already exist;
+run `cd website && npm ci` once before the gate if you have not installed the site dependencies.
 
 ## Build & test gotchas
 
@@ -56,4 +60,3 @@ cd website && npm install && npm run build   # Docusaurus static site (Node 18+)
 - **Wartremover**: pinned to 3.6.0 — 3.5.6 had no artifact for Scala 3.8.4; no Mill plugin exists, so it's wired by hand as a compiler-plugin dep + `-P:wartremover:…` scalacOptions per module.
 
 More decisions and history: [Design decisions](design.md).
-


### PR DESCRIPTION
This PR adds automatic validation of the Docusaurus/mdoc docs site to `./mill prePush` when changes are detected in files under `docs/`, `mdoc-docs/`, `website/`, or `scripts/gen-release-notes.sh`. It also updates the development documentation and gitignores.