### PR TITLE
style: format build.mill

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -21,7 +21,6 @@ import mill.contrib.buildinfo.BuildInfo
 import com.goyeau.mill.scalafix.ScalafixModule
 import mill.javalib.SonatypeCentralPublishModule
 
-
 // ---------------------------------------------------------------------------------------------
 // Shared versions (were `lazy val`s in build.sbt)
 // ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a minor formatting error (extra newline) in build.mill that caused the CI build to fail.