### PR TITLE
chore(hooks): auto-format and check build.mill in git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,5 +6,6 @@
 # Skip with: git commit --no-verify, or PRECOMMIT_SKIP=1 git commit.
 [ "${PRECOMMIT_SKIP:-0}" = "1" ] && exit 0
 ./mill mill.scalalib.scalafmt/reformatAll __.sources >/dev/null
+./mill --meta-level 1 mill.scalalib.scalafmt/reformatAll sources >/dev/null
 # Re-stage tracked files scalafmt may have rewritten so the formatting is part of this commit.
 git add -u

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 # Run the full gate before pushing. Skip with: git push --no-verify, or PREPUSH_SKIP=1 git push.
 [ "${PREPUSH_SKIP:-0}" = "1" ] && exit 0
+./mill --meta-level 1 mill.scalalib.scalafmt/checkFormatAll sources >/dev/null || exit 1
 exec ./mill prePush >/dev/null


### PR DESCRIPTION
This PR adds formatting and checking of `build.mill` to the Git hooks (`pre-commit` and `pre-push`). Because `build.mill` lives in the meta-level 1 evaluator context, it is not verified by standard module tasks, and this prevents formatting drift in the build configuration script from failing CI builds in the future.