### PR TITLE
fix: execute docs.run task correctly in prePush and set UTF-8 encoding

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Generate release notes page from tags
         run: scripts/gen-release-notes.sh # writes docs/RELEASE_NOTES.md (gitignored, build-time only)
       - name: Render docs with mdoc
-        run: ./mill docs.run # writes executed Markdown into website/docs
+        run: ./mill -i docs.run # writes executed Markdown into website/docs
       - name: Build Docusaurus site
         working-directory: website
         run: |

--- a/build.mill
+++ b/build.mill
@@ -723,7 +723,7 @@ def docsSiteChanged: T[Boolean] = Task {
 def docsSiteBuild() = Task.Command {
   os.proc("bash", (build.moduleDir / "scripts" / "gen-release-notes.sh").toString)
     .call(cwd = build.moduleDir, stdout = os.Inherit, stderr = os.Inherit)
-  docs.run()
+  docs.run()()
   val docusaurusBin = build.moduleDir / "website" / "node_modules" / ".bin" / "docusaurus"
   if (!os.exists(docusaurusBin)) {
     sys.error(

--- a/mdoc-docs/src/main/scala/DocsMain.scala
+++ b/mdoc-docs/src/main/scala/DocsMain.scala
@@ -35,7 +35,11 @@ object DocsMain:
       generated
         .filter((p: java.nio.file.Path) => p.toString.endsWith(".md"))
         .filter((p: java.nio.file.Path) =>
-          java.nio.file.Files.readString(p).linesIterator.take(6).contains("format: mdx")
+          java.nio.file.Files
+            .readString(p, java.nio.charset.StandardCharsets.UTF_8)
+            .linesIterator
+            .take(6)
+            .contains("format: mdx")
         )
         .forEach((p: java.nio.file.Path) => mdxPages += p)
     finally generated.close()


### PR DESCRIPTION
This PR fixes a bug in build.mill where docs.run() was called without executing the returned task (fixed to docs.run()()). It also sets the UTF-8 charset explicitly in DocsMain.scala when reading files to prevent crashes on GitHub runners with non-UTF-8 default locales, and adds the interactive flag -i to mill docs.run in docs-deploy.yml to expose logs on failure.