### PR TITLE
fix: set stagingRelease false for Sonatype Central portal compat gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,8 @@ jobs:
           ./mill __.publish \
             --sonatypeCreds "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_PASSWORD }}" \
             --gpgArgs "--no-tty,--pinentry-mode,loopback,--batch,--yes,--armor,--detach-sign" \
-            --release true
+            --release true \
+            --stagingRelease false
 
   release:
     name: GitHub Release (fat jar)


### PR DESCRIPTION
This PR disables staging releases in Mill publishing, which fixes a 400 error when uploading to the Sonatype Central Portal compat gateway endpoint (since it does not support staging profiles).