### PR TITLE
fix: use SonatypeCentralPublishModule/publishAll for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,12 @@ jobs:
 
       - name: Publish (sign + upload via Mill)
         run: |
-          ./mill __.publish \
-            --sonatypeCreds "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_PASSWORD }}" \
-            --gpgArgs "--no-tty,--pinentry-mode,loopback,--batch,--yes,--armor,--detach-sign" \
-            --release true \
-            --stagingRelease false
+          ./mill mill.javalib.SonatypeCentralPublishModule/publishAll \
+            --publishArtifacts __.publishArtifacts \
+            --username "${{ secrets.SONATYPE_USERNAME }}" \
+            --password "${{ secrets.SONATYPE_PASSWORD }}" \
+            --useGpgCli true \
+            --shouldRelease true
 
   release:
     name: GitHub Release (fat jar)


### PR DESCRIPTION
This PR migrates the publish step in CI to use the correct Mill task `mill.javalib.SonatypeCentralPublishModule/publishAll` with `--useGpgCli true` and `--shouldRelease true`. This correctly signs and uploads the artifacts using the modern Sonatype Central Portal API, bypassing the legacy staging profiles endpoint.