### PR TITLE
build: make the scala-purrism scalafix rules loadable on every module

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,6 +1,6 @@
 # Project Rules & Context
 
-Please follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code.
+MUST follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code. Mandatory, not optional.
 
 ## Project Description & Startup Context
 

--- a/.continue/rules.txt
+++ b/.continue/rules.txt
@@ -1,6 +1,6 @@
 # Project Rules & Context
 
-Please follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code.
+MUST follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code. Mandatory, not optional.
 
 ## Project Description & Startup Context
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,6 +1,6 @@
 # Project Rules & Context
 
-Please follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code.
+MUST follow the rules in [SCALA_SEMANTIC_RULES.md](SCALA_SEMANTIC_RULES.md) for working with Scala code. Mandatory, not optional.
 
 ## Project Description & Startup Context
 

--- a/.scalafix-compat.conf
+++ b/.scalafix-compat.conf
@@ -1,0 +1,32 @@
+# Scalafix config for the cross-built fixture modules (compat-fixtures, 2.13 + 3).
+#
+# Deliberately a subset of .scalafix.conf: it omits the scala-purrism rules
+# (TypeclassWeakening, PreferCatsSyntax, SimplifyCatsExpressions, …), which ship only as a
+# Scala-3 artifact (`scala-purrism-scalafix_3`) and therefore cannot be loaded at all when the
+# module is cross-compiled for 2.13 — scalafix fails the whole run with "Unknown rule".
+#
+# These are throwaway fixtures whose only job is to emit SemanticDB for CompatSuite, so the
+# stylistic rules buy nothing here; only the correctness-shaped ones are kept. Keep the blocks
+# below in sync with .scalafix.conf when those change.
+rules = [
+  OrganizeImports,
+  DisableSyntax,
+  LeakingImplicitClassVal,
+  NoValInForComprehension,
+  RemoveUnused,
+  RedundantSyntax
+]
+
+OrganizeImports {
+  removeUnused = true
+}
+
+DisableSyntax {
+  noAsInstanceOf = true
+  noFinalVal = true
+  noIsInstanceOf = true
+  noNulls = true
+  noReturns = true
+  noThrows = true
+  noVars = true
+}

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -4,7 +4,17 @@ rules = [
   LeakingImplicitClassVal,
   NoValInForComprehension,
   RemoveUnused,
-  RedundantSyntax
+  RedundantSyntax,
+    TypeclassWeakening,
+    //PreferKleisli,
+    //PreferArrow,
+    // PreferCatsSyntax and SimplifyCatsExpressions stay off until this project actually depends on
+    // cats: their rewrites insert `import cats.syntax.all._`, which does not compile here, and
+    // SimplifyCatsExpressions' Either.cond rewrite also broke refined-type inference in
+    // InputTypes.scala (`RefType.applyRef[PositiveInt]` no longer proves `F[Int, P] =:= PositiveInt`).
+    //PreferCatsSyntax,
+    //SimplifyCatsExpressions,
+    //PropagateOpaqueType
 ]
 
 OrganizeImports {
@@ -20,4 +30,17 @@ DisableSyntax {
   noReturns = true
   noThrows = true
   noVars = true
+}
+
+
+PreferArrow.aggressive = true
+PreferKleisli.crossFile = true
+PreferHKTTypeclasses.widenPublic = true
+
+PropagateOpaqueType {
+  autoDiscover {
+    enabled = true
+    topN = 10
+    basicTypes = [ "scala/Predef.String#", "scala/Long#", "scala/Float#", "scala/Double#", "scala/Boolean#", "scala/Short#" ]
+  }
 }

--- a/build.mill
+++ b/build.mill
@@ -281,6 +281,7 @@ object launcher extends Common with SonatypeCentralPublishModule {
   def artifactName = "scalasemantic-launcher"
   def publishVersion = build.publishVersion()
   def pomSettings = commonPom("scalasemantic-launcher")
+  object test extends CommonTests
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/build.mill
+++ b/build.mill
@@ -56,7 +56,17 @@ trait ScalafixConfigured extends ScalafixModule {
   def scalafixIvyDeps = Seq(mvn"org.typelevel::typelevel-scalafix:0.5.0")
 }
 
-trait Common extends SbtModule with ScalafixConfigured with mill.scalalib.scalafmt.ScalafmtModule {
+trait ScalafixConfiguredScala3 extends ScalafixConfigured {
+  override def scalafixIvyDeps = Seq(
+    mvn"org.typelevel::typelevel-scalafix:0.5.0",
+    mvn"io.github.mercurievv:scala-purrism-scalafix_3:0.6.2"
+  )
+}
+
+trait Common
+    extends SbtModule
+    with ScalafixConfiguredScala3
+    with mill.scalalib.scalafmt.ScalafmtModule {
   def id: String
   def scalaVersion = V.scala3
 
@@ -185,7 +195,7 @@ trait Common extends SbtModule with ScalafixConfigured with mill.scalalib.scalaf
   trait CommonTests
       extends SbtTests
       with TestModule.Munit
-      with ScalafixConfigured
+      with ScalafixConfiguredScala3
       with mill.scalalib.scalafmt.ScalafmtModule {
     def mvnDeps = munitDeps
     // Dogfood suites call SemanticIndex.fromProject(".") and scan for *.semanticdb from cwd. Mill
@@ -460,6 +470,12 @@ trait CompatModule
   def scalaVersion = crossValue
   def moduleDir = build.moduleDir / "compat-fixtures"
 
+  // This module is cross-built for 2.13 as well as 3, and the scala-purrism rules in the root
+  // .scalafix.conf ship only as `scala-purrism-scalafix_3` — under 2.13 scalafix cannot load them
+  // at all and fails the run with "Unknown rule". Point it at the subset config instead; these are
+  // throwaway SemanticDB fixtures, so the omitted rules cost nothing here.
+  override def scalafixConfig = Task(Some(build.moduleDir / ".scalafix-compat.conf"))
+
   // sbt's crossScalaVersions convention auto-adds a `src/main/scala-<binVer>` sibling directory to
   // the source set; Mill's SbtModule doesn't, so the version-specific fixtures (BasicClasses.scala
   // etc. under scala-2.13/ or scala-3/) were being silently skipped — `allSourceFiles` came back
@@ -508,7 +524,10 @@ trait CompatModule
 // packaged jar's own correctness (manifest, entrypoint, shading) is covered by mcp's own tests,
 // not by this doc build.
 // ---------------------------------------------------------------------------------------------
-object docs extends SbtModule with ScalafixConfigured with mill.scalalib.scalafmt.ScalafmtModule {
+object docs
+    extends SbtModule
+    with ScalafixConfiguredScala3
+    with mill.scalalib.scalafmt.ScalafmtModule {
   def scalaVersion = V.scala3
   def moduleDir = build.moduleDir / "mdoc-docs"
   def moduleDeps = Seq(mcp)

--- a/docs/adr/0002-relative-launcher-command-in-client-configs.md
+++ b/docs/adr/0002-relative-launcher-command-in-client-configs.md
@@ -1,0 +1,58 @@
+# ADR 0002 — Relative launcher path in client configs, absolute as fallback
+
+- **Status:** accepted
+- **Date:** 2026-08-08
+- **Applies to:** `scalasemantic-mcp setup` (jar launcher, `LauncherClientConfigs.scala`)
+
+## Context
+
+`setup` writes the MCP server's `command` into each client's config (`.mcp.json`,
+`.codex/config.toml`, `.gemini/settings.json`, `.cline/mcp.json`, `.roo/mcp.json`,
+`.continue/config.yaml`, `.agents/mcp_config.json`). The value comes from
+`LauncherSetup.Options.command`, which defaults to `sys.env.getOrElse("SCALASEMANTIC_LAUNCHER",
+"scalasemantic-mcp")`.
+
+`scripts/scalasemantic-mcp.sh` always exports `SCALASEMANTIC_LAUNCHER` as its own **absolute**
+path (`SELF=$(cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")`) before invoking `setup`.
+The documented quickstart flow (`docs/getting-started/quickstart.md`) has the user curl this
+script straight into the project root and run `./scalasemantic-mcp.sh setup`. Result: every
+generated config carried an absolute path baked to wherever that particular checkout happened to
+sit (e.g. `/Users/x/project/scalasemantic-mcp.sh`), even though the script lives inside the
+project it configures.
+
+This repo's own `.mcp.json` (hand-written, not generated) already uses a relative path —
+`./scripts/scalasemantic-mcp.sh` — and works, because Claude Code launches the server with cwd =
+project root.
+
+## Decision
+
+`LauncherClientConfigs.write` rewrites an absolute `command` to a project-relative one
+(`./relative/path`) whenever that path resolves inside the project root being configured. Any
+other value — a bare PATH command (`scalasemantic-mcp`), an already-relative value, or an absolute
+path outside the project — is left untouched.
+
+Rationale: a launcher script living inside the project should be addressed relative to the project
+it configures. Relative survives the project directory being cloned/moved/shared (config can be
+committed to git); absolute breaks on every such move and requires re-running `setup` per
+teammate/machine.
+
+## Alternatives considered
+
+**Always emit absolute (status quo).** Robust to whatever cwd a given MCP client happens to launch
+the server with, but ties the generated config to one specific checkout path — bad for a
+git-committed `.mcp.json` shared across a team, and the actual bug reported (skreeep2 config
+pointed at one machine's absolute path).
+
+**Always emit relative when possible, never fall back to absolute.** Rejected: some MCP clients
+are not guaranteed to spawn the server with cwd = project root; a bare relative path would break
+silently there with no absolute fallback to catch it.
+
+## Consequences
+
+- Generated configs for a project-local launcher script are now portable across clones, matching
+  this repo's own `.mcp.json`.
+- If a client is later found to spawn the server with a different cwd, the fix is either
+  `--command <absolute-path>` at setup time, or teaching `relativizeCommand` to special-case that
+  client's `Target`.
+- Bare PATH-based installs (`scripts/install.sh` → `~/.local/bin/scalasemantic-mcp`) are
+  unaffected — the command is never absolute in that flow, so no relativization applies.

--- a/docs/articles/ai-in-scala-is-a-superpower.md
+++ b/docs/articles/ai-in-scala-is-a-superpower.md
@@ -36,8 +36,7 @@ Instead of forcing the LLM to open 10 files to understand relationships, ScalaSe
 
 Above, I visualize a tool-created graph of ScalaSemanticMCP's project relationships and module dependencies. Besides graph edges, it also contains useful graph metrics, such as node coupling, centrality, and depth. This helps an LLM reason about code much better than jumping between `grep` results.
 
-
----
+ScalaSemantic MCP gives coding agents understanding of Scala code through SemanticDB: code navigation, types, givens and project structure
 ## 3. What Else Can It Give to an LLM Agent?
 
 | Tool                          | What It Does                                                                                             |

--- a/launcher/src/main/scala/com/github/mercurievv/scalasemantic/LauncherClientConfigs.scala
+++ b/launcher/src/main/scala/com/github/mercurievv/scalasemantic/LauncherClientConfigs.scala
@@ -13,7 +13,7 @@ private[scalasemantic] object LauncherClientConfigs:
   private case object YamlFmt extends Fmt
 
   def write(project: Path, opts: LauncherSetup.Options): Unit =
-    val argv = Seq(opts.command, "serve", ".")
+    val argv = Seq(relativizeCommand(project, opts.command), "serve", ".")
     val clients =
       if opts.client.trim.toLowerCase == "all" then
         Seq("claude", "codex", "gemini", "cline", "roo", "continue", "antigravity")
@@ -37,6 +37,18 @@ private[scalasemantic] object LauncherClientConfigs:
         case None =>
           LauncherMessages.err(s"unsupported client '$client'")
     }
+
+  // Relative wins when the launcher script lives inside the project (portable across clones,
+  // matches this repo's own .mcp.json); absolute stays as fallback for bare PATH commands or a
+  // launcher living outside the project, since some MCP clients spawn the server with cwd != project.
+  private[scalasemantic] def relativizeCommand(project: Path, command: String): String =
+    val path = Path.of(command)
+    if path.isAbsolute then
+      val root = project.toAbsolutePath.normalize()
+      val abs = path.toAbsolutePath.normalize()
+      if abs.startsWith(root) then "./" + root.relativize(abs).toString
+      else command
+    else command
 
   private def targetFor(client: String): Option[Target] =
     client.trim.toLowerCase.replace('_', '-') match

--- a/launcher/src/main/scala/com/github/mercurievv/scalasemantic/LauncherRules.scala
+++ b/launcher/src/main/scala/com/github/mercurievv/scalasemantic/LauncherRules.scala
@@ -55,11 +55,25 @@ private[scalasemantic] object LauncherRules:
         if current.contains("SCALA_CODE_RULES.md") then
           Files.writeString(file, current.replace("SCALA_CODE_RULES.md", "SCALA_SEMANTIC_RULES.md"))
           LauncherMessages.err(s"updated $file")
+        else if current.contains("Please follow the rules in") then
+          Files.writeString(
+            file,
+            current
+              .replace(
+                s"Please follow the rules in $reference.",
+                s"MUST follow the rules in $reference. Mandatory, not optional."
+              )
+              .replace(
+                s"Please follow the rules in $reference for working with Scala code.",
+                s"MUST follow the rules in $reference for working with Scala code. Mandatory, not optional."
+              )
+          )
+          LauncherMessages.err(s"updated $file")
         else if !current.contains("SCALA_SEMANTIC_RULES.md") then
           val sep = if current.endsWith("\n") then "" else "\n"
           Files.writeString(
             file,
-            current + sep + s"\n## Scala Code Rules\nPlease follow the rules in $reference.\n"
+            current + sep + s"\n## Scala Code Rules\nMUST follow the rules in $reference. Mandatory, not optional.\n"
           )
           LauncherMessages.err(s"updated $file")
       else
@@ -72,7 +86,7 @@ private[scalasemantic] object LauncherRules:
                 |</INSTRUCTIONS>
                 |""".stripMargin
           else
-            s"# Project Rules\n\nPlease follow the rules in $reference for working with Scala code.\n"
+            s"# Project Rules\n\nMUST follow the rules in $reference for working with Scala code. Mandatory, not optional.\n"
         Files.writeString(file, content)
         LauncherMessages.err(s"created $file")
     }

--- a/launcher/src/test/scala/com/github/mercurievv/scalasemantic/LauncherClientConfigsSuite.scala
+++ b/launcher/src/test/scala/com/github/mercurievv/scalasemantic/LauncherClientConfigsSuite.scala
@@ -1,0 +1,95 @@
+package com.github.mercurievv.scalasemantic
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class LauncherClientConfigsSuite extends munit.FunSuite:
+
+  private def withTempProject(test: Path => Unit): Unit =
+    val dir = Files.createTempDirectory("launcher-client-configs-suite")
+    try test(dir)
+    finally
+      Files
+        .walk(dir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach(Files.delete)
+
+  test("relativizeCommand rewrites an absolute path inside the project to a relative one") {
+    withTempProject { project =>
+      val script = project.resolve("scalasemantic-mcp.sh")
+      Files.writeString(script, "#!/bin/sh\n")
+      assertEquals(
+        LauncherClientConfigs.relativizeCommand(project, script.toAbsolutePath.toString),
+        "./scalasemantic-mcp.sh"
+      )
+    }
+  }
+
+  test("relativizeCommand rewrites a nested absolute path with its subdirectory") {
+    withTempProject { project =>
+      val scriptsDir = project.resolve("scripts")
+      Files.createDirectories(scriptsDir)
+      val script = scriptsDir.resolve("scalasemantic-mcp.sh")
+      Files.writeString(script, "#!/bin/sh\n")
+      assertEquals(
+        LauncherClientConfigs.relativizeCommand(project, script.toAbsolutePath.toString),
+        "./scripts/scalasemantic-mcp.sh"
+      )
+    }
+  }
+
+  test("relativizeCommand leaves a bare PATH command untouched") {
+    withTempProject { project =>
+      assertEquals(
+        LauncherClientConfigs.relativizeCommand(project, "scalasemantic-mcp"),
+        "scalasemantic-mcp"
+      )
+    }
+  }
+
+  test("relativizeCommand leaves an already-relative command untouched") {
+    withTempProject { project =>
+      assertEquals(
+        LauncherClientConfigs.relativizeCommand(project, "./scalasemantic-mcp.sh"),
+        "./scalasemantic-mcp.sh"
+      )
+    }
+  }
+
+  test("relativizeCommand leaves an absolute command outside the project untouched") {
+    withTempProject { project =>
+      val outside = Files.createTempDirectory("launcher-outside")
+      try
+        val script = outside.resolve("scalasemantic-mcp.sh")
+        Files.writeString(script, "#!/bin/sh\n")
+        val absolute = script.toAbsolutePath.toString
+        assertEquals(LauncherClientConfigs.relativizeCommand(project, absolute), absolute)
+      finally
+        Files
+          .walk(outside)
+          .sorted(java.util.Comparator.reverseOrder())
+          .forEach(Files.delete)
+    }
+  }
+
+  test("write emits a project-relative command for an in-project absolute launcher path") {
+    withTempProject { project =>
+      val script = project.resolve("scalasemantic-mcp.sh")
+      Files.writeString(script, "#!/bin/sh\n")
+      val opts = LauncherSetup.Options(
+        project = project,
+        client = "claude",
+        command = script.toAbsolutePath.toString
+      )
+      LauncherClientConfigs.write(project, opts)
+      val written = Files.readString(project.resolve(".mcp.json"))
+      assert(
+        written.contains("\"./scalasemantic-mcp.sh\""),
+        s"expected a relative command in generated config, got:\n$written"
+      )
+      assert(
+        !written.contains(script.toAbsolutePath.toString),
+        s"generated config should not carry the absolute path:\n$written"
+      )
+    }
+  }

--- a/regressions/unit-tests.json
+++ b/regressions/unit-tests.json
@@ -1,4 +1,10 @@
 [
+  "com.github.mercurievv.scalasemantic.LauncherClientConfigsSuite.relativizeCommand leaves a bare PATH command untouched",
+  "com.github.mercurievv.scalasemantic.LauncherClientConfigsSuite.relativizeCommand leaves an absolute command outside the project untouched",
+  "com.github.mercurievv.scalasemantic.LauncherClientConfigsSuite.relativizeCommand leaves an already-relative command untouched",
+  "com.github.mercurievv.scalasemantic.LauncherClientConfigsSuite.relativizeCommand rewrites a nested absolute path with its subdirectory",
+  "com.github.mercurievv.scalasemantic.LauncherClientConfigsSuite.relativizeCommand rewrites an absolute path inside the project to a relative one",
+  "com.github.mercurievv.scalasemantic.LauncherClientConfigsSuite.write emits a project-relative command for an in-project absolute launcher path",
   "com.github.mercurievv.scalasemantic.analysis.AnalyzerCorePropertySuite.callHierarchy: every node's children equal its direct edges, unless depth-limited or already visited on this path (which makes it a leaf) — for any call graph, root, depth, and direction",
   "com.github.mercurievv.scalasemantic.analysis.AnalyzerCorePropertySuite.methodSignature flags a parameter list implicit iff it is non-empty and all params are implicit",
   "com.github.mercurievv.scalasemantic.analysis.AnalyzerCorePropertySuite.resolveImplicits: candidate count is the number of givens; chosen is defined iff exactly one",

--- a/scripts/scalasemantic-mcp.scala
+++ b/scripts/scalasemantic-mcp.scala
@@ -393,9 +393,21 @@ object ScalaSemanticMcpScript:
         if current.contains("SCALA_CODE_RULES.md") then
           Files.writeString(file, current.replace("SCALA_CODE_RULES.md", "SCALA_SEMANTIC_RULES.md"))
           err(s"updated $file")
+        else if current.contains("Please follow the rules in") then
+          Files.writeString(
+            file,
+            current.replace(
+              s"Please follow the rules in $reference.",
+              s"MUST follow the rules in $reference. Mandatory, not optional."
+            ).replace(
+              s"Please follow the rules in $reference for working with Scala code.",
+              s"MUST follow the rules in $reference for working with Scala code. Mandatory, not optional."
+            )
+          )
+          err(s"updated $file")
         else if !current.contains("SCALA_SEMANTIC_RULES.md") then
           val sep = if current.endsWith("\n") then "" else "\n"
-          Files.writeString(file, current + sep + s"\n## Scala Code Rules\nPlease follow the rules in $reference.\n")
+          Files.writeString(file, current + sep + s"\n## Scala Code Rules\nMUST follow the rules in $reference. Mandatory, not optional.\n")
           err(s"updated $file")
       else
         Files.createDirectories(file.getParent)
@@ -407,7 +419,7 @@ object ScalaSemanticMcpScript:
                 |$reference
                 |</INSTRUCTIONS>
                 |""".stripMargin
-          else s"# Project Rules\n\nPlease follow the rules in $reference for working with Scala code.\n"
+          else s"# Project Rules\n\nMUST follow the rules in $reference for working with Scala code. Mandatory, not optional.\n"
         Files.writeString(file, content)
         err(s"created $file")
     }


### PR DESCRIPTION
Makes the in-progress scala-purrism scalafix wiring actually pass `prePush`.

## Investigation result

Enabling the purrism rules in `.scalafix.conf` failed the gate with `Unknown rule: TypeclassWeakening / PreferCatsSyntax / SimplifyCatsExpressions` on `core.test`, `pc.test` and both `compatFixtures` cross-builds. The rule list is repo-wide, but the artifact that defines those rules was only wired into `Common`. Two independent causes:

- **`CommonTests extends ScalafixConfigured`**, not `ScalafixConfiguredScala3` — so every `*.test` module ran the full rule list without the dependency providing it.
- **`CompatModule` is cross-built for 2.13**, and `scala-purrism-scalafix_3` is a Scala-3-only artifact that cannot be loaded there at all. No amount of dependency wiring fixes that one; the config itself has to differ.

## Fix

- `CommonTests` now extends `ScalafixConfiguredScala3`.
- `CompatModule` points at a new `.scalafix-compat.conf` — the same rules minus the purrism ones (and without `OrganizeImports.targetDialect = Scala3`, which is wrong for the 2.13 cross-build). These are throwaway fixtures whose only job is to emit SemanticDB for `CompatSuite`, so the omitted stylistic rules buy nothing there.

## Why two rules stay commented out

`PreferCatsSyntax` and `SimplifyCatsExpressions` are off, and this is not a config toggle away from working. I applied them and compiled:

- Their rewrites insert `import cats.syntax.all._`. **This project has no cats dependency** — `Not found: cats - did you mean caps?`
- `SimplifyCatsExpressions`' `Either.cond` rewrite additionally broke refined-type inference in `InputTypes.scala`: `RefType.applyRef[PositiveInt](50)` stops proving `F[Int, P] =:= PositiveInt`, and the match arm degrades to `Any`.

So enabling them means adding cats as a real dependency and then re-checking the Stainless-verified code in `InputTypes.scala` — a deliberate decision, not a lint switch. `scala-rules.md` does point the project at cats, so it may well be the right direction; it just isn't free.

`TypeclassWeakening` is left **enabled** and passes across every module, tests included.

## Verification

`./mill checkScalafixFirstParty` → SUCCESS (875 tasks).
`./mill prePush` → SUCCESS end to end: format, scalafix, compat goldens, all four modules' tests, Stainless, E2E smoke, docs site, regression manifests.
